### PR TITLE
Ignore Spanish Wiktionary Wikcionario pages

### DIFF
--- a/wiktextract/wiktionary.py
+++ b/wiktextract/wiktionary.py
@@ -54,8 +54,8 @@ def page_handler(ctx, model, title, text, capture_cb, config_kwargs,
     # steps.
     title = re.sub(r"[\s\000-\037]+", " ", title)
     title = title.strip()
-    if capture_cb is not None:
-        capture_cb(model, title, text)
+    if capture_cb and not capture_cb(model, title, text):
+        return None
     if model == "redirect":
         config1 = WiktionaryConfig()
         ret = [{"title": title, "redirect": text}]

--- a/wiktwords
+++ b/wiktwords
@@ -34,6 +34,7 @@ ignore_prefixes = set(["Index", "Help", "MediaWiki", "Citations",
                        "Rhymes", "Thread",
                        "Summary", "File",
                        "Transwiki",
+                       "Wikcionario",
 ])
 
 # Pages with these prefixes are captured.


### PR DESCRIPTION
I'm trying to parse the Spanish dump file and find the command takes a long time parsing [Wikcionario:Frecuencias/Finés](https://es.wiktionary.org/wiki/Wikcionario:Frecuencias/Fin%C3%A9s/000001-010000) pages. These pages are not word pages and this pull request ignores them so the command won't waste over ten hours parsing them.