### PR TITLE
Bug: examples are duplicated over all senses

### DIFF
--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -1680,13 +1680,13 @@ def parse_preamble(config, data, pos_sectitle, text, p):
 
     # Parse word senses for the part-of-speech.
     for node in p.lists():
-        for item in node.items:
+        for index, item in enumerate(node.items):
             txt = str(item)
             if txt.startswith("*::"):
                 continue  # Possibly a bug in wikitextparser
             sense = {}
             parse_sense(config, sense, txt, True)
-            for node2 in node.sublists():
+            for node2 in node.sublists(index):
                 for item2 in node2.items:
                     parse_sense(config, sense, str(item2), False)
                 for node3 in node2.sublists():


### PR DESCRIPTION
This can be demonstrated well with the Italian word [trovare](https://en.wiktionary.org/wiki/trovare#Italian):

![image](https://user-images.githubusercontent.com/1302357/81698490-590fbc80-9466-11ea-98de-8a2deb9e865c.png)

Even though the example sentence _"lo chiamo spesso, ma mai lo trovo"_ is valid only for the third sense, Wiktextract includes this example sentence in all senses. This is clearly wrong, the example does not make sense when the word is translated as "to find".
