### PR TITLE
deal with cite template redirects

### DIFF
--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -511,12 +511,11 @@ ignored_etymology_templates = [
     "deprecated code",
     "check deprecated lang param usage",
     "para",
-    "cite",
 ]
 # Regexp for matching ignored etymology template names.  This adds certain
 # prefixes to the names listed above.
 ignored_etymology_templates_re = re.compile(
-    r"^((cite-|R:).*|" +
+    r"^(([cC]ite|R:).*|" +
     r"|".join(re.escape(x) for x in ignored_etymology_templates) +
     r")$")
 


### PR DESCRIPTION
Change ignored_etymology_templates to match more cite template names.