### PR TITLE
Use UTF8 as the encoding of the file specified by the `--page` parameter

### DIFF
--- a/wiktwords
+++ b/wiktwords
@@ -193,7 +193,7 @@ if __name__ == "__main__":
             if args.path:
                 print("Normal input file should not be specified with --path")
                 sys.exit(1)
-            with open(args.page, "r") as f:
+            with open(args.page, "r", encoding="utf-8") as f:
                 text = f.read()
             ret = parse_page("TESTPAGE", text, config)
             for x in ret:


### PR DESCRIPTION
I'm getting errors when trying to import a non-UTF8 file using the `--page` parameter.

If this is intended, the required encoding should be documented.