### PR TITLE
avoid crashes with illegal --num-threads option

### DIFF
--- a/wiktwords
+++ b/wiktwords
@@ -197,6 +197,12 @@ if __name__ == "__main__":
     else:
         print("Capturing words for:", ", ".join(args.language))
 
+    if args.num_threads and args.num_threads > 1:
+        import multiprocessing
+        if multiprocessing.get_start_method() == "spawn":
+            print("--num-threads not supported on this OS (no stable implementation of fork() available)")
+            sys.exit(1)
+
     # Open output file.
     out_path = args.out
     if out_path and out_path != "-":


### PR DESCRIPTION
Exit with an error message if the user tries to set `--num-threads`
on a system where it leads to program errors. Killing the program
early with a helpful message is much preferable to the crash with
stack traces emitted several minutes into processing (at the
beginning of phase 2).

Fixes #151.