### PR TITLE
Allowing word definitions without a part-of-speech

### DIFF
--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -2406,11 +2406,12 @@ def page_iter(config, text):
                 # a new language or a misspelling or a previously unsupported
                 # subtitle.
                 sectitle = sectitle.lower()
-                if sectitle in part_of_speech_map:
+                isUnknownPos = language == "Chinese" and sectitle == "definitions"
+                if sectitle in part_of_speech_map or isUnknownPos:
                     # New part-of-speech.  Flush the old part-of-speech.
                     flush()
                     # Initialize for parsing the new part-of-speech.
-                    pos_ht = part_of_speech_map[sectitle]
+                    pos_ht = part_of_speech_map["unknown" if isUnknownPos else sectitle]
                     pos = pos_ht["pos"]
                     pos_sectitle = sectitle
                     # XXX errors if pos_ht["error"]

--- a/wiktextract/parts_of_speech.py
+++ b/wiktextract/parts_of_speech.py
@@ -323,6 +323,10 @@ part_of_speech_map = {
         "pos": "verb",
         "tags": ["transitive"],
     },
+    "unknown": {
+        "pos": "unknown",
+        # for languages like Chinese where we don't have the part-of-speech of a word
+    },
     "verb": {
         "pos": "verb",
     },


### PR DESCRIPTION
There are Wiktionary pages where the word definitions (glosses) are not organized inside Part-Of-Speech sections. See for example the Chinese section of

https://en.wiktionary.org/wiki/%E6%83%B3#Chinese

Although 想 is used exclusively as a verb, there is no subsection with a "Verb" title. This results in Wiktextract reading no `sense` entries from this page.

To circumvent this, I changed the code to allow no-POS headers, currently only for Chinese, and only for sections with title "Definitions".

Line 2409 should probably be extended to allow this for more languages (maybe all?).