### PR TITLE
Use the lower case title in `fix_subtitle_hierarchy()`

### DIFF
--- a/wiktextract/config.py
+++ b/wiktextract/config.py
@@ -171,16 +171,12 @@ class WiktionaryConfig(object):
         with self.data_folder.joinpath("languages.json").open(encoding="utf-8") as f:
             self.LANGUAGES_BY_CODE = json.load(f)
         self.LANGUAGES_BY_NAME = {}
-        code_and_priority = {}
-        # This is necessary to avoid overlapping and mixing up lang_codes.
-        # In the data there are several language codes that share a language
-        # value in their lists of language names; we assume that if a
-        # language name is the first one in a list, it is the primary language
-        # name of that specific language code.
         for lang_code, lang_names in self.LANGUAGES_BY_CODE.items():
-            for i, lang_name in enumerate(lang_names):
-                if lang_name in code_and_priority:
-                    if code_and_priority[lang_name][1] >= i:
-                        continue
-                code_and_priority[lang_name] = (lang_code, i)
-                self.LANGUAGES_BY_NAME[lang_name] = lang_code
+            for lang_name in lang_names:
+                # some languages have the same name but different language codes
+                # only overwrite the language names of three-letter codes with
+                # the name of two-letter codes
+                if lang_name not in self.LANGUAGES_BY_NAME or len(lang_code) < len(
+                        self.LANGUAGES_BY_NAME[lang_name]
+                ):
+                    self.LANGUAGES_BY_NAME[lang_name] = lang_code

--- a/wiktextract/data/zh/languages.json
+++ b/wiktextract/data/zh/languages.json
@@ -1,6 +1,7 @@
 {
   "aa": [
-    "阿法爾語"
+    "阿法爾語",
+    "阿法尔语"
   ],
   "aaa": [
     "Ghotuo"
@@ -22,7 +23,8 @@
   ],
   "aag": [
     "安布拉克語",
-    "Ambrak"
+    "Ambrak",
+    "安布拉克语"
   ],
   "aah": [
     "Abu' Arapesh",
@@ -35,7 +37,8 @@
     "Miniafia"
   ],
   "aak": [
-    "安卡維語"
+    "安卡維語",
+    "安卡维语"
   ],
   "aal": [
     "Afade"
@@ -51,7 +54,8 @@
     "佩諾布斯科特語",
     "Penobscot",
     "Eastern Abenaki",
-    "Eastern Abnaki"
+    "Eastern Abnaki",
+    "佩诺布斯科特语"
   ],
   "aas": [
     "Aasax",
@@ -62,20 +66,25 @@
   ],
   "aau": [
     "阿包語",
-    "Abau"
+    "Abau",
+    "阿包语"
   ],
   "aav-khs-pro": [
-    "原始卡西語"
+    "原始卡西語",
+    "原始卡西语"
   ],
   "aav-nic-pro": [
-    "原始尼科巴語"
+    "原始尼科巴語",
+    "原始尼科巴语"
   ],
   "aav-pkl-pro": [
-    "原始布那-卡西-林甘語"
+    "原始布那-卡西-林甘語",
+    "原始布那-卡西-林甘语"
   ],
   "aav-pro": [
     "原始南亞語",
-    "Proto-Austroasiatic"
+    "Proto-Austroasiatic",
+    "原始南亚语"
   ],
   "aaw": [
     "Solong",
@@ -87,10 +96,12 @@
   ],
   "aaz": [
     "阿馬拉斯語",
-    "Amarasi"
+    "Amarasi",
+    "阿马拉斯语"
   ],
   "ab": [
-    "阿布哈茲語"
+    "阿布哈茲語",
+    "阿布哈兹语"
   ],
   "aba": [
     "Abé"
@@ -104,18 +115,21 @@
     "Mandouka"
   ],
   "abc": [
-    "安巴拉埃塔語"
+    "安巴拉埃塔語",
+    "安巴拉埃塔语"
   ],
   "abd": [
     "北甘馬粦阿埃塔語",
-    "Manide"
+    "Manide",
+    "北甘马粦阿埃塔语"
   ],
   "abe": [
     "阿貝納基語",
     "Abenaki",
     "Western Abenaki",
     "Abnaki",
-    "Western Abnaki"
+    "Western Abnaki",
+    "阿贝纳基语"
   ],
   "abf": [
     "Abai Sungai"
@@ -125,7 +139,8 @@
   ],
   "abh": [
     "塔吉克阿拉伯語",
-    "Tajiki Arabic"
+    "Tajiki Arabic",
+    "塔吉克阿拉伯语"
   ],
   "abi": [
     "Abidji"
@@ -156,11 +171,13 @@
     "Abon"
   ],
   "abp": [
-    "亞本連埃塔語"
+    "亞本連埃塔語",
+    "亚本连埃塔语"
   ],
   "abq": [
     "阿巴扎語",
-    "Abaza"
+    "Abaza",
+    "阿巴扎语"
   ],
   "abr": [
     "Abron",
@@ -168,7 +185,8 @@
   ],
   "abs": [
     "安汶馬來語",
-    "Ambonese Malay"
+    "Ambonese Malay",
+    "安汶马来语"
   ],
   "abt": [
     "Ambulas"
@@ -177,18 +195,21 @@
     "Abure"
   ],
   "abv": [
-    "巴林阿拉伯語"
+    "巴林阿拉伯語",
+    "巴林阿拉伯语"
   ],
   "abw": [
     "Pal"
   ],
   "abx": [
     "阿巴克農語",
-    "Inabaknon"
+    "Inabaknon",
+    "阿巴克农语"
   ],
   "aby": [
     "阿比亞語",
-    "Aneme Wake"
+    "Aneme Wake",
+    "阿比亚语"
   ],
   "abz": [
     "Abui"
@@ -203,10 +224,12 @@
     "Gikyode"
   ],
   "ace": [
-    "亞齊語"
+    "亞齊語",
+    "亚齐语"
   ],
   "ach": [
-    "阿喬利語"
+    "阿喬利語",
+    "阿乔利语"
   ],
   "aci": [
     "Aka-Cari",
@@ -232,14 +255,17 @@
     "美索不達米亞阿拉伯語",
     "伊拉克阿拉伯語",
     "Iraqi Arabic",
-    "Mesopotamian Arabic"
+    "Mesopotamian Arabic",
+    "美索不达米亚阿拉伯语",
+    "伊拉克阿拉伯语"
   ],
   "acn": [
     "阿昌語",
     "Achang",
     "Xiandao",
     "Ngochang",
-    "Ngachang"
+    "Ngachang",
+    "阿昌语"
   ],
   "acp": [
     "Eastern Acipa"
@@ -266,21 +292,26 @@
     "漢志阿拉伯語",
     "Hijazi Arabic",
     "Hejazi Arabic",
-    "West Arabian Arabic"
+    "West Arabian Arabic",
+    "汉志阿拉伯语"
   ],
   "acx": [
     "阿曼阿拉伯語",
-    "Omani Arabic"
+    "Omani Arabic",
+    "阿曼阿拉伯语"
   ],
   "acy": [
     "塞浦路斯阿拉伯語",
-    "Cypriot Arabic"
+    "Cypriot Arabic",
+    "塞浦路斯阿拉伯语"
   ],
   "acz": [
-    "阿克隆語"
+    "阿克隆語",
+    "阿克隆语"
   ],
   "ada": [
-    "阿當梅語"
+    "阿當梅語",
+    "阿当梅语"
   ],
   "adb": [
     "Adabe"
@@ -294,11 +325,13 @@
   ],
   "adf": [
     "多法爾阿拉伯語",
-    "Dhofari Arabic"
+    "Dhofari Arabic",
+    "多法尔阿拉伯语"
   ],
   "adg": [
     "安德格雷賓哈語",
-    "Andegerebinha"
+    "Andegerebinha",
+    "安德格雷宾哈语"
   ],
   "adh": [
     "Adhola"
@@ -314,7 +347,8 @@
     "Panggi",
     "Pasi",
     "Shimong",
-    "Ajukru"
+    "Ajukru",
+    "阿迪语"
   ],
   "adj": [
     "Adioukrou"
@@ -329,7 +363,8 @@
   "ado": [
     "阿布語",
     "Abu",
-    "Adjora"
+    "Adjora",
+    "阿布语"
   ],
   "adp": [
     "Adap"
@@ -346,7 +381,8 @@
   ],
   "adt": [
     "阿德尼亞馬塔納語",
-    "Adnyamathanh"
+    "Adnyamathanh",
+    "阿德尼亚马塔纳语"
   ],
   "adu": [
     "Aduge"
@@ -358,32 +394,40 @@
     "安多藏語",
     "Amdo Tibetan",
     "Amdo",
-    "Panang"
+    "Panang",
+    "安多藏语"
   ],
   "ady": [
     "阿迪格語",
     "Adyghe",
-    "West Circassian"
+    "West Circassian",
+    "阿迪格语"
   ],
   "adz": [
     "阿哲拉語",
-    "Adzera"
+    "Adzera",
+    "阿哲拉语"
   ],
   "ae": [
-    "阿維斯陀語"
+    "阿維斯陀語",
+    "阿维斯陀语"
   ],
   "aea": [
     "阿雷巴語",
-    "Areba"
+    "Areba",
+    "阿雷巴语"
   ],
   "aeb": [
     "突尼斯阿拉伯語",
     "突尼西亞阿拉伯語",
-    "Tunisian Arabic"
+    "Tunisian Arabic",
+    "突尼斯阿拉伯语",
+    "突尼西亚阿拉伯语"
   ],
   "aed": [
     "阿根廷手語",
-    "Argentine Sign Language"
+    "Argentine Sign Language",
+    "阿根廷手语"
   ],
   "aee": [
     "Northeast Pashayi",
@@ -398,19 +442,23 @@
   ],
   "aem": [
     "阿楞語",
-    "Arem"
+    "Arem",
+    "阿楞语"
   ],
   "aen": [
     "亞美尼亞手語",
-    "Armenian Sign Language"
+    "Armenian Sign Language",
+    "亚美尼亚手语"
   ],
   "aeq": [
     "埃爾語",
-    "Aer"
+    "Aer",
+    "埃尔语"
   ],
   "aer": [
     "東阿蘭達語",
-    "Eastern Arrernte"
+    "Eastern Arrernte",
+    "东阿兰达语"
   ],
   "aes": [
     "Alsea",
@@ -439,14 +487,19 @@
   "af": [
     "南非語",
     "阿非利堪斯語",
-    "南非荷蘭語"
+    "南非荷蘭語",
+    "南非语",
+    "阿非利堪斯语",
+    "南非荷兰语"
   ],
   "afa-pro": [
-    "原始亞非語"
+    "原始亞非語",
+    "原始亚非语"
   ],
   "afb": [
     "海灣阿拉伯語",
-    "Gulf Arabic"
+    "Gulf Arabic",
+    "海湾阿拉伯语"
   ],
   "afd": [
     "Andai"
@@ -456,10 +509,12 @@
   ],
   "afg": [
     "阿富汗手語",
-    "Afghan Sign Language"
+    "Afghan Sign Language",
+    "阿富汗手语"
   ],
   "afh": [
-    "阿弗里希利語"
+    "阿弗里希利語",
+    "阿弗里希利语"
   ],
   "afi": [
     "Akrukay"
@@ -529,20 +584,24 @@
   ],
   "agm": [
     "安加塔哈語",
-    "Angaataha"
+    "Angaataha",
+    "安加塔哈语"
   ],
   "agn": [
-    "阿古塔農語"
+    "阿古塔農語",
+    "阿古塔农语"
   ],
   "ago": [
     "Tainae"
   ],
   "agq": [
-    "亞罕語"
+    "亞罕語",
+    "亚罕语"
   ],
   "agr": [
     "阿瓜魯那語",
-    "Aguaruna"
+    "Aguaruna",
+    "阿瓜鲁那语"
   ],
   "ags": [
     "Esimbi"
@@ -557,13 +616,15 @@
     "雷蒙達道阿埃塔語",
     "Remontado Dumagat",
     "Sinauna",
-    "Hatang Kayey"
+    "Hatang Kayey",
+    "雷蒙达道阿埃塔语"
   ],
   "agw": [
     "Kahua"
   ],
   "agx": [
-    "阿古爾語"
+    "阿古爾語",
+    "阿古尔语"
   ],
   "agy": [
     "Southern Alta"
@@ -600,7 +661,8 @@
   ],
   "aho": [
     "阿洪姆語",
-    "Ahom"
+    "Ahom",
+    "阿洪姆语"
   ],
   "ahp": [
     "Aproumu Aizi"
@@ -609,7 +671,8 @@
     "阿希拉尼語",
     "Ahirani",
     "Khandeshi",
-    "Khandesi"
+    "Khandesi",
+    "阿希拉尼语"
   ],
   "ahs": [
     "Ashe"
@@ -630,14 +693,16 @@
     "Eyni",
     "Ejnu",
     "Abdal",
-    "Äynú"
+    "Äynú",
+    "艾努语"
   ],
   "aic": [
     "Ainbai"
   ],
   "aid": [
     "阿爾吉特語",
-    "Alngith"
+    "Alngith",
+    "阿尔吉特语"
   ],
   "aie": [
     "Amara"
@@ -659,17 +724,27 @@
     "Kokoy Creole English",
     "聖基茨克里奧爾語",
     "蒙特塞拉特克里奧爾語",
-    "安圭拉克里奧爾語"
+    "安圭拉克里奧爾語",
+    "安提瓜和巴布达克里奥尔英语",
+    "向风加勒比克里奥尔英语",
+    "安提瓜克里奥尔英语",
+    "圣基茨克里奥尔语",
+    "蒙特塞拉特克里奥尔语",
+    "安圭拉克里奥尔语"
   ],
   "aih": [
     "錦語",
     "Ai-Cham",
     "錦話",
-    "甲姆話"
+    "甲姆話",
+    "锦语",
+    "锦话",
+    "甲姆话"
   ],
   "aii": [
     "亞述新亞拉姆語",
-    "Assyrian Neo-Aramaic"
+    "Assyrian Neo-Aramaic",
+    "亚述新亚拉姆语"
   ],
   "aij": [
     "Lishanid Noshan"
@@ -687,10 +762,13 @@
     "阿伊努語",
     "愛奴語",
     "Ainu",
-    "Ainu (Japan)"
+    "Ainu (Japan)",
+    "阿伊努语",
+    "爱奴语"
   ],
   "aio": [
-    "艾通語"
+    "艾通語",
+    "艾通语"
   ],
   "aip": [
     "Burumakok"
@@ -714,7 +792,8 @@
     "Aja"
   ],
   "ajg": [
-    "阿賈語"
+    "阿賈語",
+    "阿贾语"
   ],
   "aji": [
     "Ajië",
@@ -725,15 +804,18 @@
   ],
   "ajp": [
     "南黎凡特阿拉伯語",
-    "South Levantine Arabic"
+    "South Levantine Arabic",
+    "南黎凡特阿拉伯语"
   ],
   "ajt": [
     "猶太突尼西亞阿拉伯語",
-    "Judeo-Tunisian Arabic"
+    "Judeo-Tunisian Arabic",
+    "犹太突尼西亚阿拉伯语"
   ],
   "aju": [
     "猶太摩洛哥阿拉伯語",
-    "Judeo-Moroccan Arabic"
+    "Judeo-Moroccan Arabic",
+    "犹太摩洛哥阿拉伯语"
   ],
   "ajw": [
     "Ajawa"
@@ -742,10 +824,12 @@
     "Amri Karbi"
   ],
   "ak": [
-    "阿坎語"
+    "阿坎語",
+    "阿坎语"
   ],
   "akb": [
-    "昂科拉巴塔克語"
+    "昂科拉巴塔克語",
+    "昂科拉巴塔克语"
   ],
   "akc": [
     "Mpur"
@@ -774,13 +858,15 @@
   ],
   "akk": [
     "阿卡德語",
-    "Akkadian"
+    "Akkadian",
+    "阿卡德语"
   ],
   "akl": [
     "阿克蘭語",
     "Aklanon",
     "Aklan",
-    "Akeanon"
+    "Akeanon",
+    "阿克兰语"
   ],
   "akm": [
     "Aka-Bo",
@@ -798,7 +884,8 @@
   ],
   "akr": [
     "阿拉基語",
-    "Araki"
+    "Araki",
+    "阿拉基语"
   ],
   "aks": [
     "Akaselem",
@@ -814,7 +901,8 @@
   ],
   "akv": [
     "阿赫瓦赫語",
-    "Akhvakh"
+    "Akhvakh",
+    "阿赫瓦赫语"
   ],
   "akw": [
     "Akwa"
@@ -832,7 +920,8 @@
   ],
   "akz": [
     "亞拉巴馬語",
-    "Alabama"
+    "Alabama",
+    "亚拉巴马语"
   ],
   "ala": [
     "Alago"
@@ -842,7 +931,9 @@
     "阿拉卡盧夫語",
     "Kawésqar",
     "Qawasqar",
-    "Alacaluf"
+    "Alacaluf",
+    "卡瓦斯卡尔语",
+    "阿拉卡卢夫语"
   ],
   "ald": [
     "Alladian",
@@ -853,33 +944,40 @@
   "ale": [
     "阿留申語",
     "Aleut",
-    "Aleutian"
+    "Aleutian",
+    "阿留申语"
   ],
   "alf": [
     "Alege"
   ],
   "alg-aga": [
-    "阿加萬語"
+    "阿加萬語",
+    "阿加万语"
   ],
   "alg-pro": [
     "原始阿爾岡昆語",
-    "Proto-Algonquian"
+    "Proto-Algonquian",
+    "原始阿尔冈昆语"
   ],
   "alh": [
     "阿拉瓦語",
-    "Alawa"
+    "Alawa",
+    "阿拉瓦语"
   ],
   "ali": [
     "阿邁蒙語",
-    "Amaimon"
+    "Amaimon",
+    "阿迈蒙语"
   ],
   "alj": [
     "阿蘭岡語",
-    "Alangan"
+    "Alangan",
+    "阿兰冈语"
   ],
   "alk": [
     "阿拉克語",
-    "Alak"
+    "Alak",
+    "阿拉克语"
   ],
   "all": [
     "Allar",
@@ -893,22 +991,26 @@
   ],
   "alp": [
     "阿魯尼語",
-    "Alune"
+    "Alune",
+    "阿鲁尼语"
   ],
   "alq": [
     "阿爾岡昆語",
-    "Algonquin"
+    "Algonquin",
+    "阿尔冈昆语"
   ],
   "alr": [
     "阿留特語",
-    "Alutor"
+    "Alutor",
+    "阿留特语"
   ],
   "alt": [
     "南阿爾泰語",
     "Southern Altai",
     "Southern Altay",
     "Altai",
-    "Altay"
+    "Altay",
+    "南阿尔泰语"
   ],
   "alu": [
     "'Are'are"
@@ -924,30 +1026,35 @@
   ],
   "alv-bua-pro": [
     "原始布阿語",
-    "Proto-Bua"
+    "Proto-Bua",
+    "原始布阿语"
   ],
   "alv-cng-pro": [
     "Proto-Cangin"
   ],
   "alv-edo-pro": [
     "原始類埃多語",
-    "Proto-Edoid"
+    "Proto-Edoid",
+    "原始类埃多语"
   ],
   "alv-fli-pro": [
     "Proto-Fali"
   ],
   "alv-gbe-pro": [
     "原始格貝語",
-    "Proto-Gbe"
+    "Proto-Gbe",
+    "原始格贝语"
   ],
   "alv-gng-pro": [
     "Proto-Guang"
   ],
   "alv-gtm-pro": [
-    "原始中多哥語"
+    "原始中多哥語",
+    "原始中多哥语"
   ],
   "alv-gwa": [
-    "瓜拉語"
+    "瓜拉語",
+    "瓜拉语"
   ],
   "alv-hei-pro": [
     "Proto-Heiban"
@@ -965,10 +1072,12 @@
     "Proto-Nupoid"
   ],
   "alv-pro": [
-    "原始大西洋-剛果語"
+    "原始大西洋-剛果語",
+    "原始大西洋-刚果语"
   ],
   "alv-yor-pro": [
-    "類約魯巴語支"
+    "類約魯巴語支",
+    "类约鲁巴语支"
   ],
   "alw": [
     "Alaba",
@@ -981,13 +1090,15 @@
   ],
   "aly": [
     "阿利亞瓦拉語",
-    "Alyawarr"
+    "Alyawarr",
+    "阿利亚瓦拉语"
   ],
   "alz": [
     "Alur"
   ],
   "am": [
-    "阿姆哈拉語"
+    "阿姆哈拉語",
+    "阿姆哈拉语"
   ],
   "ama": [
     "Amanayé"
@@ -1011,7 +1122,8 @@
   ],
   "ami": [
     "阿美語",
-    "Amis"
+    "Amis",
+    "阿美语"
   ],
   "amj": [
     "Amdang",
@@ -1027,11 +1139,13 @@
   ],
   "amm": [
     "阿瑪語",
-    "Ama"
+    "Ama",
+    "阿玛语"
   ],
   "amn": [
     "阿瑪納卜語",
-    "Amanab"
+    "Amanab",
+    "阿玛纳卜语"
   ],
   "amo": [
     "Amo",
@@ -1052,7 +1166,8 @@
   ],
   "ams": [
     "南奄美大島語",
-    "Southern Amami-Oshima"
+    "Southern Amami-Oshima",
+    "南奄美大岛语"
   ],
   "amt": [
     "Amto"
@@ -1063,14 +1178,16 @@
     "Amuzgo",
     "Xochistlahuaca Amuzgo",
     "Northern Amuzgo",
-    "Southern Amuzgo"
+    "Southern Amuzgo",
+    "格雷罗阿穆兹戈语"
   ],
   "amv": [
     "Ambelau"
   ],
   "amw": [
     "西現代亞拉姆語",
-    "Western Neo-Aramaic"
+    "Western Neo-Aramaic",
+    "西现代亚拉姆语"
   ],
   "amx": [
     "Anmatyerre",
@@ -1080,14 +1197,17 @@
     "阿米語",
     "Ami",
     "Ame",
-    "Amijangal"
+    "Amijangal",
+    "阿米语"
   ],
   "amz": [
     "阿坦帕雅語",
-    "Atampaya"
+    "Atampaya",
+    "阿坦帕雅语"
   ],
   "an": [
-    "阿拉貢語"
+    "阿拉貢語",
+    "阿拉贡语"
   ],
   "ana": [
     "Andaqui"
@@ -1118,13 +1238,15 @@
   ],
   "ane": [
     "哈拉楚語",
-    "Xârâcùù"
+    "Xârâcùù",
+    "哈拉楚语"
   ],
   "anf": [
     "Animere"
   ],
   "ang": [
-    "古英語"
+    "古英語",
+    "古英语"
   ],
   "anh": [
     "Nend",
@@ -1133,7 +1255,8 @@
   ],
   "ani": [
     "安迪語",
-    "Andi"
+    "Andi",
+    "安迪语"
   ],
   "anj": [
     "Anor"
@@ -1151,7 +1274,8 @@
     "阿納爾語",
     "Anal",
     "Anaal",
-    "Namfau"
+    "Namfau",
+    "阿纳尔语"
   ],
   "ann": [
     "Obolo"
@@ -1161,23 +1285,27 @@
   ],
   "anp": [
     "昂加語",
-    "Angika"
+    "Angika",
+    "昂加语"
   ],
   "anq": [
     "加洛瓦語",
     "Jarawa",
-    "Jarawa (India)"
+    "Jarawa (India)",
+    "加洛瓦语"
   ],
   "anr": [
     "安德赫語",
-    "Andh"
+    "Andh",
+    "安德赫语"
   ],
   "ans": [
     "Anserma"
   ],
   "ant": [
     "安塔卡林亞語",
-    "Antakarinya"
+    "Antakarinya",
+    "安塔卡林亚语"
   ],
   "anu": [
     "Anuak"
@@ -1202,7 +1330,8 @@
   ],
   "aoa": [
     "安哥拉克里奧爾語",
-    "Angolar"
+    "Angolar",
+    "安哥拉克里奥尔语"
   ],
   "aob": [
     "Abom"
@@ -1228,7 +1357,8 @@
     "Maramba"
   ],
   "aoi": [
-    "阿寧迪爾雅夸語"
+    "阿寧迪爾雅夸語",
+    "阿宁迪尔雅夸语"
   ],
   "aoj": [
     "Mufian"
@@ -1252,7 +1382,8 @@
     "Taikat"
   ],
   "aot": [
-    "阿通語（印度）"
+    "阿通語（印度）",
+    "阿通语（印度）"
   ],
   "aou": [
     "阿歐語",
@@ -1260,20 +1391,28 @@
     "阿歐方言",
     "阿歐仡佬語",
     "紅仡佬語",
-    "紅豐仡佬語"
+    "紅豐仡佬語",
+    "阿欧语",
+    "阿欧话",
+    "阿欧方言",
+    "阿欧仡佬语",
+    "红仡佬语",
+    "红丰仡佬语"
   ],
   "aox": [
     "Atorada"
   ],
   "aoz": [
     "瓦布梅托語",
-    "Uab Meto"
+    "Uab Meto",
+    "瓦布梅托语"
   ],
   "apa-pro": [
     "原始阿帕契語",
     "Proto-Apachean",
     "Proto-Apache",
-    "Proto-Southern Athabaskan"
+    "Proto-Southern Athabaskan",
+    "原始阿帕契语"
   ],
   "apb": [
     "Sa'a",
@@ -1282,11 +1421,13 @@
   ],
   "apc": [
     "北黎凡特阿拉伯語",
-    "North Levantine Arabic"
+    "North Levantine Arabic",
+    "北黎凡特阿拉伯语"
   ],
   "apd": [
     "蘇丹阿拉伯語",
-    "Sudanese Arabic"
+    "Sudanese Arabic",
+    "苏丹阿拉伯语"
   ],
   "ape": [
     "Bukiyip"
@@ -1308,7 +1449,8 @@
     "Jicarilla"
   ],
   "apk": [
-    "平原阿帕契語"
+    "平原阿帕契語",
+    "平原阿帕契语"
   ],
   "apl": [
     "Lipan"
@@ -1346,7 +1488,8 @@
   "apt": [
     "阿帕塔尼語",
     "Apa Tani",
-    "Tanii"
+    "Tanii",
+    "阿帕塔尼语"
   ],
   "apu": [
     "Apurinã"
@@ -1356,7 +1499,8 @@
   ],
   "apw": [
     "西阿帕契語",
-    "Western Apacheii"
+    "Western Apacheii",
+    "西阿帕契语"
   ],
   "apx": [
     "Aputai"
@@ -1364,13 +1508,15 @@
   "apy": [
     "阿帕萊語",
     "Apalai",
-    "Apalaí"
+    "Apalaí",
+    "阿帕莱语"
   ],
   "apz": [
     "Safeyoka"
   ],
   "aqc": [
-    "阿奇語"
+    "阿奇語",
+    "阿奇语"
   ],
   "aqd": [
     "Ampari Dogon"
@@ -1380,7 +1526,8 @@
   ],
   "aql-pro": [
     "原始阿爾吉克語",
-    "Proto-Algic"
+    "Proto-Algic",
+    "原始阿尔吉克语"
   ],
   "aqm": [
     "Atohwaim"
@@ -1409,22 +1556,29 @@
     "現代標準阿拉伯語",
     "標準阿拉伯語",
     "書面阿拉伯語",
-    "Classical Arabic"
+    "Classical Arabic",
+    "阿拉伯语",
+    "现代标准阿拉伯语",
+    "标准阿拉伯语",
+    "书面阿拉伯语"
   ],
   "arc": [
     "亞拉姆語",
     "Aramaic",
     "Imperial Aramaic",
     "Official Aramaic",
-    "Biblical Aramaic"
+    "Biblical Aramaic",
+    "亚拉姆语"
   ],
   "ard": [
     "阿拉巴納語",
-    "Arabana"
+    "Arabana",
+    "阿拉巴纳语"
   ],
   "are": [
     "西阿蘭達語",
-    "Western Arrernte"
+    "Western Arrernte",
+    "西阿兰达语"
   ],
   "arh": [
     "Arhuaco",
@@ -1449,18 +1603,22 @@
     "Mapudungün",
     "Mapuzugün",
     "Mapudungu",
-    "Araucanian"
+    "Araucanian",
+    "马普切语"
   ],
   "aro": [
-    "阿拉奧納語"
+    "阿拉奧納語",
+    "阿拉奥纳语"
   ],
   "arp": [
     "阿拉帕霍語",
-    "Arapaho"
+    "Arapaho",
+    "阿拉帕霍语"
   ],
   "arq": [
     "阿爾及利亞阿拉伯語",
-    "Algerian Arabic"
+    "Algerian Arabic",
+    "阿尔及利亚阿拉伯语"
   ],
   "arr": [
     "Arara-Karo",
@@ -1480,22 +1638,26 @@
   ],
   "ars": [
     "內志阿拉伯語",
-    "Najdi Arabic"
+    "Najdi Arabic",
+    "内志阿拉伯语"
   ],
   "art-blk": [
     "Bolak"
   ],
   "art-bsp": [
     "黑暗語",
-    "Black Speech"
+    "Black Speech",
+    "黑暗语"
   ],
   "art-com": [
     "溝通語",
-    "Communicationssprache"
+    "Communicationssprache",
+    "沟通语"
   ],
   "art-dtk": [
     "多斯拉克語",
-    "Dothraki"
+    "Dothraki",
+    "多斯拉克语"
   ],
   "art-elo": [
     "Eloi"
@@ -1508,7 +1670,8 @@
   ],
   "art-man": [
     "曼達洛語",
-    "Mandalorian"
+    "Mandalorian",
+    "曼达洛语"
   ],
   "art-mun": [
     "Mundolinco"
@@ -1532,21 +1695,25 @@
     "阿拉瓦克語",
     "Arawak",
     "Arowak",
-    "Lokono"
+    "Lokono",
+    "阿拉瓦克语"
   ],
   "arx": [
     "Aruá"
   ],
   "ary": [
     "摩洛哥阿拉伯語",
-    "Moroccan Arabic"
+    "Moroccan Arabic",
+    "摩洛哥阿拉伯语"
   ],
   "arz": [
     "埃及阿拉伯語",
-    "Egyptian Arabic"
+    "Egyptian Arabic",
+    "埃及阿拉伯语"
   ],
   "as": [
-    "阿薩姆語"
+    "阿薩姆語",
+    "阿萨姆语"
   ],
   "asa": [
     "阿蘇語",
@@ -1555,11 +1722,13 @@
     "Chasu",
     "Kipare",
     "Southern Pare",
-    "South Pare"
+    "South Pare",
+    "阿苏语"
   ],
   "asb": [
     "阿西內本語",
-    "Assiniboine"
+    "Assiniboine",
+    "阿西内本语"
   ],
   "asc": [
     "Casuarina Coast Asmat"
@@ -1568,10 +1737,12 @@
     "美國手語",
     "American Sign Language",
     "Ameslan",
-    "ASL"
+    "ASL",
+    "美国手语"
   ],
   "asf": [
-    "澳洲手語"
+    "澳洲手語",
+    "澳洲手语"
   ],
   "asg": [
     "Cishingini"
@@ -1597,11 +1768,13 @@
   ],
   "ask": [
     "阿什昆語",
-    "Ashkun"
+    "Ashkun",
+    "阿什昆语"
   ],
   "asl": [
     "阿西魯魯語",
-    "Asilulu"
+    "Asilulu",
+    "阿西鲁鲁语"
   ],
   "asn": [
     "Xingú Asuriní"
@@ -1611,11 +1784,13 @@
   ],
   "asp": [
     "阿爾及利亞手語",
-    "Algerian Sign Language"
+    "Algerian Sign Language",
+    "阿尔及利亚手语"
   ],
   "asq": [
     "奧地利手語",
-    "Austrian Sign Language"
+    "Austrian Sign Language",
+    "奥地利手语"
   ],
   "asr": [
     "Asuri"
@@ -1625,7 +1800,8 @@
   ],
   "ast": [
     "阿斯圖里亞斯語",
-    "Asturian"
+    "Asturian",
+    "阿斯图里亚斯语"
   ],
   "asu": [
     "Tocantins Asurini",
@@ -1640,7 +1816,8 @@
     "Asoa"
   ],
   "asw": [
-    "澳洲原住民手語"
+    "澳洲原住民手語",
+    "澳洲原住民手语"
   ],
   "asx": [
     "Muratayak"
@@ -1658,14 +1835,17 @@
   ],
   "atb": [
     "載瓦語",
-    "Zaiwa"
+    "Zaiwa",
+    "载瓦语"
   ],
   "atc": [
     "阿查瓦卡語",
-    "Atsahuaca"
+    "Atsahuaca",
+    "阿查瓦卡语"
   ],
   "atd": [
-    "亞他-馬諾博語"
+    "亞他-馬諾博語",
+    "亚他-马诺博语"
   ],
   "ate": [
     "Atemble"
@@ -1682,14 +1862,17 @@
   "ath-pro": [
     "原始德內語",
     "Proto-Athabaskan",
-    "原始阿薩巴斯卡語"
+    "原始阿薩巴斯卡語",
+    "原始德内语",
+    "原始阿萨巴斯卡语"
   ],
   "ati": [
     "Attié"
   ],
   "atj": [
     "阿提卡梅克語",
-    "Atikamekw"
+    "Atikamekw",
+    "阿提卡梅克语"
   ],
   "atk": [
     "Ati"
@@ -1718,7 +1901,8 @@
   ],
   "att": [
     "帕姆普羅納-阿塔語",
-    "Pamplona Atta"
+    "Pamplona Atta",
+    "帕姆普罗纳-阿塔语"
   ],
   "atu": [
     "Reel"
@@ -1728,7 +1912,8 @@
     "Northern Altai",
     "Northern Altay",
     "Altai",
-    "Altay"
+    "Altay",
+    "北阿尔泰语"
   ],
   "atw": [
     "Atsugewi"
@@ -1741,14 +1926,16 @@
   ],
   "atz": [
     "阿爾塔語",
-    "Arta"
+    "Arta",
+    "阿尔塔语"
   ],
   "aua": [
     "Asumboa"
   ],
   "aub": [
     "阿盧固語",
-    "Alugu"
+    "Alugu",
+    "阿卢固语"
   ],
   "auc": [
     "瓦奧語",
@@ -1761,13 +1948,15 @@
     "Ssabela",
     "Wao Terero",
     "Auka",
-    "Auca"
+    "Auca",
+    "瓦奥语"
   ],
   "aud": [
     "Anuta"
   ],
   "auf-pro": [
-    "原始阿拉萬語"
+    "原始阿拉萬語",
+    "原始阿拉万语"
   ],
   "aug": [
     "Aguna"
@@ -1777,13 +1966,15 @@
   ],
   "aui": [
     "阿努基語",
-    "Anuki"
+    "Anuki",
+    "阿努基语"
   ],
   "auj": [
     "奧吉拉語",
     "Augila",
     "Awjilah",
-    "Awjila"
+    "Awjila",
+    "奥吉拉语"
   ],
   "auk": [
     "Heyo"
@@ -1845,7 +2036,8 @@
   ],
   "aus-cww-pro": [
     "原始中新南威爾士語",
-    "Proto-Central New South Wales"
+    "Proto-Central New South Wales",
+    "原始中新南威尔士语"
   ],
   "aus-dal-pro": [
     "Proto-Daly"
@@ -1878,11 +2070,13 @@
   ],
   "aus-nyu-pro": [
     "原始紐爾紐爾語",
-    "Proto-Nyulnyulan"
+    "Proto-Nyulnyulan",
+    "原始纽尔纽尔语"
   ],
   "aus-pam-pro": [
     "原始帕馬-恩永甘語",
-    "Proto-Pama-Nyungan"
+    "Proto-Pama-Nyungan",
+    "原始帕马-恩永甘语"
   ],
   "aus-tul": [
     "Tulua",
@@ -1899,7 +2093,8 @@
   ],
   "aus-wdj-pro": [
     "原始伊瓦伊賈語",
-    "Proto-Iwaidjan"
+    "Proto-Iwaidjan",
+    "原始伊瓦伊贾语"
   ],
   "aus-won": [
     "Wong-gie"
@@ -1932,10 +2127,12 @@
   "auz": [
     "烏茲別克阿拉伯語",
     "Uzbeki Arabic",
-    "Uzbek Arabic"
+    "Uzbek Arabic",
+    "乌兹别克阿拉伯语"
   ],
   "av": [
-    "阿瓦爾語"
+    "阿瓦爾語",
+    "阿瓦尔语"
   ],
   "avb": [
     "Avau"
@@ -1944,17 +2141,20 @@
     "阿爾維里-維達里語",
     "Alviri-Vidari",
     "Alviri",
-    "Vidari"
+    "Vidari",
+    "阿尔维里-维达里语"
   ],
   "avi": [
     "Avikam"
   ],
   "avk": [
-    "科塔瓦語"
+    "科塔瓦語",
+    "科塔瓦语"
   ],
   "avm": [
     "昂卡穆蒂語",
-    "Angkamuthi"
+    "Angkamuthi",
+    "昂卡穆蒂语"
   ],
   "avn": [
     "Avatime"
@@ -1970,7 +2170,8 @@
   ],
   "avu": [
     "阿沃卡雅語",
-    "Avokaya"
+    "Avokaya",
+    "阿沃卡雅语"
   ],
   "avv": [
     "Avá-Canoeiro",
@@ -1979,7 +2180,8 @@
   ],
   "awa": [
     "阿瓦德語",
-    "Awadhi"
+    "Awadhi",
+    "阿瓦德语"
   ],
   "awb": [
     "Awa (New Guinea)"
@@ -2054,7 +2256,8 @@
     "Proto-Arawak",
     "Proto-Arawakan",
     "Proto-Maipurean",
-    "Proto-Maipuran"
+    "Proto-Maipuran",
+    "原始阿拉瓦克语"
   ],
   "awd-prw-pro": [
     "Proto-Paresi-Waura",
@@ -2071,7 +2274,8 @@
     "原始泰諾-阿拉瓦克語",
     "Proto-Ta-Arawak",
     "Proto-Ta-Arawakan",
-    "Proto-Caribbean Northern Arawak"
+    "Proto-Caribbean Northern Arawak",
+    "原始泰诺-阿拉瓦克语"
   ],
   "awd-wai": [
     "Wainumá",
@@ -2095,7 +2299,8 @@
     "Anguthimri",
     "Alngith",
     "Leningitij",
-    "Mpakwithi"
+    "Mpakwithi",
+    "安古蒂姆里语"
   ],
   "awh": [
     "Awbono"
@@ -2103,11 +2308,13 @@
   "awi": [
     "阿溫語",
     "Aekyom",
-    "Awin"
+    "Awin",
+    "阿温语"
   ],
   "awk": [
     "阿瓦巴卡爾語",
-    "Awabakal"
+    "Awabakal",
+    "阿瓦巴卡尔语"
   ],
   "awm": [
     "Arawum"
@@ -2138,7 +2345,8 @@
   ],
   "awx": [
     "阿瓦拉語",
-    "Awara"
+    "Awara",
+    "阿瓦拉语"
   ],
   "awy": [
     "Edera Awyu"
@@ -2167,17 +2375,21 @@
     "Lower Southern Aranda",
     "Lower Southern Arrernte",
     "Southern Arrernte",
-    "Southern Aranda"
+    "Southern Aranda",
+    "南阿兰达语"
   ],
   "axm": [
     "中古亞美尼亞語",
-    "Middle Armenian"
+    "Middle Armenian",
+    "中古亚美尼亚语"
   ],
   "axx": [
-    "哈拉古雷語"
+    "哈拉古雷語",
+    "哈拉古雷语"
   ],
   "ay": [
-    "艾馬拉語"
+    "艾馬拉語",
+    "艾马拉语"
   ],
   "aya": [
     "Awar"
@@ -2186,7 +2398,8 @@
     "Ayizo"
   ],
   "ayd": [
-    "阿雅巴德胡語"
+    "阿雅巴德胡語",
+    "阿雅巴德胡语"
   ],
   "aye": [
     "Ayere"
@@ -2202,11 +2415,13 @@
   ],
   "ayl": [
     "利比亞阿拉伯語",
-    "Libyan Arabic"
+    "Libyan Arabic",
+    "利比亚阿拉伯语"
   ],
   "ayn": [
     "也門阿拉伯語",
-    "Yemeni Arabic"
+    "Yemeni Arabic",
+    "也门阿拉伯语"
   ],
   "ayo": [
     "Ayoreo",
@@ -2218,7 +2433,8 @@
   ],
   "ayp": [
     "北美索不達米亞阿拉伯語",
-    "North Mesopotamian Arabic"
+    "North Mesopotamian Arabic",
+    "北美索不达米亚阿拉伯语"
   ],
   "ayq": [
     "Ayi"
@@ -2229,7 +2445,8 @@
   "ayt": [
     "巴丹埃塔語",
     "Magbukun Ayta",
-    "Mariveleño"
+    "Mariveleño",
+    "巴丹埃塔语"
   ],
   "ayu": [
     "Ayu"
@@ -2244,7 +2461,8 @@
     "Ayamaru"
   ],
   "az": [
-    "阿塞拜疆語"
+    "阿塞拜疆語",
+    "阿塞拜疆语"
   ],
   "aza": [
     "Azha"
@@ -2260,15 +2478,18 @@
   ],
   "azc-nah-pro": [
     "原始納瓦語",
-    "Proto-Nahuan"
+    "Proto-Nahuan",
+    "原始纳瓦语"
   ],
   "azc-num-pro": [
     "原始努姆語",
-    "Proto-Numic"
+    "Proto-Numic",
+    "原始努姆语"
   ],
   "azc-pro": [
     "原始猶他-阿茲特克語",
-    "Proto-Uto-Aztecan"
+    "Proto-Uto-Aztecan",
+    "原始犹他-阿兹特克语"
   ],
   "azc-tak-pro": [
     "Proto-Takic"
@@ -2278,22 +2499,26 @@
   ],
   "azd": [
     "東杜蘭戈納瓦特爾語",
-    "Eastern Durango Nahuatl"
+    "Eastern Durango Nahuatl",
+    "东杜兰戈纳瓦特尔语"
   ],
   "azg": [
     "聖彼德羅阿穆茲戈語",
     "San Pedro Amuzgos Amuzgo",
     "Upper Eastern Amuzgo",
-    "Oaxaca Amuzgo"
+    "Oaxaca Amuzgo",
+    "圣彼德罗阿穆兹戈语"
   ],
   "azm": [
     "伊帕拉帕阿穆茲戈語",
     "Ipalapa Amuzgo",
-    "Lower Eastern Amuzgo"
+    "Lower Eastern Amuzgo",
+    "伊帕拉帕阿穆兹戈语"
   ],
   "azn": [
     "西杜蘭戈納瓦特爾語",
-    "Western Durango Nahuatl"
+    "Western Durango Nahuatl",
+    "西杜兰戈纳瓦特尔语"
   ],
   "azo": [
     "Awing"
@@ -2303,10 +2528,12 @@
   ],
   "azz": [
     "高地普埃布拉納瓦特爾語",
-    "Highland Puebla Nahuatl"
+    "Highland Puebla Nahuatl",
+    "高地普埃布拉纳瓦特尔语"
   ],
   "ba": [
-    "巴什基爾語"
+    "巴什基爾語",
+    "巴什基尔语"
   ],
   "baa": [
     "Babatana"
@@ -2329,7 +2556,8 @@
     "Tuki"
   ],
   "bah": [
-    "巴哈馬克里奧爾語"
+    "巴哈馬克里奧爾語",
+    "巴哈马克里奥尔语"
   ],
   "baj": [
     "Barakai"
@@ -2343,23 +2571,28 @@
     "Eastern Baluchi",
     "Eastern Balochi",
     "Western Baluchi",
-    "Western Balochi"
+    "Western Balochi",
+    "俾路支语"
   ],
   "ban": [
     "巴厘語",
-    "Balinese"
+    "Balinese",
+    "巴厘语"
   ],
   "bao": [
     "Waimaha"
   ],
   "bap": [
-    "班塔瓦語"
+    "班塔瓦語",
+    "班塔瓦语"
   ],
   "bar": [
-    "巴伐利亞語"
+    "巴伐利亞語",
+    "巴伐利亚语"
   ],
   "bas": [
-    "巴薩語"
+    "巴薩語",
+    "巴萨语"
   ],
   "bau": [
     "Badanchi",
@@ -2374,7 +2607,8 @@
     "Bambili-Bambui"
   ],
   "bax": [
-    "巴姆穆語"
+    "巴姆穆語",
+    "巴姆穆语"
   ],
   "bay": [
     "Batuley"
@@ -2384,11 +2618,13 @@
   ],
   "bbb": [
     "巴賴語",
-    "Barai"
+    "Barai",
+    "巴赖语"
   ],
   "bbc": [
     "托巴巴塔克語",
-    "Toba Batak"
+    "Toba Batak",
+    "托巴巴塔克语"
   ],
   "bbd": [
     "Bau"
@@ -2411,19 +2647,22 @@
   "bbj": [
     "戈馬拉語'",
     "Ghomálá'",
-    "Bamileke-Banjun"
+    "Bamileke-Banjun",
+    "戈马拉语'"
   ],
   "bbk": [
     "巴邦基語",
     "Babanki",
     "Kejom",
-    "Kidzem"
+    "Kidzem",
+    "巴邦基语"
   ],
   "bbl": [
     "巴茨語",
     "Bats",
     "Batsbi",
-    "Tsova-Tush"
+    "Tsova-Tush",
+    "巴茨语"
   ],
   "bbm": [
     "Babango",
@@ -2483,7 +2722,9 @@
     "中部白語",
     "劍川話",
     "Central Bai",
-    "Jianchuan Bai"
+    "Jianchuan Bai",
+    "中部白语",
+    "剑川话"
   ],
   "bcb": [
     "Bainouk-Samik"
@@ -2513,13 +2754,15 @@
   ],
   "bck": [
     "布納巴語",
-    "Bunaba"
+    "Bunaba",
+    "布纳巴语"
   ],
   "bcl": [
     "中比科爾語",
     "Bikol Central",
     "Central Bikol",
-    "Bikol"
+    "Bikol",
+    "中比科尔语"
   ],
   "bcm": [
     "Banoni",
@@ -2621,10 +2864,12 @@
     "BGamba",
     "Gumba",
     "Mbegumba",
-    "Mvegumba"
+    "Mvegumba",
+    "拜语"
   ],
   "bdk": [
-    "布都赫語"
+    "布都赫語",
+    "布都赫语"
   ],
   "bdl": [
     "Indonesian Bajau",
@@ -2651,11 +2896,13 @@
   ],
   "bdq": [
     "巴拿語",
-    "Bahnar"
+    "Bahnar",
+    "巴拿语"
   ],
   "bdr": [
     "西海岸巴瑤語",
-    "West Coast Bajau"
+    "West Coast Bajau",
+    "西海岸巴瑶语"
   ],
   "bds": [
     "Burunge"
@@ -2671,7 +2918,8 @@
   ],
   "bdv": [
     "博多帕爾賈語",
-    "Bodo Parja"
+    "Bodo Parja",
+    "博多帕尔贾语"
   ],
   "bdw": [
     "Baham"
@@ -2681,14 +2929,17 @@
   ],
   "bdy": [
     "班賈朗語",
-    "Bandjalang"
+    "Bandjalang",
+    "班贾朗语"
   ],
   "bdz": [
     "巴德斯語",
-    "Badeshi"
+    "Badeshi",
+    "巴德斯语"
   ],
   "be": [
-    "白俄羅斯語"
+    "白俄羅斯語",
+    "白俄罗斯语"
   ],
   "bea": [
     "Beaver",
@@ -2714,7 +2965,8 @@
   "beg": [
     "馬來奕語",
     "Belait",
-    "Lemeting"
+    "Lemeting",
+    "马来奕语"
   ],
   "beh": [
     "Biali",
@@ -2725,13 +2977,15 @@
     "Bekati'"
   ],
   "bej": [
-    "貝扎語"
+    "貝扎語",
+    "贝扎语"
   ],
   "bek": [
     "Bebeli"
   ],
   "bem": [
-    "別姆巴語"
+    "別姆巴語",
+    "别姆巴语"
   ],
   "beo": [
     "Beami",
@@ -2749,7 +3003,8 @@
   ],
   "ber-pro": [
     "原始柏柏爾語",
-    "Proto-Berber"
+    "Proto-Berber",
+    "原始柏柏尔语"
   ],
   "bes": [
     "Besme"
@@ -2760,7 +3015,8 @@
     "Western Bété"
   ],
   "beu": [
-    "布拉加爾語"
+    "布拉加爾語",
+    "布拉加尔语"
   ],
   "bev": [
     "Daloa Bété",
@@ -2768,7 +3024,8 @@
     "Northern Bété"
   ],
   "bew": [
-    "伯塔維語"
+    "伯塔維語",
+    "伯塔维语"
   ],
   "bex": [
     "Jur Modo"
@@ -2782,7 +3039,8 @@
   "bez": [
     "貝納語",
     "Bena",
-    "Bena (Tanzania)"
+    "Bena (Tanzania)",
+    "贝纳语"
   ],
   "bfa": [
     "巴利語",
@@ -2792,11 +3050,13 @@
     "Fadjulu",
     "Fajelu",
     "Madi",
-    "Pajulu"
+    "Pajulu",
+    "巴利语"
   ],
   "bfb": [
     "鮑里巴雷里語",
-    "Pauri Bareli"
+    "Pauri Bareli",
+    "鲍里巴雷里语"
   ],
   "bfc": [
     "北部白語",
@@ -2805,10 +3065,13 @@
     "Bijiang Bai",
     "Laemae",
     "Lama",
-    "Panyi Bai"
+    "Panyi Bai",
+    "北部白语",
+    "碧江话"
   ],
   "bfd": [
-    "富特語"
+    "富特語",
+    "富特语"
   ],
   "bfe": [
     "Betaf"
@@ -2823,7 +3086,8 @@
     "Blafe"
   ],
   "bfi": [
-    "英國手語"
+    "英國手語",
+    "英国手语"
   ],
   "bfj": [
     "Bafanji"
@@ -2847,7 +3111,8 @@
     "Beba"
   ],
   "bfq": [
-    "巴達加語"
+    "巴達加語",
+    "巴达加语"
   ],
   "bfr": [
     "Bazigar"
@@ -2856,11 +3121,14 @@
     "南部白語",
     "大理話",
     "Southern Bai",
-    "Dali Bai"
+    "Dali Bai",
+    "南部白语",
+    "大理话"
   ],
   "bft": [
     "巴爾蒂語",
-    "Balti"
+    "Balti",
+    "巴尔蒂语"
   ],
   "bfu": [
     "Gahri"
@@ -2874,14 +3142,17 @@
   ],
   "bfy": [
     "巴格里語",
-    "Bagheli"
+    "Bagheli",
+    "巴格里语"
   ],
   "bfz": [
     "馬哈蘇帕哈里語",
-    "Mahasu Pahari"
+    "Mahasu Pahari",
+    "马哈苏帕哈里语"
   ],
   "bg": [
-    "保加利亞語"
+    "保加利亞語",
+    "保加利亚语"
   ],
   "bga": [
     "Gwamhi-Wuri",
@@ -2893,25 +3164,30 @@
   ],
   "bgc": [
     "哈爾彥維語",
-    "Haryanvi"
+    "Haryanvi",
+    "哈尔彦维语"
   ],
   "bgd": [
     "拉特維巴雷里語",
-    "Rathwi Bareli"
+    "Rathwi Bareli",
+    "拉特维巴雷里语"
   ],
   "bge": [
     "包利雅語",
-    "Bauria"
+    "Bauria",
+    "包利雅语"
   ],
   "bgf": [
     "Bangandu"
   ],
   "bgg": [
     "布貢語",
-    "Bugun"
+    "Bugun",
+    "布贡语"
   ],
   "bgi": [
-    "嘉安語"
+    "嘉安語",
+    "嘉安语"
   ],
   "bgj": [
     "Bangolan"
@@ -2927,7 +3203,8 @@
   ],
   "bgq": [
     "巴格里語",
-    "Bagri"
+    "Bagri",
+    "巴格里语"
   ],
   "bgr": [
     "Bawm Chin",
@@ -2936,7 +3213,8 @@
   ],
   "bgs": [
     "塔加巴瓦語",
-    "Tagabawa"
+    "Tagabawa",
+    "塔加巴瓦语"
   ],
   "bgt": [
     "Bughotu"
@@ -2949,37 +3227,44 @@
   ],
   "bgw": [
     "巴特里語",
-    "Bhatri"
+    "Bhatri",
+    "巴特里语"
   ],
   "bgx": [
-    "巴爾幹加告茲土耳其語"
+    "巴爾幹加告茲土耳其語",
+    "巴尔干加告兹土耳其语"
   ],
   "bgy": [
     "Benggoi"
   ],
   "bgz": [
-    "邦蓋語"
+    "邦蓋語",
+    "邦盖语"
   ],
   "bh": [
-    "比哈爾語"
+    "比哈爾語",
+    "比哈尔语"
   ],
   "bha": [
     "Bharia"
   ],
   "bhb": [
     "比里語",
-    "Bhili"
+    "Bhili",
+    "比里语"
   ],
   "bhc": [
     "Biga"
   ],
   "bhd": [
     "巴德拉瓦希語",
-    "Bhadarwahi"
+    "Bhadarwahi",
+    "巴德拉瓦希语"
   ],
   "bhe": [
     "巴雅語",
-    "Bhaya"
+    "Bhaya",
+    "巴雅语"
   ],
   "bhf": [
     "Odiai"
@@ -2992,7 +3277,8 @@
   ],
   "bhi": [
     "比拉里語",
-    "Bhilali"
+    "Bhilali",
+    "比拉里语"
   ],
   "bhj": [
     "Bahing"
@@ -3013,7 +3299,8 @@
   ],
   "bho": [
     "博杰普爾語",
-    "Bhojpuri"
+    "Bhojpuri",
+    "博杰普尔语"
   ],
   "bhp": [
     "Bima"
@@ -3026,11 +3313,13 @@
   ],
   "bht": [
     "巴梯亞里語",
-    "Bhattiyali"
+    "Bhattiyali",
+    "巴梯亚里语"
   ],
   "bhu": [
     "本賈語",
-    "Bhunjia"
+    "Bhunjia",
+    "本贾语"
   ],
   "bhv": [
     "Bahau"
@@ -3041,7 +3330,8 @@
   "bhx": [
     "巴萊語",
     "Bhalay",
-    "Bhalay-Gowlan"
+    "Bhalay-Gowlan",
+    "巴莱语"
   ],
   "bhy": [
     "Bhele",
@@ -3053,11 +3343,13 @@
     "Bada"
   ],
   "bi": [
-    "比斯拉馬語"
+    "比斯拉馬語",
+    "比斯拉马语"
   ],
   "bia": [
     "巴迪馬亞語",
-    "Badimaya"
+    "Badimaya",
+    "巴迪马亚语"
   ],
   "bib": [
     "Bissa"
@@ -3095,7 +3387,8 @@
   "bin": [
     "埃多語",
     "Edo",
-    "Bini"
+    "Bini",
+    "埃多语"
   ],
   "bio": [
     "Nai",
@@ -3164,7 +3457,8 @@
     "Punkirla",
     "Wanbirujurari",
     "Willara",
-    "Willeuroo"
+    "Willeuroo",
+    "巴尔恩加尔拉语"
   ],
   "bjc": [
     "Bariji",
@@ -3175,7 +3469,8 @@
     "標敏語",
     "Biao-Jiao Mien",
     "Biao Min",
-    "Jiaogong Mian"
+    "Jiaogong Mian",
+    "标敏语"
   ],
   "bjf": [
     "Barzani Jewish Neo-Aramaic"
@@ -3200,10 +3495,12 @@
   ],
   "bjm": [
     "巴傑蘭語",
-    "Bajelani"
+    "Bajelani",
+    "巴杰兰语"
   ],
   "bjn": [
-    "班查語"
+    "班查語",
+    "班查语"
   ],
   "bjo": [
     "Mid-Southern Banda"
@@ -3240,7 +3537,8 @@
   ],
   "bjz": [
     "巴魯加語",
-    "Baruga"
+    "Baruga",
+    "巴鲁加语"
   ],
   "bka": [
     "Kyak",
@@ -3252,7 +3550,8 @@
   ],
   "bkd": [
     "布基語",
-    "Binukid"
+    "Binukid",
+    "布基语"
   ],
   "bkf": [
     "Beeke"
@@ -3272,14 +3571,17 @@
   ],
   "bkk": [
     "布羅克斯卡特語",
-    "Brokskat"
+    "Brokskat",
+    "布罗克斯卡特语"
   ],
   "bkl": [
     "貝里克語",
-    "Berik"
+    "Berik",
+    "贝里克语"
   ],
   "bkm": [
-    "康姆語（喀麥隆）"
+    "康姆語（喀麥隆）",
+    "康姆语（喀麦隆）"
   ],
   "bkn": [
     "Bukitan"
@@ -3303,7 +3605,8 @@
     "Boloki"
   ],
   "bku": [
-    "布希德語"
+    "布希德語",
+    "布希德语"
   ],
   "bkv": [
     "Bekwarra"
@@ -3324,7 +3627,9 @@
     "黑腳語",
     "Blackfoot",
     "錫克錫卡語",
-    "Blackfeet"
+    "Blackfeet",
+    "黑脚语",
+    "锡克锡卡语"
   ],
   "blb": [
     "Bilua"
@@ -3337,7 +3642,8 @@
   ],
   "ble": [
     "肯托赫-巴蘭塔語",
-    "Balanta-Kentohe"
+    "Balanta-Kentohe",
+    "肯托赫-巴兰塔语"
   ],
   "blf": [
     "Buol"
@@ -3360,7 +3666,8 @@
     "Bolongan"
   ],
   "blk": [
-    "勃歐語"
+    "勃歐語",
+    "勃欧语"
   ],
   "bll": [
     "Biloxi"
@@ -3402,7 +3709,8 @@
     "Balaesang"
   ],
   "blt": [
-    "傣黯語"
+    "傣黯語",
+    "傣黯语"
   ],
   "blv": [
     "Kibala",
@@ -3414,7 +3722,8 @@
     "Balangao"
   ],
   "blx": [
-    "麥因迪埃塔語"
+    "麥因迪埃塔語",
+    "麦因迪埃塔语"
   ],
   "bly": [
     "Notre"
@@ -3423,7 +3732,8 @@
     "Balantak"
   ],
   "bm": [
-    "班巴拉語"
+    "班巴拉語",
+    "班巴拉语"
   ],
   "bma": [
     "Lame"
@@ -3457,7 +3767,8 @@
   ],
   "bmj": [
     "博特-邁希語",
-    "Bote-Majhi"
+    "Bote-Majhi",
+    "博特-迈希语"
   ],
   "bmk": [
     "Ghayavi"
@@ -3479,11 +3790,13 @@
   ],
   "bmr": [
     "穆伊納內語",
-    "Muinane"
+    "Muinane",
+    "穆伊纳内语"
   ],
   "bmt": [
     "標曼語",
-    "Biao Mon"
+    "Biao Mon",
+    "标曼语"
   ],
   "bmu": [
     "Somba-Siawari"
@@ -3501,7 +3814,8 @@
     "Baramu"
   ],
   "bn": [
-    "孟加拉語"
+    "孟加拉語",
+    "孟加拉语"
   ],
   "bna": [
     "Bonerate"
@@ -3510,7 +3824,8 @@
     "Bookan"
   ],
   "bnd": [
-    "班達語"
+    "班達語",
+    "班达语"
   ],
   "bne": [
     "Bintauna"
@@ -3528,7 +3843,8 @@
     "Bubangi"
   ],
   "bnj": [
-    "東塔烏碧語"
+    "東塔烏碧語",
+    "东塔乌碧语"
   ],
   "bnk": [
     "Bierebo"
@@ -3541,11 +3857,13 @@
   ],
   "bnn": [
     "布農語",
-    "Bunun"
+    "Bunun",
+    "布农语"
   ],
   "bno": [
     "班頓語",
-    "Asi"
+    "Asi",
+    "班顿语"
   ],
   "bnp": [
     "Bola"
@@ -3559,7 +3877,8 @@
   "bns": [
     "布恩德里語",
     "Bundeli",
-    "Bundelkhandi"
+    "Bundelkhandi",
+    "布恩德里语"
   ],
   "bnt-bal": [
     "Balong"
@@ -3587,7 +3906,8 @@
   ],
   "bnt-lal": [
     "拉拉語（南非）",
-    "Lala (South Africa)"
+    "Lala (South Africa)",
+    "拉拉语（南非）"
   ],
   "bnt-lwl": [
     "Lwel",
@@ -3602,28 +3922,33 @@
   ],
   "bnt-ngu-pro": [
     "原始恩古尼語",
-    "Proto-Nguni"
+    "Proto-Nguni",
+    "原始恩古尼语"
   ],
   "bnt-phu": [
-    "普提語"
+    "普提語",
+    "普提语"
   ],
   "bnt-pro": [
     "原始班圖語",
-    "Proto-Bantu"
+    "Proto-Bantu",
+    "原始班图语"
   ],
   "bnt-sbo": [
     "South Boma"
   ],
   "bnt-sts-pro": [
     "原始索托-茨瓦納語",
-    "Proto-Sotho-Tswana"
+    "Proto-Sotho-Tswana",
+    "原始索托-茨瓦纳语"
   ],
   "bnu": [
     "Bentong"
   ],
   "bnv": [
     "貝內拉夫語",
-    "Beneraf"
+    "Beneraf",
+    "贝内拉夫语"
   ],
   "bnw": [
     "Bisis"
@@ -3633,13 +3958,15 @@
   ],
   "bny": [
     "民都魯語",
-    "Bintulu"
+    "Bintulu",
+    "民都鲁语"
   ],
   "bnz": [
     "Beezen"
   ],
   "bo": [
-    "藏語"
+    "藏語",
+    "藏语"
   ],
   "boa": [
     "Bora"
@@ -3670,7 +3997,8 @@
   ],
   "bol": [
     "博雷語",
-    "Bole"
+    "Bole",
+    "博雷语"
   ],
   "bom": [
     "Berom"
@@ -3689,7 +4017,8 @@
   ],
   "bor": [
     "博羅洛語",
-    "Borôro"
+    "Borôro",
+    "博罗洛语"
   ],
   "bot": [
     "Bongo"
@@ -3698,7 +4027,8 @@
     "邦代語",
     "Bondei",
     "Boondei",
-    "Boondéi"
+    "Boondéi",
+    "邦代语"
   ],
   "bov": [
     "Tuwuli",
@@ -3729,13 +4059,15 @@
     "Baiap"
   ],
   "bpd": [
-    "班達-班達語"
+    "班達-班達語",
+    "班达-班达语"
   ],
   "bpg": [
     "Bonggo"
   ],
   "bph": [
-    "博特利赫語"
+    "博特利赫語",
+    "博特利赫语"
   ],
   "bpi": [
     "Bagupi"
@@ -3754,7 +4086,8 @@
   ],
   "bpn": [
     "藻敏語",
-    "Dzao Min"
+    "Dzao Min",
+    "藻敏语"
   ],
   "bpo": [
     "Anasi"
@@ -3763,17 +4096,21 @@
     "Kaure"
   ],
   "bpq": [
-    "班達-馬來語"
+    "班達-馬來語",
+    "班达-马来语"
   ],
   "bpr": [
-    "科羅納達爾-布拉安語"
+    "科羅納達爾-布拉安語",
+    "科罗纳达尔-布拉安语"
   ],
   "bps": [
-    "薩蘭尼加-布拉安語"
+    "薩蘭尼加-布拉安語",
+    "萨兰尼加-布拉安语"
   ],
   "bpt": [
     "巴羅角語",
-    "Barrow Point"
+    "Barrow Point",
+    "巴罗角语"
   ],
   "bpu": [
     "Bongu"
@@ -3783,17 +4120,20 @@
   ],
   "bpx": [
     "帕爾雅巴雷里語",
-    "Palya Bareli"
+    "Palya Bareli",
+    "帕尔雅巴雷里语"
   ],
   "bpy": [
     "比什奴普萊利亞-曼尼普爾語",
     "Bishnupriya Manipuri",
     "Bishnupriya",
-    "Manipuri Bishnupriya"
+    "Manipuri Bishnupriya",
+    "比什奴普莱利亚-曼尼普尔语"
   ],
   "bpz": [
     "比爾巴語",
-    "Bilba"
+    "Bilba",
+    "比尔巴语"
   ],
   "bqa": [
     "Tchumbuli"
@@ -3819,7 +4159,9 @@
   "bqi": [
     "巴赫蒂亞里語",
     "Bakhtiari",
-    "巴克鐵力語"
+    "巴克鐵力語",
+    "巴赫蒂亚里语",
+    "巴克铁力语"
   ],
   "bqj": [
     "Bandial"
@@ -3834,14 +4176,16 @@
     "Wumboko"
   ],
   "bqn": [
-    "保加利亞手語"
+    "保加利亞手語",
+    "保加利亚手语"
   ],
   "bqo": [
     "Balo"
   ],
   "bqp": [
     "布撒語",
-    "Busa"
+    "Busa",
+    "布撒语"
   ],
   "bqq": [
     "Biritai"
@@ -3874,12 +4218,14 @@
     "Bakaka"
   ],
   "br": [
-    "布列塔尼語"
+    "布列塔尼語",
+    "布列塔尼语"
   ],
   "bra": [
     "布萊語",
     "Braj",
-    "Braj Bhasha"
+    "Braj Bhasha",
+    "布莱语"
   ],
   "brb": [
     "Lave",
@@ -3892,7 +4238,8 @@
     "Berbice Creole Dutch",
     "Berbice Dutch",
     "Berbice Dutch Creole",
-    "Berbice Creole"
+    "Berbice Creole",
+    "伯比斯克里奥尔荷兰语"
   ],
   "brd": [
     "Baraamu"
@@ -3905,7 +4252,8 @@
   ],
   "brh": [
     "布拉灰語",
-    "Brahui"
+    "Brahui",
+    "布拉灰语"
   ],
   "bri": [
     "Mokpwe"
@@ -3960,7 +4308,8 @@
     "Bodo",
     "Boro",
     "Boro (India)",
-    "Mech"
+    "Mech",
+    "博多语"
   ],
   "bry": [
     "Burui"
@@ -3970,11 +4319,13 @@
   ],
   "bsa": [
     "阿比諾姆語",
-    "Abinomn"
+    "Abinomn",
+    "阿比诺姆语"
   ],
   "bsb": [
     "汶萊米沙鄢語",
-    "Brunei Bisaya"
+    "Brunei Bisaya",
+    "汶莱米沙鄢语"
   ],
   "bsc": [
     "Bassari",
@@ -3995,7 +4346,8 @@
   ],
   "bsg": [
     "巴斯卡爾迪語",
-    "Bashkardi"
+    "Bashkardi",
+    "巴斯卡尔迪语"
   ],
   "bsh": [
     "Kamkata-viri",
@@ -4009,7 +4361,8 @@
   ],
   "bsk": [
     "布魯夏斯基語",
-    "Burushaski"
+    "Burushaski",
+    "布鲁夏斯基语"
   ],
   "bsl": [
     "Basa-Gumna"
@@ -4028,13 +4381,15 @@
   ],
   "bsq": [
     "巴薩語",
-    "Bassa"
+    "Bassa",
+    "巴萨语"
   ],
   "bsr": [
     "Bassa-Kontagora"
   ],
   "bss": [
-    "阿庫色語"
+    "阿庫色語",
+    "阿库色语"
   ],
   "bst": [
     "Basketo"
@@ -4053,7 +4408,8 @@
   ],
   "bsy": [
     "沙巴米沙鄢語",
-    "Sabah Bisaya"
+    "Sabah Bisaya",
+    "沙巴米沙鄢语"
   ],
   "bta": [
     "Bata"
@@ -4062,7 +4418,8 @@
     "Bati (Cameroon)"
   ],
   "btd": [
-    "代里巴塔克語"
+    "代里巴塔克語",
+    "代里巴塔克语"
   ],
   "bte": [
     "Gamo-Ningi"
@@ -4087,16 +4444,19 @@
     "Proto-Batak",
     "Proto-Abkhaz-Abaza",
     "Proto-Abazgi",
-    "Proto-Abkhaz-Tapanta"
+    "Proto-Abkhaz-Tapanta",
+    "原始巴塔克语"
   ],
   "btm": [
     "曼特寧語",
     "Mandailing Batak",
-    "Batak Mandailing"
+    "Batak Mandailing",
+    "曼特宁语"
   ],
   "btn": [
     "拉達農語",
-    "Ratagnon"
+    "Ratagnon",
+    "拉达农语"
   ],
   "bto": [
     "Iriga Bicolano"
@@ -4105,13 +4465,15 @@
     "Budibud"
   ],
   "btq": [
-    "巴特克語"
+    "巴特克語",
+    "巴特克语"
   ],
   "btr": [
     "Baetora"
   ],
   "bts": [
-    "西馬隆貢巴塔克語"
+    "西馬隆貢巴塔克語",
+    "西马隆贡巴塔克语"
   ],
   "btt": [
     "Bete-Bendi"
@@ -4121,13 +4483,16 @@
   ],
   "btv": [
     "巴特里語",
-    "Bateri"
+    "Bateri",
+    "巴特里语"
   ],
   "btw": [
-    "布圖阿農語"
+    "布圖阿農語",
+    "布图阿农语"
   ],
   "btx": [
-    "卡羅巴塔克語"
+    "卡羅巴塔克語",
+    "卡罗巴塔克语"
   ],
   "bty": [
     "Bobot"
@@ -4136,7 +4501,8 @@
     "Alas-Kluet Batak"
   ],
   "bua": [
-    "布里亞特語"
+    "布里亞特語",
+    "布里亚特语"
   ],
   "bub": [
     "Bua"
@@ -4156,12 +4522,14 @@
   ],
   "bug": [
     "布吉語",
-    "Buginese"
+    "Buginese",
+    "布吉语"
   ],
   "buh": [
     "優諾語",
     "Younuo Bunu",
-    "Yuno"
+    "Yuno",
+    "优诺语"
   ],
   "bui": [
     "Bongili"
@@ -4173,7 +4541,8 @@
     "Bukawa"
   ],
   "bum": [
-    "布魯語（喀麥隆）"
+    "布魯語（喀麥隆）",
+    "布鲁语（喀麦隆）"
   ],
   "bun": [
     "Sherbro"
@@ -4249,7 +4618,8 @@
     "Bukat"
   ],
   "bvl": [
-    "玻利維亞手語"
+    "玻利維亞手語",
+    "玻利维亚手语"
   ],
   "bvm": [
     "Bamunka"
@@ -4268,7 +4638,8 @@
   ],
   "bvr": [
     "布拉拉語",
-    "Burarra"
+    "Burarra",
+    "布拉拉语"
   ],
   "bvt": [
     "Bati (Indonesia)"
@@ -4328,7 +4699,8 @@
     "Carúzana",
     "Izaneni",
     "Karu",
-    "Tapuya"
+    "Tapuya",
+    "巴尼瓦语"
   ],
   "bwj": [
     "Láá Láá Bwamu"
@@ -4344,7 +4716,8 @@
     "Mundugumor"
   ],
   "bwn": [
-    "唔奈語"
+    "唔奈語",
+    "唔奈语"
   ],
   "bwo": [
     "Shinasha",
@@ -4376,7 +4749,8 @@
     "Bura",
     "Bura-Pabir",
     "Pabir",
-    "Burra"
+    "Burra",
+    "布拉语"
   ],
   "bws": [
     "Bomboma"
@@ -4407,7 +4781,8 @@
     "Nu Mhou",
     "Nunu",
     "Lingyun Nunu",
-    "Nu Nu"
+    "Nu Nu",
+    "布努语"
   ],
   "bwy": [
     "Cwi Bwamu"
@@ -4444,11 +4819,13 @@
   ],
   "bxi": [
     "皮爾拉塔帕語",
-    "Pirlatapa"
+    "Pirlatapa",
+    "皮尔拉塔帕语"
   ],
   "bxj": [
     "巴永古語",
-    "Bayungu"
+    "Bayungu",
+    "巴永古语"
   ],
   "bxk": [
     "Bukusu"
@@ -4458,7 +4835,8 @@
   ],
   "bxn": [
     "布爾杜納語",
-    "Burduna"
+    "Burduna",
+    "布尔杜纳语"
   ],
   "bxo": [
     "Barikanchi"
@@ -4484,7 +4862,8 @@
   "bya": [
     "巴拉望巴塔克語",
     "Palawan Batak",
-    "Batak"
+    "Batak",
+    "巴拉望巴塔克语"
   ],
   "byb": [
     "Bikya"
@@ -4516,14 +4895,16 @@
   ],
   "byk": [
     "標話",
-    "Biao"
+    "Biao",
+    "标话"
   ],
   "byl": [
     "Bayono"
   ],
   "bym": [
     "比賈拉語",
-    "Bidyara"
+    "Bidyara",
+    "比贾拉语"
   ],
   "byn": [
     "比林語",
@@ -4531,7 +4912,8 @@
     "Bilin",
     "Bilen",
     "Belen",
-    "Bilein"
+    "Bilein",
+    "比林语"
   ],
   "byo": [
     "Biyo",
@@ -4542,7 +4924,8 @@
     "Bumaji"
   ],
   "byq": [
-    "巴賽語"
+    "巴賽語",
+    "巴赛语"
   ],
   "byr": [
     "Baruya"
@@ -4554,7 +4937,8 @@
     "Berti"
   ],
   "byv": [
-    "梅敦巴語"
+    "梅敦巴語",
+    "梅敦巴语"
   ],
   "byw": [
     "Belhariya"
@@ -4589,7 +4973,10 @@
     "Poavosa",
     "Taokas",
     "道卡斯語",
-    "虎尾壟語"
+    "虎尾壟語",
+    "巴布萨语",
+    "道卡斯语",
+    "虎尾垄语"
   ],
   "bzh": [
     "Mapos Buang"
@@ -4598,14 +4985,16 @@
     "Bisu"
   ],
   "bzj": [
-    "伯利茲克里奧爾語"
+    "伯利茲克里奧爾語",
+    "伯利兹克里奥尔语"
   ],
   "bzk": [
     "尼加拉瓜克里奧爾語",
     "Nicaraguan Creole",
     "Miskito Coast Creole",
     "Nicaraguan Creole English",
-    "Nicaragua Creole English"
+    "Nicaragua Creole English",
+    "尼加拉瓜克里奥尔语"
   ],
   "bzl": [
     "Boano (Sulawesi)",
@@ -4633,7 +5022,8 @@
   ],
   "bzr": [
     "比里語",
-    "Biri"
+    "Biri",
+    "比里语"
   ],
   "bzs": [
     "巴西手語",
@@ -4641,7 +5031,8 @@
     "LGB",
     "LSB",
     "LSCB",
-    "Libras"
+    "Libras",
+    "巴西手语"
   ],
   "bzu": [
     "Burmeso",
@@ -4666,20 +5057,25 @@
     "Evant"
   ],
   "ca": [
-    "加泰羅尼亞語"
+    "加泰羅尼亞語",
+    "加泰罗尼亚语"
   ],
   "caa": [
-    "喬爾蒂語"
+    "喬爾蒂語",
+    "乔尔蒂语"
   ],
   "cab": [
-    "加里富納語"
+    "加里富納語",
+    "加里富纳语"
   ],
   "cac": [
-    "丘赫語"
+    "丘赫語",
+    "丘赫语"
   ],
   "cad": [
     "喀多語",
-    "Caddo"
+    "Caddo",
+    "喀多语"
   ],
   "cae": [
     "Laalaa"
@@ -4689,7 +5085,8 @@
   ],
   "cag": [
     "尼瓦克萊語",
-    "Nivaclé"
+    "Nivaclé",
+    "尼瓦克莱语"
   ],
   "cah": [
     "Cahuarano"
@@ -4698,11 +5095,13 @@
     "Chané"
   ],
   "cak": [
-    "喀克其奎語"
+    "喀克其奎語",
+    "喀克其奎语"
   ],
   "cal": [
     "加羅林語",
-    "Carolinian"
+    "Carolinian",
+    "加罗林语"
   ],
   "cam": [
     "Cemuhî"
@@ -4717,7 +5116,8 @@
     "Chipaya"
   ],
   "caq": [
-    "卡爾尼科巴語"
+    "卡爾尼科巴語",
+    "卡尔尼科巴语"
   ],
   "car": [
     "加勒比語",
@@ -4730,7 +5130,8 @@
     "Kali'na",
     "Kalinya",
     "Maraworno",
-    "Marworno"
+    "Marworno",
+    "加勒比语"
   ],
   "cas": [
     "Tsimané",
@@ -4741,39 +5142,48 @@
     "原始阿布哈茲-阿巴扎語",
     "Proto-Abkhaz-Abaza",
     "Proto-Abazgi",
-    "Proto-Abkhaz-Tapanta"
+    "Proto-Abkhaz-Tapanta",
+    "原始阿布哈兹-阿巴扎语"
   ],
   "cau-ava-pro": [
-    "原始阿瓦爾-安迪語"
+    "原始阿瓦爾-安迪語",
+    "原始阿瓦尔-安迪语"
   ],
   "cau-cir-pro": [
     "原始切爾克斯語",
     "Proto-Circassian",
     "Proto-Adyghe-Kabardian",
-    "Proto-Adyghe-Circassian"
+    "Proto-Adyghe-Circassian",
+    "原始切尔克斯语"
   ],
   "cau-drg-pro": [
     "原始達爾金語",
     "Proto-Dargwa",
-    "Proto-Dargin"
+    "Proto-Dargin",
+    "原始达尔金语"
   ],
   "cau-lzg-pro": [
-    "原始列茲金語"
+    "原始列茲金語",
+    "原始列兹金语"
   ],
   "cau-nec-pro": [
-    "原始東北高加索語"
+    "原始東北高加索語",
+    "原始东北高加索语"
   ],
   "cau-nkh-pro": [
-    "原始納克語"
+    "原始納克語",
+    "原始纳克语"
   ],
   "cau-nwc-pro": [
-    "原始西北高加索語"
+    "原始西北高加索語",
+    "原始西北高加索语"
   ],
   "cau-tsz-pro": [
     "原始采茲語",
     "Proto-Tsezian",
     "Proto-Tsezic",
-    "Proto-Didoic"
+    "Proto-Didoic",
+    "原始采兹语"
   ],
   "cav": [
     "Cavineña"
@@ -4785,7 +5195,8 @@
     "Chiquitano"
   ],
   "cay": [
-    "卡尤加語"
+    "卡尤加語",
+    "卡尤加语"
   ],
   "caz": [
     "Canichana"
@@ -4827,7 +5238,8 @@
   ],
   "cba-pro": [
     "原始奇布查語",
-    "Proto-Chibchan"
+    "Proto-Chibchan",
+    "原始奇布查语"
   ],
   "cbb": [
     "Cabiyarí"
@@ -4854,7 +5266,8 @@
     "Chimila"
   ],
   "cbi": [
-    "查茨語"
+    "查茨語",
+    "查茨语"
   ],
   "cbj": [
     "Ede Cabe"
@@ -4862,14 +5275,16 @@
   "cbk": [
     "查瓦卡諾語",
     "Chavacano",
-    "Zamboanga Chavacano"
+    "Zamboanga Chavacano",
+    "查瓦卡诺语"
   ],
   "cbl": [
     "Bualkhaw Chin",
     "Bualkhaw"
   ],
   "cbn": [
-    "涅固爾語"
+    "涅固爾語",
+    "涅固尔语"
   ],
   "cbo": [
     "Izora"
@@ -4914,7 +5329,8 @@
   ],
   "ccc": [
     "查米庫羅語",
-    "Chamicuro"
+    "Chamicuro",
+    "查米库罗语"
   ],
   "ccd": [
     "Cafundó"
@@ -4928,7 +5344,8 @@
     "Nakanyare"
   ],
   "cch": [
-    "阿燦語"
+    "阿燦語",
+    "阿灿语"
   ],
   "ccj": [
     "Kasanga"
@@ -4938,29 +5355,35 @@
   ],
   "ccm": [
     "馬六甲克里奧爾馬來語",
-    "Malaccan Creole Malay"
+    "Malaccan Creole Malay",
+    "马六甲克里奥尔马来语"
   ],
   "ccn-pro": [
     "原始北高加索語",
-    "Proto-North Caucasian"
+    "Proto-North Caucasian",
+    "原始北高加索语"
   ],
   "cco": [
     "科馬爾特佩克-奇南特克語",
-    "Comaltepec Chinantec"
+    "Comaltepec Chinantec",
+    "科马尔特佩克-奇南特克语"
   ],
   "ccp": [
     "查克馬語",
-    "Chakma"
+    "Chakma",
+    "查克马语"
   ],
   "ccr": [
     "Cacaopera"
   ],
   "ccs-gzn-pro": [
-    "原始格魯吉亞-贊語"
+    "原始格魯吉亞-贊語",
+    "原始格鲁吉亚-赞语"
   ],
   "ccs-pro": [
     "原始南高加索語",
-    "Proto-Kartvelian"
+    "Proto-Kartvelian",
+    "原始南高加索语"
   ],
   "cda": [
     "Choni"
@@ -4969,14 +5392,16 @@
     "原始中乍得語",
     "Proto-Central Chadic",
     "Proto-Central-Chadic",
-    "Proto-Biu-Mandara"
+    "Proto-Biu-Mandara",
+    "原始中乍得语"
   ],
   "cdc-mas-pro": [
     "Proto-Masa"
   ],
   "cdc-pro": [
     "原始乍得語",
-    "Proto-Chadic"
+    "Proto-Chadic",
+    "原始乍得语"
   ],
   "cdd-pro": [
     "Proto-Caddoan"
@@ -4989,19 +5414,23 @@
   ],
   "cdh": [
     "昌貝阿里語",
-    "Chambeali"
+    "Chambeali",
+    "昌贝阿里语"
   ],
   "cdi": [
     "楚德里語",
-    "Chodri"
+    "Chodri",
+    "楚德里语"
   ],
   "cdj": [
     "楚拉希語",
-    "Churahi"
+    "Churahi",
+    "楚拉希语"
   ],
   "cdm": [
     "切彭語",
-    "Chepang"
+    "Chepang",
+    "切彭语"
   ],
   "cdn": [
     "Chaudangsi"
@@ -5009,7 +5438,8 @@
   "cdo": [
     "閩東語",
     "Min Dong",
-    "Min Dong Chinese"
+    "Min Dong Chinese",
+    "闽东语"
   ],
   "cdr": [
     "Cinda-Regi-Tiyal"
@@ -5017,17 +5447,21 @@
   "cds": [
     "乍得手語",
     "查德手語",
-    "Chadian Sign Language"
+    "Chadian Sign Language",
+    "乍得手语",
+    "查德手语"
   ],
   "cdy": [
     "茶洞語",
-    "Chadong"
+    "Chadong",
+    "茶洞语"
   ],
   "cdz": [
     "Koda"
   ],
   "ce": [
-    "車臣語"
+    "車臣語",
+    "车臣语"
   ],
   "cea": [
     "Lower Chehalis"
@@ -5035,24 +5469,29 @@
   "ceb": [
     "宿霧語",
     "Cebuano",
-    "宿務語"
+    "宿務語",
+    "宿雾语",
+    "宿务语"
   ],
   "ceg": [
     "Chamacoco"
   ],
   "cel-bry-pro": [
-    "原始布立吞語"
+    "原始布立吞語",
+    "原始布立吞语"
   ],
   "cel-gal": [
     "Gallaecian"
   ],
   "cel-gau": [
     "高盧語",
-    "Gaulish"
+    "Gaulish",
+    "高卢语"
   ],
   "cel-pro": [
     "原始凱爾特語",
-    "Proto-Celtic"
+    "Proto-Celtic",
+    "原始凯尔特语"
   ],
   "cen": [
     "Cen",
@@ -5082,24 +5521,29 @@
   ],
   "cgc": [
     "卡加揚語",
-    "Kagayanen"
+    "Kagayanen",
+    "卡加扬语"
   ],
   "cgg": [
-    "奇加語"
+    "奇加語",
+    "奇加语"
   ],
   "cgk": [
     "Chocangaca"
   ],
   "ch": [
-    "查莫羅語"
+    "查莫羅語",
+    "查莫罗语"
   ],
   "chb": [
     "奇布查語",
-    "Chibcha"
+    "Chibcha",
+    "奇布查语"
   ],
   "chc": [
     "卡托巴語",
-    "Catawba"
+    "Catawba",
+    "卡托巴语"
   ],
   "chd": [
     "高地瓦哈卡瓊塔爾語",
@@ -5110,15 +5554,18 @@
     "Tequistlatec",
     "Mountain Tequistlateco",
     "Highland Chontal",
-    "Mountain Chontal"
+    "Mountain Chontal",
+    "高地瓦哈卡琼塔尔语"
   ],
   "chf": [
     "塔巴斯科瓊塔爾語",
-    "Tabasco Chontal"
+    "Tabasco Chontal",
+    "塔巴斯科琼塔尔语"
   ],
   "chg": [
     "察合臺語",
-    "Chagatai"
+    "Chagatai",
+    "察合台语"
   ],
   "chh": [
     "Chinook"
@@ -5128,15 +5575,18 @@
   ],
   "chj": [
     "奧希特蘭奇南特克語",
-    "Ojitlán Chinantec"
+    "Ojitlán Chinantec",
+    "奥希特兰奇南特克语"
   ],
   "chk": [
     "楚克語",
-    "Chuukese"
+    "Chuukese",
+    "楚克语"
   ],
   "chl": [
     "卡維拉語",
-    "Cahuilla"
+    "Cahuilla",
+    "卡维拉语"
   ],
   "chm": [
     "草原馬里語",
@@ -5148,15 +5598,19 @@
     "Standard Mari",
     "Upo Mari",
     "Mari",
-    "Mari (Russia)"
+    "Mari (Russia)",
+    "草原马里语",
+    "东马里语"
   ],
   "chn": [
     "契努克語",
-    "Chinook Jargon"
+    "Chinook Jargon",
+    "契努克语"
   ],
   "cho": [
     "喬克托語",
-    "Choctaw"
+    "Choctaw",
+    "乔克托语"
   ],
   "chp": [
     "契帕瓦語",
@@ -5166,15 +5620,18 @@
     "Dëne",
     "Dene Suline",
     "Denesuline",
-    "Dene"
+    "Dene",
+    "契帕瓦语"
   ],
   "chq": [
     "基奧基特佩克奇南特克語",
-    "Quiotepec Chinantec"
+    "Quiotepec Chinantec",
+    "基奥基特佩克奇南特克语"
   ],
   "chr": [
     "切羅基語",
-    "Cherokee"
+    "Cherokee",
+    "切罗基语"
   ],
   "cht": [
     "Cholón"
@@ -5193,22 +5650,26 @@
   ],
   "chy": [
     "夏延語",
-    "Cheyenne"
+    "Cheyenne",
+    "夏延语"
   ],
   "chz": [
     "奧蘇馬辛奇南特克語",
-    "Ozumacín Chinantec"
+    "Ozumacín Chinantec",
+    "奥苏马辛奇南特克语"
   ],
   "cia": [
     "吉阿吉阿語",
-    "Cia-Cia"
+    "Cia-Cia",
+    "吉阿吉阿语"
   ],
   "cib": [
     "Ci Gbe"
   ],
   "cic": [
     "奇卡索語",
-    "Chickasaw"
+    "Chickasaw",
+    "奇卡索语"
   ],
   "cid": [
     "Chimariko"
@@ -5218,21 +5679,25 @@
   ],
   "cih": [
     "奇納里語",
-    "Chinali"
+    "Chinali",
+    "奇纳里语"
   ],
   "cik": [
     "奇特庫利金瑙里語",
-    "Chitkuli Kinnauri"
+    "Chitkuli Kinnauri",
+    "奇特库利金瑙里语"
   ],
   "cim": [
-    "辛布里語"
+    "辛布里語",
+    "辛布里语"
   ],
   "cin": [
     "Cinta Larga"
   ],
   "cip": [
     "恰帕內克語",
-    "Chiapanec"
+    "Chiapanec",
+    "恰帕内克语"
   ],
   "cir": [
     "Tiri",
@@ -5247,7 +5712,8 @@
   ],
   "cja": [
     "西占語",
-    "Western Cham"
+    "Western Cham",
+    "西占语"
   ],
   "cje": [
     "Chru"
@@ -5257,28 +5723,32 @@
   ],
   "cji": [
     "查馬拉爾語",
-    "Chamalal"
+    "Chamalal",
+    "查马拉尔语"
   ],
   "cjk": [
     "Chokwe"
   ],
   "cjm": [
     "東占語",
-    "Eastern Cham"
+    "Eastern Cham",
+    "东占语"
   ],
   "cjn": [
     "Chenapian"
   ],
   "cjo": [
     "帕胡納爾-阿舍寧卡語",
-    "Ashéninka Pajonal"
+    "Ashéninka Pajonal",
+    "帕胡纳尔-阿舍宁卡语"
   ],
   "cjp": [
     "Cabécar"
   ],
   "cjs": [
     "紹爾語",
-    "Shor"
+    "Shor",
+    "绍尔语"
   ],
   "cjv": [
     "Chuave"
@@ -5291,12 +5761,14 @@
     "Jinese",
     "Shanxinese",
     "Jin Chinese",
-    "Jinyu Chinese"
+    "Jinyu Chinese",
+    "晋语"
   ],
   "ckb": [
     "中庫爾德語",
     "Central Kurdish",
-    "Sorani"
+    "Sorani",
+    "中库尔德语"
   ],
   "ckh": [
     "Chak"
@@ -5320,14 +5792,17 @@
     "Tayo"
   ],
   "ckt": [
-    "楚科奇語"
+    "楚科奇語",
+    "楚科奇语"
   ],
   "cku": [
     "科阿薩提語",
-    "Koasati"
+    "Koasati",
+    "科阿萨提语"
   ],
   "ckv": [
-    "噶瑪蘭語"
+    "噶瑪蘭語",
+    "噶玛兰语"
   ],
   "ckx": [
     "Caka"
@@ -5350,11 +5825,13 @@
   ],
   "cld": [
     "迦勒底新亞拉姆語",
-    "Chaldean Neo-Aramaic"
+    "Chaldean Neo-Aramaic",
+    "迦勒底新亚拉姆语"
   ],
   "cle": [
     "萊勞奇南特克語",
-    "Lealao Chinantec"
+    "Lealao Chinantec",
+    "莱劳奇南特克语"
   ],
   "clh": [
     "Chilisso"
@@ -5375,7 +5852,8 @@
   ],
   "clm": [
     "克拉勒姆語",
-    "Klallam"
+    "Klallam",
+    "克拉勒姆语"
   ],
   "clo": [
     "低地瓦哈卡瓊塔爾語",
@@ -5385,7 +5863,8 @@
     "Chontal",
     "Huamelultec",
     "Huamelula Chontal",
-    "Coastal Chontal"
+    "Coastal Chontal",
+    "低地瓦哈卡琼塔尔语"
   ],
   "clt": [
     "Lautu Chin"
@@ -5400,25 +5879,29 @@
     "Chulym-Turkic",
     "Küerik",
     "Chulym Tatar",
-    "Melets Tatar"
+    "Melets Tatar",
+    "楚利姆语"
   ],
   "cly": [
     "東部高地查蒂諾語",
-    "Eastern Highland Chatino"
+    "Eastern Highland Chatino",
+    "东部高地查蒂诺语"
   ],
   "cma": [
     "Maa"
   ],
   "cmc-pro": [
     "原始占語",
-    "Proto-Chamic"
+    "Proto-Chamic",
+    "原始占语"
   ],
   "cme": [
     "Cerma"
   ],
   "cmg": [
     "古典蒙古語",
-    "Classical Mongolian"
+    "Classical Mongolian",
+    "古典蒙古语"
   ],
   "cmi": [
     "Emberá-Chamí"
@@ -5442,10 +5925,16 @@
     "Huayu",
     "Guanhua",
     "Beifanghua",
-    "Standard Chinese"
+    "Standard Chinese",
+    "官话",
+    "普通话",
+    "北方话",
+    "国语",
+    "华话"
   ],
   "cmo": [
-    "中墨儂語"
+    "中墨儂語",
+    "中墨侬语"
   ],
   "cmr": [
     "Mro Chin",
@@ -5454,7 +5943,8 @@
     "Mro-Khimi"
   ],
   "cms": [
-    "梅薩比語"
+    "梅薩比語",
+    "梅萨比语"
   ],
   "cmt": [
     "Camtho"
@@ -5470,7 +5960,8 @@
   ],
   "cng": [
     "北羌語",
-    "Northern Qiang"
+    "Northern Qiang",
+    "北羌语"
   ],
   "cnh": [
     "Lai",
@@ -5488,26 +5979,31 @@
     "Nisay",
     "Nise",
     "Eastern Khumi",
-    "Eastern Khumi Chin"
+    "Eastern Khumi Chin",
+    "库米钦语"
   ],
   "cnl": [
     "拉拉納奇南特克語",
-    "Lalana Chinantec"
+    "Lalana Chinantec",
+    "拉拉纳奇南特克语"
   ],
   "cno": [
     "Con"
   ],
   "cnp": [
     "桂北平話",
-    "Northern Pinghua"
+    "Northern Pinghua",
+    "桂北平话"
   ],
   "cns": [
     "中阿斯馬特語",
-    "Central Asmat"
+    "Central Asmat",
+    "中阿斯马特语"
   ],
   "cnt": [
     "特佩托圖特拉奇南特克語",
-    "Tepetotutla Chinantec"
+    "Tepetotutla Chinantec",
+    "特佩托图特拉奇南特克语"
   ],
   "cnu": [
     "Chenoua"
@@ -5516,16 +6012,20 @@
     "Ngawn Chin"
   ],
   "cnx": [
-    "中古康沃爾語"
+    "中古康沃爾語",
+    "中古康沃尔语"
   ],
   "co": [
-    "科西嘉語"
+    "科西嘉語",
+    "科西嘉语"
   ],
   "coa": [
-    "科科斯馬來語"
+    "科科斯馬來語",
+    "科科斯马来语"
   ],
   "cob": [
-    "奇科穆塞爾特克語"
+    "奇科穆塞爾特克語",
+    "奇科穆塞尔特克语"
   ],
   "coc": [
     "Cocopa"
@@ -5550,11 +6050,13 @@
   ],
   "cog": [
     "仲語",
-    "Chong"
+    "Chong",
+    "仲语"
   ],
   "coh": [
     "齊瓊依-齊基哈納-奇考瑪語",
-    "Chichonyi-Chidzihana-Chikauma"
+    "Chichonyi-Chidzihana-Chikauma",
+    "齐琼依-齐基哈纳-奇考玛语"
   ],
   "coj": [
     "Cochimi"
@@ -5573,7 +6075,9 @@
   "com": [
     "科曼奇語",
     "Comanche",
-    "科曼切語"
+    "科曼切語",
+    "科曼奇语",
+    "科曼切语"
   ],
   "con": [
     "科梵語",
@@ -5583,11 +6087,13 @@
     "Kofane",
     "A'ingae",
     "Maku",
-    "Macu"
+    "Macu",
+    "科梵语"
   ],
   "coo": [
     "科莫克斯語",
-    "Comox"
+    "Comox",
+    "科莫克斯语"
   ],
   "cop": [
     "科普特語",
@@ -5604,7 +6110,8 @@
     "Oxyrhynchite",
     "Sahidic",
     "Subakhmimic",
-    "Thebaic"
+    "Thebaic",
+    "科普特语"
   ],
   "coq": [
     "Coquille"
@@ -5617,7 +6124,8 @@
   ],
   "cov": [
     "草苗語",
-    "Cao Miao"
+    "Cao Miao",
+    "草苗语"
   ],
   "cow": [
     "Cowlitz"
@@ -5632,11 +6140,13 @@
     "喬喬特克語",
     "Chochotec",
     "Chocho",
-    "Chocholtec"
+    "Chocholtec",
+    "乔乔特克语"
   ],
   "cpa": [
     "帕蘭特拉奇南特克語",
-    "Palantla Chinantec"
+    "Palantla Chinantec",
+    "帕兰特拉奇南特克语"
   ],
   "cpb": [
     "Ucayali-Yurúa Ashéninka"
@@ -5649,16 +6159,19 @@
     "Jamaican Maroon Spirit Possession Language"
   ],
   "cpe-spp": [
-    "薩摩亞種植園皮欽語"
+    "薩摩亞種植園皮欽語",
+    "萨摩亚种植园皮钦语"
   ],
   "cpg": [
     "卡帕多細亞希臘語",
     "Cappadocian Greek",
-    "Cappadocian"
+    "Cappadocian",
+    "卡帕多细亚希腊语"
   ],
   "cpi": [
     "洋涇浜英語",
-    "Chinese Pidgin English"
+    "Chinese Pidgin English",
+    "洋泾浜英语"
   ],
   "cpn": [
     "Cherepon",
@@ -5675,7 +6188,8 @@
   ],
   "cps": [
     "卡皮塞尼奧語",
-    "Capiznon"
+    "Capiznon",
+    "卡皮塞尼奥语"
   ],
   "cpu": [
     "Pichis Ashéninka"
@@ -5693,17 +6207,23 @@
     "Pu Xian Chinese",
     "Putian",
     "Xinghua",
-    "Hinghwa"
+    "Hinghwa",
+    "莆仙语",
+    "莆仙闽语",
+    "莆田话",
+    "兴化话"
   ],
   "cpy": [
     "South Ucayali Ashéninka"
   ],
   "cqd": [
     "川黔滇苗語",
-    "Chuanqiandian Cluster Miao"
+    "Chuanqiandian Cluster Miao",
+    "川黔滇苗语"
   ],
   "cr": [
-    "克里語"
+    "克里語",
+    "克里语"
   ],
   "cra": [
     "Chara"
@@ -5725,25 +6245,30 @@
   ],
   "crh": [
     "克里米亞韃靼語",
-    "Crimean Tatar"
+    "Crimean Tatar",
+    "克里米亚鞑靼语"
   ],
   "cri": [
     "聖多美語",
     "Sãotomense",
     "Forro",
-    "São Tomense"
+    "São Tomense",
+    "圣多美语"
   ],
   "crj": [
     "南部東克里語",
-    "Southern East Cree"
+    "Southern East Cree",
+    "南部东克里语"
   ],
   "crk": [
     "平原克里語",
-    "Plains Cree"
+    "Plains Cree",
+    "平原克里语"
   ],
   "crl": [
     "北部東克里語",
-    "Northern East Cree"
+    "Northern East Cree",
+    "北部东克里语"
   ],
   "crm": [
     "Moose Cree"
@@ -5756,19 +6281,23 @@
     "Apsalooke"
   ],
   "crp-gep": [
-    "西格陵蘭皮欽語"
+    "西格陵蘭皮欽語",
+    "西格陵兰皮钦语"
   ],
   "crp-mpp": [
     "澳門皮欽葡萄牙語",
-    "Macau Pidgin Portuguese"
+    "Macau Pidgin Portuguese",
+    "澳门皮钦葡萄牙语"
   ],
   "crp-rsn": [
     "挪威俄語",
-    "Russenorsk"
+    "Russenorsk",
+    "挪威俄语"
   ],
   "crp-tpr": [
     "泰梅爾皮欽俄語",
-    "Taimyr Pidgin Russian"
+    "Taimyr Pidgin Russian",
+    "泰梅尔皮钦俄语"
   ],
   "crp-ykx": [
     "寒溪語",
@@ -5776,7 +6305,10 @@
     "宜蘭克里奧語",
     "Yilan Creole Japanese",
     "Kankei language",
-    "Yilan Creole"
+    "Yilan Creole",
+    "寒溪语",
+    "宜兰克里奥尔语",
+    "宜兰克里奥语"
   ],
   "crq": [
     "Iyo'wujwa Chorote"
@@ -5787,7 +6319,9 @@
   "crs": [
     "塞舌爾克里奧爾語",
     "賽席爾克里奧爾語",
-    "Seychellois Creole"
+    "Seychellois Creole",
+    "塞舌尔克里奥尔语",
+    "赛席尔克里奥尔语"
   ],
   "crt": [
     "Iyojwa'ja Chorote"
@@ -5801,7 +6335,8 @@
   ],
   "crx": [
     "卡列爾語",
-    "Carrier"
+    "Carrier",
+    "卡列尔语"
   ],
   "cry": [
     "Cori"
@@ -5810,35 +6345,43 @@
     "Cruzeño"
   ],
   "cs": [
-    "捷克語"
+    "捷克語",
+    "捷克语"
   ],
   "csa": [
     "奇爾特佩克奇南特克語",
-    "Chiltepec Chinantec"
+    "Chiltepec Chinantec",
+    "奇尔特佩克奇南特克语"
   ],
   "csb": [
     "卡舒比語",
-    "Kashubian"
+    "Kashubian",
+    "卡舒比语"
   ],
   "csc": [
     "加泰羅尼亞手語",
-    "Catalan Sign Language"
+    "Catalan Sign Language",
+    "加泰罗尼亚手语"
   ],
   "csd": [
     "清邁手語",
-    "Chiangmai Sign Language"
+    "Chiangmai Sign Language",
+    "清迈手语"
   ],
   "cse": [
     "捷克手語",
-    "Czech Sign Language"
+    "Czech Sign Language",
+    "捷克手语"
   ],
   "csf": [
     "古巴手語",
-    "Cuban Sign Language"
+    "Cuban Sign Language",
+    "古巴手语"
   ],
   "csg": [
     "智利手語",
-    "Chilean Sign Language"
+    "Chilean Sign Language",
+    "智利手语"
   ],
   "csh": [
     "Asho Chin"
@@ -5854,32 +6397,40 @@
   ],
   "csl": [
     "中國手語",
-    "Chinese Sign Language"
+    "Chinese Sign Language",
+    "中国手语"
   ],
   "csm": [
     "中部山地米沃克語",
-    "Central Sierra Miwok"
+    "Central Sierra Miwok",
+    "中部山地米沃克语"
   ],
   "csn": [
     "哥倫比亞手語",
-    "Colombian Sign Language"
+    "Colombian Sign Language",
+    "哥伦比亚手语"
   ],
   "cso": [
     "索奇亞帕姆奇南特克語",
-    "Sochiapam Chinantec"
+    "Sochiapam Chinantec",
+    "索奇亚帕姆奇南特克语"
   ],
   "csp": [
     "桂南平話",
-    "Southern Pinghua"
+    "Southern Pinghua",
+    "桂南平话"
   ],
   "csq": [
     "克羅地亞手語",
-    "Croatian Sign Language"
+    "Croatian Sign Language",
+    "克罗地亚手语"
   ],
   "csr": [
     "哥斯達黎加手語",
     "哥斯大黎加手語",
-    "Costa Rican Sign Language"
+    "Costa Rican Sign Language",
+    "哥斯达黎加手语",
+    "哥斯大黎加手语"
   ],
   "css": [
     "南奧龍尼語",
@@ -5888,11 +6439,13 @@
     "San Juan Bautista Costanoan",
     "Rumsien",
     "San Carlos Costanoan",
-    "Carmeleno"
+    "Carmeleno",
+    "南奥龙尼语"
   ],
   "cst": [
     "北奧龍尼語",
-    "Northern Ohlone"
+    "Northern Ohlone",
+    "北奥龙尼语"
   ],
   "csu-bba-pro": [
     "Proto-Bongo-Bagirmi"
@@ -5902,7 +6455,8 @@
   ],
   "csu-pro": [
     "原始中蘇丹語",
-    "Proto-Central Sudanic"
+    "Proto-Central Sudanic",
+    "原始中苏丹语"
   ],
   "csu-sar-pro": [
     "Proto-Sara"
@@ -5923,7 +6477,8 @@
   ],
   "cta": [
     "塔塔爾特佩克查蒂諾語",
-    "Tataltepec Chatino"
+    "Tataltepec Chatino",
+    "塔塔尔特佩克查蒂诺语"
   ],
   "ctc": [
     "Chetco-Tolowa",
@@ -5938,26 +6493,31 @@
     "Tedim Chin",
     "Tedim",
     "Tiddim",
-    "Sukte"
+    "Sukte",
+    "梯顶语"
   ],
   "cte": [
     "特皮納帕奇南特克語",
-    "Tepinapa Chinantec"
+    "Tepinapa Chinantec",
+    "特皮纳帕奇南特克语"
   ],
   "ctg": [
     "吉大港語",
-    "Chittagonian"
+    "Chittagonian",
+    "吉大港语"
   ],
   "cth": [
     "Thaiphum Chin"
   ],
   "ctl": [
     "特拉科亞津特佩克奇南特克語",
-    "Tlacoatzintepec Chinantec"
+    "Tlacoatzintepec Chinantec",
+    "特拉科亚津特佩克奇南特克语"
   ],
   "ctm": [
     "奇蒂馬查語",
-    "Chitimacha"
+    "Chitimacha",
+    "奇蒂马查语"
   ],
   "ctn": [
     "Chhintange"
@@ -5967,15 +6527,18 @@
   ],
   "ctp": [
     "西部高地查蒂諾語",
-    "Western Highland Chatino"
+    "Western Highland Chatino",
+    "西部高地查蒂诺语"
   ],
   "ctp-san": [
     "聖胡安基阿伊赫查蒂諾語",
-    "San Juan Quiahije Chatino"
+    "San Juan Quiahije Chatino",
+    "圣胡安基阿伊赫查蒂诺语"
   ],
   "cts": [
     "北卡坦端內斯比科拉諾語",
-    "Northern Catanduanes Bicolano"
+    "Northern Catanduanes Bicolano",
+    "北卡坦端内斯比科拉诺语"
   ],
   "ctt": [
     "Wayanad Chetti"
@@ -5985,10 +6548,12 @@
   ],
   "ctz": [
     "薩卡特佩克查蒂諾語",
-    "Zacatepec Chatino"
+    "Zacatepec Chatino",
+    "萨卡特佩克查蒂诺语"
   ],
   "cu": [
-    "教會斯拉夫語"
+    "教會斯拉夫語",
+    "教会斯拉夫语"
   ],
   "cua": [
     "Cua"
@@ -5998,7 +6563,8 @@
   ],
   "cuc": [
     "尤斯拉奇南特克語",
-    "Usila Chinantec"
+    "Usila Chinantec",
+    "尤斯拉奇南特克语"
   ],
   "cug": [
     "Cung",
@@ -6043,7 +6609,8 @@
   ],
   "cup": [
     "庫佩諾語",
-    "Cupeño"
+    "Cupeño",
+    "库佩诺语"
   ],
   "cuq": [
     "仡隆語",
@@ -6051,7 +6618,11 @@
     "Gelong",
     "村語",
     "村話",
-    "哥隆語"
+    "哥隆語",
+    "仡隆语",
+    "村语",
+    "村话",
+    "哥隆语"
   ],
   "cur": [
     "Chhulung"
@@ -6063,14 +6634,17 @@
   ],
   "cus-pro": [
     "原始庫希特語",
-    "Proto-Cushitic"
+    "Proto-Cushitic",
+    "原始库希特语"
   ],
   "cut": [
-    "特烏蒂拉奎卡特克語"
+    "特烏蒂拉奎卡特克語",
+    "特乌蒂拉奎卡特克语"
   ],
   "cuu": [
     "傣雅語",
-    "Tai Ya"
+    "Tai Ya",
+    "傣雅语"
   ],
   "cuv": [
     "Cuvok"
@@ -6079,20 +6653,23 @@
     "Chukwa"
   ],
   "cux": [
-    "特佩烏希拉奎卡特克語"
+    "特佩烏希拉奎卡特克語",
+    "特佩乌希拉奎卡特克语"
   ],
   "cuy": [
     "Cuitlatec"
   ],
   "cv": [
-    "楚瓦什語"
+    "楚瓦什語",
+    "楚瓦什语"
   ],
   "cvg": [
     "Chug"
   ],
   "cvn": [
     "國家山谷奇南特克語",
-    "Valle Nacional Chinantec"
+    "Valle Nacional Chinantec",
+    "国家山谷奇南特克语"
   ],
   "cwa": [
     "Kabwa"
@@ -6102,7 +6679,8 @@
   ],
   "cwd": [
     "森林克里語",
-    "Woods Cree"
+    "Woods Cree",
+    "森林克里语"
   ],
   "cwe": [
     "Kwere"
@@ -6114,40 +6692,49 @@
     "Kuwaataay"
   ],
   "cy": [
-    "威爾士語"
+    "威爾士語",
+    "威尔士语"
   ],
   "cya": [
-    "諾帕拉查蒂諾語"
+    "諾帕拉查蒂諾語",
+    "诺帕拉查蒂诺语"
   ],
   "cyb": [
     "Cayubaba"
   ],
   "cyo": [
-    "庫約農語"
+    "庫約農語",
+    "库约农语"
   ],
   "czh": [
     "徽語",
     "徽州話",
     "Huizhou",
-    "Huizhou Chinese"
+    "Huizhou Chinese",
+    "徽语",
+    "徽州话"
   ],
   "czk": [
     "Knaanic"
   ],
   "czn": [
     "森松特佩克查蒂諾語",
-    "Zenzontepec Chatino"
+    "Zenzontepec Chatino",
+    "森松特佩克查蒂诺语"
   ],
   "czo": [
     "閩中語",
     "Min Zhong",
-    "Min Zhong Chinese"
+    "Min Zhong Chinese",
+    "闽中语"
   ],
   "czt": [
-    "佐通語"
+    "佐通語",
+    "佐通语"
   ],
   "da": [
-    "丹麥語"
+    "丹麥語",
+    "丹麦语"
   ],
   "daa": [
     "Dangaléat"
@@ -6163,7 +6750,8 @@
   ],
   "dag": [
     "達加巴尼語",
-    "Dagbani"
+    "Dagbani",
+    "达加巴尼语"
   ],
   "dah": [
     "Gwahatike"
@@ -6176,7 +6764,8 @@
   ],
   "dak": [
     "達科他語",
-    "Dakota"
+    "Dakota",
+    "达科他语"
   ],
   "dal": [
     "Dahalo"
@@ -6198,7 +6787,8 @@
   "dar": [
     "達爾金語",
     "Dargwa",
-    "Dargin"
+    "Dargin",
+    "达尔金语"
   ],
   "das": [
     "Daho-Doo"
@@ -6207,7 +6797,8 @@
     "Dar Sila Daju"
   ],
   "dav": [
-    "台塔語"
+    "台塔語",
+    "台塔语"
   ],
   "daw": [
     "Davawenyo"
@@ -6231,7 +6822,8 @@
     "Dabe"
   ],
   "dbf": [
-    "埃多皮語"
+    "埃多皮語",
+    "埃多皮语"
   ],
   "dbg": [
     "Dogul Dom"
@@ -6244,7 +6836,8 @@
   ],
   "dbl": [
     "迪爾巴爾語",
-    "Dyirbal"
+    "Dyirbal",
+    "迪尔巴尔语"
   ],
   "dbm": [
     "Duguri"
@@ -6280,13 +6873,15 @@
     "Dibiyaso"
   ],
   "dcc": [
-    "達金語"
+    "達金語",
+    "达金语"
   ],
   "dcr": [
     "Negerhollands"
   ],
   "dda": [
-    "達迪-達迪語"
+    "達迪-達迪語",
+    "达迪-达迪语"
   ],
   "ddd": [
     "Dongotono"
@@ -6296,25 +6891,30 @@
   ],
   "ddg": [
     "法塔魯庫語",
-    "Fataluku"
+    "Fataluku",
+    "法塔鲁库语"
   ],
   "ddi": [
     "迪奧迪奧語",
-    "Diodio"
+    "Diodio",
+    "迪奥迪奥语"
   ],
   "ddj": [
     "賈魯語",
-    "Jaru"
+    "Jaru",
+    "贾鲁语"
   ],
   "ddn": [
     "登迪語",
     "Dendi",
     "Dandawa",
     "Dendi (West Africa)",
-    "Dendi (Benin)"
+    "Dendi (Benin)",
+    "登迪语"
   ],
   "ddo": [
-    "采茲語"
+    "采茲語",
+    "采兹语"
   ],
   "ddr": [
     "Dhudhuroa",
@@ -6327,7 +6927,8 @@
     "Dawera-Daweloor"
   ],
   "de": [
-    "德語"
+    "德語",
+    "德语"
   ],
   "dec": [
     "Dagik"
@@ -6346,7 +6947,8 @@
   ],
   "deh": [
     "德赫瓦里語",
-    "Dehwari"
+    "Dehwari",
+    "德赫瓦里语"
   ],
   "dei": [
     "Demisa"
@@ -6361,11 +6963,13 @@
     "斯拉維語",
     "Slavey",
     "Slave",
-    "Slavé"
+    "Slavé",
+    "斯拉维语"
   ],
   "dep": [
     "德拉瓦皮欽語",
-    "Pidgin Delaware"
+    "Pidgin Delaware",
+    "德拉瓦皮钦语"
   ],
   "der": [
     "Deori"
@@ -6387,7 +6991,8 @@
   ],
   "dgc": [
     "卡西古蘭杜馬加特阿埃塔語",
-    "Casiguran Dumagat Agta"
+    "Casiguran Dumagat Agta",
+    "卡西古兰杜马加特阿埃塔语"
   ],
   "dgd": [
     "Dagaari Dioula"
@@ -6409,17 +7014,20 @@
   ],
   "dgn": [
     "達格曼語",
-    "Dagoman"
+    "Dagoman",
+    "达格曼语"
   ],
   "dgo": [
     "印地多格拉語",
-    "Hindi Dogri"
+    "Hindi Dogri",
+    "印地多格拉语"
   ],
   "dgr": [
     "多格里布語",
     "Dogrib",
     "Tłicho",
-    "Tlinchon"
+    "Tlinchon",
+    "多格里布语"
   ],
   "dgs": [
     "Dogoso"
@@ -6427,10 +7035,12 @@
   "dgt": [
     "恩德拉恩吉特語",
     "Ntra'ngith",
-    "Ndra'ngith"
+    "Ndra'ngith",
+    "恩德拉恩吉特语"
   ],
   "dgw": [
-    "道恩烏隆語"
+    "道恩烏隆語",
+    "道恩乌隆语"
   ],
   "dgx": [
     "Doghoro"
@@ -6446,7 +7056,8 @@
   ],
   "dhl": [
     "達蘭吉語",
-    "Dhalandji"
+    "Dhalandji",
+    "达兰吉语"
   ],
   "dhm": [
     "Zemba",
@@ -6460,14 +7071,17 @@
   ],
   "dhn": [
     "丹基語",
-    "Dhanki"
+    "Dhanki",
+    "丹基语"
   ],
   "dho": [
     "多迪亞語",
-    "Dhodia"
+    "Dhodia",
+    "多迪亚语"
   ],
   "dhr": [
-    "達爾加里語"
+    "達爾加里語",
+    "达尔加里语"
   ],
   "dhs": [
     "Dhaiso"
@@ -6477,18 +7091,21 @@
   ],
   "dhv": [
     "利富語",
-    "Drehu"
+    "Drehu",
+    "利富语"
   ],
   "dhw": [
     "達努瓦里語",
     "Danuwar",
     "Danwar",
     "Dhanwar",
-    "Rai"
+    "Rai",
+    "达努瓦里语"
   ],
   "dhx": [
     "敦加羅語",
-    "Dhungaloo"
+    "Dhungaloo",
+    "敦加罗语"
   ],
   "dia": [
     "Dia"
@@ -6506,7 +7123,8 @@
     "迪埃里語",
     "Dieri",
     "Diyari",
-    "Dirari"
+    "Dirari",
+    "迪埃里语"
   ],
   "dig": [
     "Digo",
@@ -6529,7 +7147,8 @@
   ],
   "din": [
     "丁卡語",
-    "Dinka"
+    "Dinka",
+    "丁卡语"
   ],
   "dio": [
     "Dibo"
@@ -6565,7 +7184,8 @@
     "Ding"
   ],
   "dja": [
-    "賈賈伍龍語"
+    "賈賈伍龍語",
+    "贾贾伍龙语"
   ],
   "djb": [
     "Djinba"
@@ -6574,13 +7194,16 @@
     "Dar Daju Daju"
   ],
   "djd": [
-    "賈明瓊語"
+    "賈明瓊語",
+    "贾明琼语"
   ],
   "dje": [
-    "扎爾馬語"
+    "扎爾馬語",
+    "扎尔马语"
   ],
   "djf": [
-    "詹貢語"
+    "詹貢語",
+    "詹贡语"
   ],
   "dji": [
     "Djinang"
@@ -6588,7 +7211,8 @@
   "djj": [
     "恩傑巴納語",
     "Ndjébbana",
-    "Djeebbana"
+    "Djeebbana",
+    "恩杰巴纳语"
   ],
   "djk": [
     "Aukan",
@@ -6596,7 +7220,8 @@
   ],
   "djl": [
     "吉瓦利語",
-    "Djiwarli"
+    "Djiwarli",
+    "吉瓦利语"
   ],
   "djm": [
     "Jamsay",
@@ -6604,7 +7229,8 @@
     "Jamsai"
   ],
   "djn": [
-    "賈萬語"
+    "賈萬語",
+    "贾万语"
   ],
   "djo": [
     "Jangkang"
@@ -6617,7 +7243,8 @@
   ],
   "djw": [
     "賈維語",
-    "Djawi"
+    "Djawi",
+    "贾维语"
   ],
   "dka": [
     "Dakpa",
@@ -6633,14 +7260,16 @@
   ],
   "dks": [
     "東南丁卡語",
-    "Southeastern Dinka"
+    "Southeastern Dinka",
+    "东南丁卡语"
   ],
   "dkx": [
     "Mazagway"
   ],
   "dlg": [
     "多爾干語",
-    "Dolgan"
+    "Dolgan",
+    "多尔干语"
   ],
   "dlk": [
     "Dahalik"
@@ -6648,7 +7277,8 @@
   "dlm": [
     "達爾馬提亞語",
     "Dalmatian",
-    "Dalmatic"
+    "Dalmatic",
+    "达尔马提亚语"
   ],
   "dln": [
     "Darlong"
@@ -6667,7 +7297,8 @@
     "Dimer"
   ],
   "dmd": [
-    "馬蒂馬蒂語"
+    "馬蒂馬蒂語",
+    "马蒂马蒂语"
   ],
   "dme": [
     "Dugwor"
@@ -6677,15 +7308,18 @@
   ],
   "dmg": [
     "上京那巴當岸語",
-    "Upper Kinabatangan"
+    "Upper Kinabatangan",
+    "上京那巴当岸语"
   ],
   "dmk": [
     "多馬基語",
-    "Domaaki"
+    "Domaaki",
+    "多马基语"
   ],
   "dml": [
     "達梅里語",
-    "Dameli"
+    "Dameli",
+    "达梅里语"
   ],
   "dmm": [
     "Dama (Nigeria)"
@@ -6715,7 +7349,8 @@
     "Dumpas"
   ],
   "dmw": [
-    "穆德布拉語"
+    "穆德布拉語",
+    "穆德布拉语"
   ],
   "dmx": [
     "Dema"
@@ -6734,7 +7369,8 @@
   ],
   "dng": [
     "東干語",
-    "Dungan"
+    "Dungan",
+    "东干语"
   ],
   "dni": [
     "Lower Grand Valley Dani"
@@ -6771,7 +7407,8 @@
   ],
   "dny": [
     "丹尼語",
-    "Dení"
+    "Dení",
+    "丹尼语"
   ],
   "doa": [
     "Dom"
@@ -6783,7 +7420,8 @@
     "北侗語",
     "Northern Kam",
     "Northern Gam",
-    "Northern Dong"
+    "Northern Dong",
+    "北侗语"
   ],
   "doe": [
     "Doe"
@@ -6796,7 +7434,8 @@
   ],
   "doi": [
     "多格拉語",
-    "Dogri"
+    "Dogri",
+    "多格拉语"
   ],
   "dok": [
     "Dondo"
@@ -6843,27 +7482,32 @@
   ],
   "doz": [
     "多爾澤語",
-    "Dorze"
+    "Dorze",
+    "多尔泽语"
   ],
   "dpp": [
     "Papar"
   ],
   "dra-mkn": [
-    "中古卡納達語"
+    "中古卡納達語",
+    "中古卡纳达语"
   ],
   "dra-okn": [
-    "古卡納達語"
+    "古卡納達語",
+    "古卡纳达语"
   ],
   "dra-pro": [
     "原始達羅毗荼語",
-    "Proto-Dravidian"
+    "Proto-Dravidian",
+    "原始达罗毗荼语"
   ],
   "drb": [
     "Dair"
   ],
   "drc": [
     "明德里科語",
-    "Minderico"
+    "Minderico",
+    "明德里科语"
   ],
   "drd": [
     "Darmiya"
@@ -6881,7 +7525,8 @@
     "巴阿甘吉語",
     "Baagandji",
     "Darling",
-    "Bandjigali"
+    "Bandjigali",
+    "巴阿甘吉语"
   ],
   "drn": [
     "West Damar"
@@ -6898,17 +7543,21 @@
   "dru": [
     "魯凱語",
     "Rukai",
-    "Drekay"
+    "Drekay",
+    "鲁凯语"
   ],
   "dru-pro": [
-    "原始魯凱語"
+    "原始魯凱語",
+    "原始鲁凯语"
   ],
   "dry": [
     "達萊語",
-    "Darai"
+    "Darai",
+    "达莱语"
   ],
   "dsb": [
-    "下索布語"
+    "下索布語",
+    "下索布语"
   ],
   "dse": [
     "Dutch Sign Language"
@@ -6921,21 +7570,24 @@
   ],
   "dsl": [
     "丹麥手語",
-    "Danish Sign Language"
+    "Danish Sign Language",
+    "丹麦手语"
   ],
   "dsn": [
     "Dusner"
   ],
   "dso": [
     "德西雅語",
-    "Desiya"
+    "Desiya",
+    "德西雅语"
   ],
   "dsq": [
     "Tadaksahak"
   ],
   "dta": [
     "達斡爾語",
-    "Daur"
+    "Daur",
+    "达斡尔语"
   ],
   "dtb": [
     "Labuk-Kinabatangan Kadazan"
@@ -6944,7 +7596,8 @@
     "Ditidaht"
   ],
   "dth": [
-    "阿迪廷吉蒂格語"
+    "阿迪廷吉蒂格語",
+    "阿迪廷吉蒂格语"
   ],
   "dti": [
     "Ana Tinga Dogon"
@@ -6965,7 +7618,8 @@
     "Kadazan Dusun",
     "Kadazan",
     "Bunduliwan",
-    "Boros Dusun"
+    "Boros Dusun",
+    "中部杜顺语"
   ],
   "dtr": [
     "Lotud"
@@ -6982,20 +7636,24 @@
   "dty": [
     "都特利語",
     "Doteli",
-    "Dotyali"
+    "Dotyali",
+    "都特利语"
   ],
   "dua": [
-    "杜亞拉語"
+    "杜亞拉語",
+    "杜亚拉语"
   ],
   "dub": [
     "杜布里語",
-    "Dubli"
+    "Dubli",
+    "杜布里语"
   ],
   "duc": [
     "Duna"
   ],
   "due": [
-    "烏米萊杜馬加特阿埃塔語"
+    "烏米萊杜馬加特阿埃塔語",
+    "乌米莱杜马加特阿埃塔语"
   ],
   "duf": [
     "Dumbea"
@@ -7005,7 +7663,8 @@
   ],
   "duh": [
     "敦格拉比爾語",
-    "Dungra Bhil"
+    "Dungra Bhil",
+    "敦格拉比尔语"
   ],
   "dui": [
     "Dumun"
@@ -7014,17 +7673,20 @@
     "Uyajitaya"
   ],
   "dul": [
-    "阿拉伯島阿埃塔語"
+    "阿拉伯島阿埃塔語",
+    "阿拉伯岛阿埃塔语"
   ],
   "dum": [
     "中古荷蘭語",
-    "Middle Dutch"
+    "Middle Dutch",
+    "中古荷兰语"
   ],
   "dun": [
     "Dusun Deyah"
   ],
   "duo": [
-    "杜巴尼南阿埃塔語"
+    "杜巴尼南阿埃塔語",
+    "杜巴尼南阿埃塔语"
   ],
   "dup": [
     "Duano"
@@ -7043,7 +7705,8 @@
     "Drung",
     "Derung",
     "Dulong",
-    "Trung"
+    "Trung",
+    "独龙语"
   ],
   "duv": [
     "Duvle"
@@ -7064,7 +7727,8 @@
     "Duli-Gewe"
   ],
   "dv": [
-    "迪維希語"
+    "迪維希語",
+    "迪维希语"
   ],
   "dva": [
     "Duau"
@@ -7089,7 +7753,8 @@
     "Gupapuyngu",
     "Dhay'yi",
     "Dayi",
-    "Dhalwangu"
+    "Dhalwangu",
+    "杜瓦尔语"
   ],
   "dww": [
     "Dawawa"
@@ -7101,18 +7766,21 @@
     "德維斯萊語",
     "Dewas Rai",
     "Danuwar Rai",
-    "Rai Danuwar"
+    "Rai Danuwar",
+    "德维斯莱语"
   ],
   "dya": [
     "Dyan"
   ],
   "dyb": [
     "迪亞貝爾迪亞貝爾語",
-    "Dyaberdyaber"
+    "Dyaberdyaber",
+    "迪亚贝尔迪亚贝尔语"
   ],
   "dyd": [
     "迪尤貢語",
-    "Dyugun"
+    "Dyugun",
+    "迪尤贡语"
   ],
   "dyg": [
     "Villa Viciosa Agta"
@@ -7131,23 +7799,27 @@
   ],
   "dyn": [
     "迪揚加迪語",
-    "Dyangadi"
+    "Dyangadi",
+    "迪扬加迪语"
   ],
   "dyo": [
     "Jola-Fonyi",
     "Diola-Fogny",
     "朱拉語",
     "Joola",
-    "Diola"
+    "Diola",
+    "朱拉语"
   ],
   "dyu": [
-    "迪尤拉語"
+    "迪尤拉語",
+    "迪尤拉语"
   ],
   "dyy": [
     "Dyaabugay"
   ],
   "dz": [
-    "宗喀語"
+    "宗喀語",
+    "宗喀语"
   ],
   "dza": [
     "Tunzu",
@@ -7156,7 +7828,8 @@
   "dzg": [
     "達薩語",
     "Daza",
-    "Dasaga"
+    "Dasaga",
+    "达萨语"
   ],
   "dzl": [
     "Dzala",
@@ -7171,25 +7844,29 @@
     "Ebughu"
   ],
   "ebk": [
-    "東邦圖克語"
+    "東邦圖克語",
+    "东邦图克语"
   ],
   "ebr": [
     "Ebrié"
   ],
   "ebu": [
-    "恩布語"
+    "恩布語",
+    "恩布语"
   ],
   "ecr": [
     "Eteocretan"
   ],
   "ecs": [
-    "厄瓜多爾手語"
+    "厄瓜多爾手語",
+    "厄瓜多尔手语"
   ],
   "ecy": [
     "Eteocypriot"
   ],
   "ee": [
-    "埃維語"
+    "埃維語",
+    "埃维语"
   ],
   "eee": [
     "E"
@@ -7202,24 +7879,29 @@
   ],
   "efi": [
     "埃菲克語",
-    "Efik"
+    "Efik",
+    "埃菲克语"
   ],
   "ega": [
     "Ega"
   ],
   "egl": [
-    "艾米利亞語"
+    "艾米利亞語",
+    "艾米利亚语"
   ],
   "ego": [
     "Eggon"
   ],
   "egx-dem": [
-    "世俗埃及語"
+    "世俗埃及語",
+    "世俗埃及语"
   ],
   "egy": [
     "埃及語",
     "Egyptian",
-    "古埃及語"
+    "古埃及語",
+    "埃及语",
+    "古埃及语"
   ],
   "ehu": [
     "Ehueun"
@@ -7237,7 +7919,8 @@
     "Ejamat"
   ],
   "eka": [
-    "艾卡朱克語"
+    "艾卡朱克語",
+    "艾卡朱克语"
   ],
   "eke": [
     "Ekit"
@@ -7265,10 +7948,12 @@
   ],
   "eky": [
     "東克耶語",
-    "Eastern Kayah"
+    "Eastern Kayah",
+    "东克耶语"
   ],
   "el": [
-    "希臘語"
+    "希臘語",
+    "希腊语"
   ],
   "ele": [
     "Elepi"
@@ -7296,7 +7981,8 @@
   ],
   "elx": [
     "埃蘭語",
-    "Elamite"
+    "Elamite",
+    "埃兰语"
   ],
   "ema": [
     "Emai",
@@ -7322,7 +8008,8 @@
   ],
   "emg": [
     "東梅瓦杭語",
-    "Eastern Meohang"
+    "Eastern Meohang",
+    "东梅瓦杭语"
   ],
   "emi": [
     "Mussau-Emira"
@@ -7341,27 +8028,32 @@
   ],
   "ems": [
     "阿魯提克語",
-    "Alutiiq"
+    "Alutiiq",
+    "阿鲁提克语"
   ],
   "emu": [
     "東穆里亞語",
-    "Eastern Muria"
+    "Eastern Muria",
+    "东穆里亚语"
   ],
   "emw": [
     "Emplawas"
   ],
   "emx": [
     "巴斯克羅姆語",
-    "Erromintxela"
+    "Erromintxela",
+    "巴斯克罗姆语"
   ],
   "emy": [
     "古典馬雅語",
     "Epigraphic Mayan",
     "Classic Ch'olti'an",
-    "Ch'olti'"
+    "Ch'olti'",
+    "古典马雅语"
   ],
   "en": [
-    "英語"
+    "英語",
+    "英语"
   ],
   "ena": [
     "Apali"
@@ -7371,18 +8063,21 @@
   ],
   "enc": [
     "恩語",
-    "En"
+    "En",
+    "恩语"
   ],
   "end": [
     "Ende"
   ],
   "enf": [
     "森林埃涅茨語",
-    "Forest Enets"
+    "Forest Enets",
+    "森林埃涅茨语"
   ],
   "enh": [
     "凍原埃涅茨語",
-    "Tundra Enets"
+    "Tundra Enets",
+    "冻原埃涅茨语"
   ],
   "enl": [
     "Enlhet",
@@ -7393,7 +8088,9 @@
     "Middle English",
     "Medieval English",
     "Mediaeval English",
-    "中世紀英語"
+    "中世紀英語",
+    "中古英语",
+    "中世纪英语"
   ],
   "enn": [
     "Engenni"
@@ -7421,7 +8118,8 @@
     "Lengua"
   ],
   "eo": [
-    "世界語"
+    "世界語",
+    "世界语"
   ],
   "eot": [
     "Eotile",
@@ -7481,17 +8179,20 @@
     "爾蘇語",
     "Ersu",
     "Duoxu",
-    "Erhsu"
+    "Erhsu",
+    "尔苏语"
   ],
   "ert": [
     "埃里泰語",
-    "Eritai"
+    "Eritai",
+    "埃里泰语"
   ],
   "erw": [
     "Erokwanas"
   ],
   "es": [
-    "西班牙語"
+    "西班牙語",
+    "西班牙语"
   ],
   "ese": [
     "Ese Ejja",
@@ -7499,30 +8200,36 @@
   ],
   "esh": [
     "埃斯特哈爾迪語",
-    "Eshtehardi"
+    "Eshtehardi",
+    "埃斯特哈尔迪语"
   ],
   "esi": [
     "北阿拉斯加伊努皮克語",
-    "North Alaskan Inupiatun"
+    "North Alaskan Inupiatun",
+    "北阿拉斯加伊努皮克语"
   ],
   "esk": [
     "西北阿拉斯加伊努皮克語",
-    "Northwest Alaskan Inupiatun"
+    "Northwest Alaskan Inupiatun",
+    "西北阿拉斯加伊努皮克语"
   ],
   "esl": [
     "埃及手語",
-    "Egyptian Sign Language"
+    "Egyptian Sign Language",
+    "埃及手语"
   ],
   "esm": [
     "Esuma"
   ],
   "esn": [
     "薩爾瓦多手語",
-    "Salvadoran Sign Language"
+    "Salvadoran Sign Language",
+    "萨尔瓦多手语"
   ],
   "eso": [
     "愛沙尼亞手語",
-    "Estonian Sign Language"
+    "Estonian Sign Language",
+    "爱沙尼亚手语"
   ],
   "esq": [
     "Esselen"
@@ -7540,16 +8247,19 @@
     "Siberian Yup'ik Eskimo",
     "St. Lawrence Island Eskimo",
     "St. Lawrence Island Yupik",
-    "St. Lawrence Island Yup'ik"
+    "St. Lawrence Island Yup'ik",
+    "中西伯利亚尤皮克语"
   ],
   "esu": [
     "中阿拉斯加尤皮克語",
     "Yup'ik",
-    "Central Alaskan Yupik"
+    "Central Alaskan Yupik",
+    "中阿拉斯加尤皮克语"
   ],
   "esx-esk-pro": [
     "原始愛斯基摩語",
-    "Proto-Eskimo"
+    "Proto-Eskimo",
+    "原始爱斯基摩语"
   ],
   "esx-ink": [
     "Inuktun"
@@ -7559,21 +8269,25 @@
   ],
   "esx-inu-pro": [
     "原始因紐特語",
-    "Proto-Inuit"
+    "Proto-Inuit",
+    "原始因纽特语"
   ],
   "esx-pro": [
     "原始愛斯基摩-阿留申語",
-    "Proto-Eskimo-Aleut"
+    "Proto-Eskimo-Aleut",
+    "原始爱斯基摩-阿留申语"
   ],
   "esx-tut": [
     "Tunumiisut"
   ],
   "esy": [
     "埃斯卡亞語",
-    "Eskayan"
+    "Eskayan",
+    "埃斯卡亚语"
   ],
   "et": [
-    "愛沙尼亞語"
+    "愛沙尼亞語",
+    "爱沙尼亚语"
   ],
   "etb": [
     "Etebi"
@@ -7584,7 +8298,9 @@
   "eth": [
     "埃塞俄比亞手語",
     "Ethiopian Sign Language",
-    "衣索比亞手語"
+    "衣索比亞手語",
+    "埃塞俄比亚手语",
+    "衣索比亚手语"
   ],
   "etn": [
     "Eton (Vanuatu)"
@@ -7603,7 +8319,8 @@
   ],
   "ett": [
     "伊特拉斯坎語",
-    "Etruscan"
+    "Etruscan",
+    "伊特拉斯坎语"
   ],
   "etu": [
     "Ejagham"
@@ -7615,35 +8332,42 @@
     "Semimi"
   ],
   "eu": [
-    "巴斯克語"
+    "巴斯克語",
+    "巴斯克语"
   ],
   "euq-pro": [
     "原始巴斯克語",
     "Proto-Basque",
-    "Proto-Vasconic"
+    "Proto-Vasconic",
+    "原始巴斯克语"
   ],
   "eve": [
     "鄂溫語",
-    "Even"
+    "Even",
+    "鄂温语"
   ],
   "evh": [
     "Uvbie"
   ],
   "evn": [
     "鄂溫克語",
-    "Evenki"
+    "Evenki",
+    "鄂温克语"
   ],
   "ewo": [
     "依汪都語",
-    "Kolo"
+    "Kolo",
+    "依汪都语"
   ],
   "ext": [
     "埃斯特雷馬杜拉語",
-    "Extremaduran"
+    "Extremaduran",
+    "埃斯特雷马杜拉语"
   ],
   "eya": [
     "埃雅克語",
-    "Eyak"
+    "Eyak",
+    "埃雅克语"
   ],
   "eyo": [
     "Keiyo"
@@ -7655,7 +8379,8 @@
     "Uzekwe"
   ],
   "fa": [
-    "波斯語"
+    "波斯語",
+    "波斯语"
   ],
   "faa": [
     "Fasu",
@@ -7669,7 +8394,8 @@
   "fab": [
     "安諾本語",
     "Annobonese",
-    "Fa d'Ambu"
+    "Fa d'Ambu",
+    "安诺本语"
   ],
   "fad": [
     "Wagi"
@@ -7704,7 +8430,8 @@
     "Fang (Guinea)",
     "Pahouin",
     "Fang (Equatorial Guinea)",
-    "Fang"
+    "Fang",
+    "芳语"
   ],
   "fap": [
     "Palor",
@@ -7723,29 +8450,35 @@
   ],
   "fax": [
     "法拉語",
-    "Fala"
+    "Fala",
+    "法拉语"
   ],
   "fay": [
     "西南法爾斯語",
-    "Southwestern Fars"
+    "Southwestern Fars",
+    "西南法尔斯语"
   ],
   "faz": [
     "西北法爾斯語",
-    "Northwestern Fars"
+    "Northwestern Fars",
+    "西北法尔斯语"
   ],
   "fbl": [
     "西阿爾拜比科爾語",
-    "West Albay Bikol"
+    "West Albay Bikol",
+    "西阿尔拜比科尔语"
   ],
   "fcs": [
     "魁北克手語",
-    "Quebec Sign Language"
+    "Quebec Sign Language",
+    "魁北克手语"
   ],
   "fer": [
     "Feroge"
   ],
   "ff": [
-    "富拉語"
+    "富拉語",
+    "富拉语"
   ],
   "ffi": [
     "Foia Foia"
@@ -7754,7 +8487,8 @@
     "Fongoro"
   ],
   "fi": [
-    "芬蘭語"
+    "芬蘭語",
+    "芬兰语"
   ],
   "fia": [
     "Nobiin"
@@ -7764,30 +8498,35 @@
   ],
   "fip": [
     "菲帕語",
-    "Fipa"
+    "Fipa",
+    "菲帕语"
   ],
   "fir": [
     "Firan"
   ],
   "fit": [
     "梅安語",
-    "Meänkieli"
+    "Meänkieli",
+    "梅安语"
   ],
   "fiu-fin-pro": [
     "原始芬蘭語",
-    "Proto-Finnic"
+    "Proto-Finnic",
+    "原始芬兰语"
   ],
   "fiw": [
     "Fiwaga"
   ],
   "fj": [
-    "斐濟語"
+    "斐濟語",
+    "斐济语"
   ],
   "fkk": [
     "Kirya-Konzel"
   ],
   "fkv": [
-    "克文語"
+    "克文語",
+    "克文语"
   ],
   "fla": [
     "蒙大拿薩利希語",
@@ -7796,7 +8535,8 @@
     "Salish",
     "Séliš",
     "Kalispel-Pend d'oreille",
-    "Kalispel"
+    "Kalispel",
+    "蒙大拿萨利希语"
   ],
   "flh": [
     "Foau"
@@ -7812,7 +8552,8 @@
     "Flinders Island",
     "Yalgawarra",
     "Wurima",
-    "Mutumui"
+    "Mutumui",
+    "费莲达岛语"
   ],
   "flr": [
     "Fuliiru"
@@ -7826,17 +8567,20 @@
   ],
   "fmu": [
     "遠西穆里亞語",
-    "Far Western Muria"
+    "Far Western Muria",
+    "远西穆里亚语"
   ],
   "fng": [
     "凡那伽羅語",
-    "Fanagalo"
+    "Fanagalo",
+    "凡那伽罗语"
   ],
   "fni": [
     "Fania"
   ],
   "fo": [
-    "法羅語"
+    "法羅語",
+    "法罗语"
   ],
   "fod": [
     "Foodo"
@@ -7848,41 +8592,48 @@
     "Foma"
   ],
   "fon": [
-    "豐語"
+    "豐語",
+    "丰语"
   ],
   "for": [
     "Fore"
   ],
   "fos": [
     "西拉雅語",
-    "Siraya"
+    "Siraya",
+    "西拉雅语"
   ],
   "fpe": [
     "皮欽利斯語",
     "Pichinglis",
-    "Fernando Po Creole English"
+    "Fernando Po Creole English",
+    "皮钦利斯语"
   ],
   "fqs": [
     "Fas"
   ],
   "fr": [
-    "法語"
+    "法語",
+    "法语"
   ],
   "frd": [
     "Fordata"
   ],
   "frm": [
     "中古法語",
-    "Middle French"
+    "Middle French",
+    "中古法语"
   ],
   "fro": [
-    "古法語"
+    "古法語",
+    "古法语"
   ],
   "frp": [
     "法蘭克-普羅旺斯語",
     "Franco-Provençal",
     "Arpetan",
-    "Arpitan"
+    "Arpitan",
+    "法兰克-普罗旺斯语"
   ],
   "frq": [
     "Forak"
@@ -7890,25 +8641,31 @@
   "frr": [
     "北弗里斯蘭語",
     "North Frisian",
-    "北弗里西語"
+    "北弗里西語",
+    "北弗里斯兰语",
+    "北弗里西语"
   ],
   "frt": [
     "Fortsenal"
   ],
   "fse": [
     "芬蘭手語",
-    "Finnish Sign Language"
+    "Finnish Sign Language",
+    "芬兰手语"
   ],
   "fsl": [
     "法國手語",
-    "French Sign Language"
+    "French Sign Language",
+    "法国手语"
   ],
   "fss": [
     "芬蘭-瑞典手語",
-    "Finnish-Swedish Sign Language"
+    "Finnish-Swedish Sign Language",
+    "芬兰-瑞典手语"
   ],
   "fud": [
-    "富圖納語"
+    "富圖納語",
+    "富图纳语"
   ],
   "fuj": [
     "Ko"
@@ -7921,7 +8678,8 @@
   ],
   "fur": [
     "弗留利語",
-    "Friulian"
+    "Friulian",
+    "弗留利语"
   ],
   "fut": [
     "Futuna-Aniwa"
@@ -7942,13 +8700,16 @@
     "Fwe"
   ],
   "fy": [
-    "西弗里斯蘭語"
+    "西弗里斯蘭語",
+    "西弗里斯兰语"
   ],
   "ga": [
-    "愛爾蘭語"
+    "愛爾蘭語",
+    "爱尔兰语"
   ],
   "gaa": [
-    "加族語"
+    "加族語",
+    "加族语"
   ],
   "gab": [
     "Gabri"
@@ -7957,7 +8718,8 @@
     "混合大安達曼語",
     "Mixed Great Andamanese",
     "Great Andamanese creole",
-    "Great Andamanese"
+    "Great Andamanese",
+    "混合大安达曼语"
   ],
   "gad": [
     "Gaddang",
@@ -7975,12 +8737,14 @@
   ],
   "gag": [
     "加告茲語",
-    "Gagauz"
+    "Gagauz",
+    "加告兹语"
   ],
   "gah": [
     "阿勒卡諾語",
     "Alekano",
-    "Gahuku"
+    "Gahuku",
+    "阿勒卡诺语"
   ],
   "gai": [
     "Borei"
@@ -8002,7 +8766,8 @@
   ],
   "gan": [
     "贛語",
-    "Gan"
+    "Gan",
+    "赣语"
   ],
   "gao": [
     "Gants",
@@ -8041,10 +8806,12 @@
     "Nobnob"
   ],
   "gay": [
-    "加約語"
+    "加約語",
+    "加约语"
   ],
   "gba": [
-    "葛巴亞語"
+    "葛巴亞語",
+    "葛巴亚语"
   ],
   "gbb": [
     "Kaytetye"
@@ -8089,7 +8856,8 @@
   ],
   "gbm": [
     "加爾華利語",
-    "Garhwali"
+    "Garhwali",
+    "加尔华利语"
   ],
   "gbn": [
     "Mo'da"
@@ -8153,11 +8921,13 @@
     "Guadeloupean Creole",
     "Guadeloupean Creole French",
     "Saint Lucian Creole",
-    "Saint Lucian Creole French"
+    "Saint Lucian Creole French",
+    "安地列斯克里奥尔语"
   ],
   "gcl": [
     "格瑞那達克里奧爾英語",
-    "Grenadian Creole English"
+    "Grenadian Creole English",
+    "格瑞那达克里奥尔英语"
   ],
   "gcn": [
     "Gaina"
@@ -8170,14 +8940,18 @@
     "Guyanais",
     "French Guianese Creole",
     "Guianese French Creole",
-    "Guyanese French Creole"
+    "Guyanese French Creole",
+    "圭亚那克里奥尔语",
+    "法属圭亚那克里奥尔语",
+    "圭亚那语"
   ],
   "gct": [
     "Colonia Tovar German",
     "Alemán Coloniero"
   ],
   "gd": [
-    "蘇格蘭蓋爾語"
+    "蘇格蘭蓋爾語",
+    "苏格兰盖尔语"
   ],
   "gdb": [
     "Ollari",
@@ -8227,12 +9001,14 @@
     "Umanakaina"
   ],
   "gdo": [
-    "戈多貝里語"
+    "戈多貝里語",
+    "戈多贝里语"
   ],
   "gdq": [
     "邁赫拉語",
     "Mehri",
-    "Mahri"
+    "Mahri",
+    "迈赫拉语"
   ],
   "gdr": [
     "Wipi"
@@ -8272,7 +9048,8 @@
   ],
   "gej": [
     "格恩語",
-    "Gen"
+    "Gen",
+    "格恩语"
   ],
   "gek": [
     "Gerka",
@@ -8318,12 +9095,14 @@
     "古勃艮第語",
     "Burgundian",
     "Burgundish",
-    "Burgundic"
+    "Burgundic",
+    "古勃艮第语"
   ],
   "gem-pro": [
     "原始日耳曼語",
     "Proto-Germanic",
-    "Common Germanic"
+    "Common Germanic",
+    "原始日耳曼语"
   ],
   "geq": [
     "Geme"
@@ -8344,11 +9123,13 @@
     "Enya"
   ],
   "gez": [
-    "吉茲語"
+    "吉茲語",
+    "吉兹语"
   ],
   "gfk": [
     "帕特帕塔爾語",
-    "Patpatar"
+    "Patpatar",
+    "帕特帕塔尔语"
   ],
   "gft": [
     "Gafat"
@@ -8442,17 +9223,22 @@
     "基里巴斯語",
     "吉里巴斯語",
     "Kiribati",
-    "Kiribatese"
+    "Kiribatese",
+    "吉伯特语",
+    "基里巴斯语",
+    "吉里巴斯语"
   ],
   "gim": [
     "Gimi (Goroka)"
   ],
   "gin": [
-    "希努赫語"
+    "希努赫語",
+    "希努赫语"
   ],
   "gio": [
     "仡佬語",
-    "Gelao"
+    "Gelao",
+    "仡佬语"
   ],
   "gip": [
     "Gimi (Austronesian)"
@@ -8461,12 +9247,14 @@
     "青仡佬語",
     "Green Gelao",
     "Hagei",
-    "Hakhi"
+    "Hakhi",
+    "青仡佬语"
   ],
   "gir": [
     "紅仡佬語",
     "Red Gelao",
-    "Vandu"
+    "Vandu",
+    "红仡佬语"
   ],
   "gis": [
     "North Giziga"
@@ -8476,14 +9264,16 @@
   ],
   "giu": [
     "木佬語",
-    "Mulao"
+    "Mulao",
+    "木佬语"
   ],
   "giw": [
     "白仡佬語",
     "White Gelao",
     "Telue",
     "Doulou",
-    "Tolo"
+    "Tolo",
+    "白仡佬语"
   ],
   "gix": [
     "Gilima"
@@ -8507,7 +9297,8 @@
     "Gonja"
   ],
   "gju": [
-    "Gojri"
+    "古賈里語",
+    "古贾里语"
   ],
   "gka": [
     "Guya"
@@ -8528,7 +9319,8 @@
     "Guinea Kpelle"
   ],
   "gl": [
-    "加利西亞語"
+    "加利西亞語",
+    "加利西亚语"
   ],
   "glc": [
     "Bon Gula"
@@ -8539,7 +9331,10 @@
     "那乃語",
     "Goldi",
     "Hezhen",
-    "赫真語"
+    "赫真語",
+    "赫哲语",
+    "那乃语",
+    "赫真语"
   ],
   "glh": [
     "Northwest Pashayi"
@@ -8548,7 +9343,8 @@
     "Kulaal"
   ],
   "glk": [
-    "吉拉基語"
+    "吉拉基語",
+    "吉拉基语"
   ],
   "glo": [
     "Galambu"
@@ -8576,18 +9372,21 @@
   ],
   "gme-cgo": [
     "克里米亞哥特語",
-    "Crimean Gothic"
+    "Crimean Gothic",
+    "克里米亚哥特语"
   ],
   "gmg": [
     "Magiyi"
   ],
   "gmh": [
     "中古高地德語",
-    "Middle High German"
+    "Middle High German",
+    "中古高地德语"
   ],
   "gml": [
     "中古低地德語",
-    "Middle Low German"
+    "Middle Low German",
+    "中古低地德语"
   ],
   "gmm": [
     "Gbaya-Mbodomo"
@@ -8597,35 +9396,43 @@
   ],
   "gmq-bot": [
     "西博滕語",
-    "Westrobothnian"
+    "Westrobothnian",
+    "西博滕语"
   ],
   "gmq-gut": [
     "哥特蘭語",
-    "Gutnish"
+    "Gutnish",
+    "哥特兰语"
   ],
   "gmq-jmk": [
     "耶姆特蘭語",
     "Jamtish",
-    "Jamtlandic"
+    "Jamtlandic",
+    "耶姆特兰语"
   ],
   "gmq-mno": [
     "中古挪威語",
-    "Middle Norwegian"
+    "Middle Norwegian",
+    "中古挪威语"
   ],
   "gmq-oda": [
     "古丹麥語",
-    "Old Danish"
+    "Old Danish",
+    "古丹麦语"
   ],
   "gmq-osw": [
     "古瑞典語",
-    "Old Swedish"
+    "Old Swedish",
+    "古瑞典语"
   ],
   "gmq-pro": [
-    "原始諾爾斯語"
+    "原始諾爾斯語",
+    "原始诺尔斯语"
   ],
   "gmq-scy": [
     "斯堪尼亞語",
-    "Scanian"
+    "Scanian",
+    "斯堪尼亚语"
   ],
   "gmu": [
     "Gumalu"
@@ -8640,7 +9447,8 @@
     "Ripuarian",
     "Moselle Franconian",
     "Colognian",
-    "Kölsch"
+    "Kölsch",
+    "中部法兰克尼亚语"
   ],
   "gmw-ecg": [
     "中東部德語",
@@ -8652,17 +9460,24 @@
     "Lusatian",
     "Erzgebirgisch",
     "Silesian",
-    "高地普魯士語"
+    "高地普魯士語",
+    "中东部德语",
+    "图林根语",
+    "上萨克森语",
+    "西里西亚德语",
+    "高地普鲁士语"
   ],
   "gmw-gts": [
     "Gottscheerish"
   ],
   "gmw-jdt": [
-    "澤西荷蘭語"
+    "澤西荷蘭語",
+    "泽西荷兰语"
   ],
   "gmw-pro": [
     "原始西日耳曼語",
-    "Proto-West Germanic"
+    "Proto-West Germanic",
+    "原始西日耳曼语"
   ],
   "gmw-rfr": [
     "萊茵法蘭克尼亞語",
@@ -8676,7 +9491,8 @@
     "Palatine German",
     "Pfälzisch",
     "Pälzisch",
-    "Palatinate German"
+    "Palatinate German",
+    "莱茵法兰克尼亚语"
   ],
   "gmw-stm": [
     "Sathmar Swabian"
@@ -8684,11 +9500,13 @@
   "gmw-tsx": [
     "特蘭西瓦尼亞薩克森語",
     "Transylvanian Saxon",
-    "Siebenbürger Saxon"
+    "Siebenbürger Saxon",
+    "特兰西瓦尼亚萨克森语"
   ],
   "gmw-vog": [
     "伏爾加德語",
-    "Volga German"
+    "Volga German",
+    "伏尔加德语"
   ],
   "gmw-zps": [
     "Zipser German",
@@ -8701,10 +9519,12 @@
   ],
   "gmy": [
     "邁錫尼希臘語",
-    "Mycenaean Greek"
+    "Mycenaean Greek",
+    "迈锡尼希腊语"
   ],
   "gn": [
-    "瓜拉尼語"
+    "瓜拉尼語",
+    "瓜拉尼语"
   ],
   "gna": [
     "Kaansa"
@@ -8732,7 +9552,8 @@
   ],
   "gni": [
     "古尼揚迪語",
-    "Gooniyandi"
+    "Gooniyandi",
+    "古尼扬迪语"
   ],
   "gnj": [
     "Ngen",
@@ -8766,7 +9587,8 @@
     "西玻利維亞瓜拉尼語",
     "Western Bolivian Guaraní",
     "Simba",
-    "Simba Guarani"
+    "Simba Guarani",
+    "西玻利维亚瓜拉尼语"
   ],
   "gnz": [
     "Ganzi"
@@ -8797,7 +9619,8 @@
     "Old High German",
     "Gobosi",
     "Gebusi",
-    "Bibo"
+    "Bibo",
+    "古高地德语"
   ],
   "goi": [
     "Gobasi",
@@ -8822,7 +9645,8 @@
     "Koya Gondi",
     "Maria Gondi",
     "Muria Gondi",
-    "Raj Gondi"
+    "Raj Gondi",
+    "冈德语"
   ],
   "goo": [
     "Gone Dau"
@@ -8835,10 +9659,12 @@
   ],
   "gor": [
     "哥倫打洛語",
-    "Gorontalo"
+    "Gorontalo",
+    "哥伦打洛语"
   ],
   "got": [
-    "哥特語"
+    "哥特語",
+    "哥特语"
   ],
   "gou": [
     "Gavar"
@@ -8867,7 +9693,8 @@
     "Ga'anda"
   ],
   "gqi": [
-    "貴瓊語"
+    "貴瓊語",
+    "贵琼语"
   ],
   "gqn": [
     "Kinikinao",
@@ -8884,17 +9711,20 @@
     "Qau",
     "Gao",
     "Aqao",
-    "Qau Gelao"
+    "Qau Gelao",
+    "稿语"
   ],
   "gra": [
     "Rajput Garasia"
   ],
   "grb": [
-    "格列博語"
+    "格列博語",
+    "格列博语"
   ],
   "grc": [
     "古希臘語",
-    "Ancient Greek"
+    "Ancient Greek",
+    "古希腊语"
   ],
   "grd": [
     "Guruntum"
@@ -8919,24 +9749,28 @@
     "卡拉布里亞希臘語",
     "Calabrian Greek",
     "Italian Greek",
-    "Bova"
+    "Bova",
+    "卡拉布里亚希腊语"
   ],
   "grk-ita": [
     "意大利希臘語",
     "Italiot Greek",
     "Griko",
     "Grico",
-    "Grecanic"
+    "Grecanic",
+    "意大利希腊语"
   ],
   "grk-mar": [
     "馬里烏波爾希臘語",
     "Mariupol Greek",
     "Mariupolitan Greek",
     "Rumeíka",
-    "Rumeika"
+    "Rumeika",
+    "马里乌波尔希腊语"
   ],
   "grk-pro": [
-    "原始希臘語"
+    "原始希臘語",
+    "原始希腊语"
   ],
   "grm": [
     "Kota Marudu Talantang"
@@ -8957,7 +9791,8 @@
     "嘎洛語",
     "Garrow",
     "Mandi",
-    "Mande"
+    "Mande",
+    "嘎洛语"
   ],
   "gru": [
     "Kistane",
@@ -8982,16 +9817,20 @@
   "gse": [
     "加納手語",
     "迦納手語",
-    "Ghanaian Sign Language"
+    "Ghanaian Sign Language",
+    "加纳手语",
+    "迦纳手语"
   ],
   "gsg": [
-    "德國手語"
+    "德國手語",
+    "德国手语"
   ],
   "gsl": [
     "Gusilay"
   ],
   "gsm": [
-    "危地馬拉手語"
+    "危地馬拉手語",
+    "危地马拉手语"
   ],
   "gsn": [
     "Gusan"
@@ -9003,7 +9842,8 @@
     "Wasembo"
   ],
   "gss": [
-    "希臘手語"
+    "希臘手語",
+    "希腊手语"
   ],
   "gsw": [
     "阿勒曼尼語",
@@ -9028,7 +9868,9 @@
     "Greschoney",
     "Gressoney",
     "Éischemtöitschu",
-    "Issime"
+    "Issime",
+    "阿勒曼尼语",
+    "瑞士德语"
   ],
   "gta": [
     "Guató"
@@ -9037,17 +9879,20 @@
     "Aghu Tharrnggala"
   ],
   "gu": [
-    "古吉拉特語"
+    "古吉拉特語",
+    "古吉拉特语"
   ],
   "gua": [
     "Shiki"
   ],
   "gub": [
     "瓜加加拉語",
-    "Guajajára"
+    "Guajajára",
+    "瓜加加拉语"
   ],
   "guc": [
-    "瓦尤語"
+    "瓦尤語",
+    "瓦尤语"
   ],
   "gud": [
     "Yocoboué Dida"
@@ -9062,7 +9907,8 @@
     "巴拉圭瓜拉尼語",
     "Jopará",
     "Yopará",
-    "Paraguayan Guaraní"
+    "Paraguayan Guaraní",
+    "巴拉圭瓜拉尼语"
   ],
   "guh": [
     "Guahibo"
@@ -9071,7 +9917,8 @@
     "東玻利維亞瓜拉尼語",
     "Eastern Bolivian Guaraní",
     "Ava Guaraní",
-    "Chiriguanos"
+    "Chiriguanos",
+    "东玻利维亚瓜拉尼语"
   ],
   "guk": [
     "Gumuz"
@@ -9080,7 +9927,8 @@
     "古拉語",
     "Gullah",
     "Geechee",
-    "Sea Island Creole English"
+    "Sea Island Creole English",
+    "古拉语"
   ],
   "gum": [
     "Guambiano"
@@ -9102,7 +9950,8 @@
     "Kaiwá",
     "Kayová",
     "Cahygua",
-    "Caingua"
+    "Caingua",
+    "姆比亚瓜拉尼语"
   ],
   "guo": [
     "Guayabero"
@@ -9144,12 +9993,14 @@
     "Naani",
     "Nankanse",
     "Ninkare",
-    "Booni"
+    "Booni",
+    "法拉法拉语"
   ],
   "gus": [
     "幾內亞手語",
     "Guinean Sign Language",
-    "Guayaki"
+    "Guayaki",
+    "几内亚手语"
   ],
   "gut": [
     "Maléku Jaíka"
@@ -9169,10 +10020,12 @@
     "Gourmanchéma"
   ],
   "guz": [
-    "古西語"
+    "古西語",
+    "古西语"
   ],
   "gv": [
-    "曼島語"
+    "曼島語",
+    "曼岛语"
   ],
   "gva": [
     "Kaskihá",
@@ -9253,7 +10106,8 @@
     "Kutchin",
     "Takudh",
     "Tukudh",
-    "Loucheux"
+    "Loucheux",
+    "圭契语"
   ],
   "gwj": [
     "Gcwi"
@@ -9310,7 +10164,8 @@
     "Ngäbere"
   ],
   "gyn": [
-    "蓋亞那克里奧爾英語"
+    "蓋亞那克里奧爾英語",
+    "盖亚那克里奥尔英语"
   ],
   "gyo": [
     "Gyalsumdo"
@@ -9328,7 +10183,8 @@
     "Gane"
   ],
   "ha": [
-    "豪薩語"
+    "豪薩語",
+    "豪萨语"
   ],
   "haa": [
     "Hän",
@@ -9339,7 +10195,8 @@
   ],
   "hab": [
     "河內手語",
-    "Hanoi Sign Language"
+    "Hanoi Sign Language",
+    "河内手语"
   ],
   "hac": [
     "古拉尼語",
@@ -9353,14 +10210,16 @@
     "Hewrami",
     "Hourami",
     "Howrami",
-    "Ourami"
+    "Ourami",
+    "古拉尼语"
   ],
   "had": [
     "Hatam"
   ],
   "haf": [
     "海防手語",
-    "Haiphong Sign Language"
+    "Haiphong Sign Language",
+    "海防手语"
   ],
   "hag": [
     "Hanga"
@@ -9370,17 +10229,22 @@
   ],
   "hai": [
     "海達語",
-    "Haida"
+    "Haida",
+    "海达语"
   ],
   "haj": [
     "哈瓊語",
-    "Hajong"
+    "Hajong",
+    "哈琼语"
   ],
   "hak": [
     "客家語",
     "客家話",
     "客語",
-    "Hakka"
+    "Hakka",
+    "客家语",
+    "客家话",
+    "客语"
   ],
   "hal": [
     "Halang"
@@ -9390,14 +10254,16 @@
   ],
   "hao": [
     "哈科語",
-    "Hakö"
+    "Hakö",
+    "哈科语"
   ],
   "hap": [
     "Hupla"
   ],
   "har": [
     "哈勒爾語",
-    "Harari"
+    "Harari",
+    "哈勒尔语"
   ],
   "has": [
     "Haisla"
@@ -9407,18 +10273,21 @@
   ],
   "haw": [
     "夏威夷語",
-    "Hawaiian"
+    "Hawaiian",
+    "夏威夷语"
   ],
   "hax": [
     "南海達語",
-    "Southern Haida"
+    "Southern Haida",
+    "南海达语"
   ],
   "hay": [
     "Haya"
   ],
   "haz": [
     "哈札拉語",
-    "Hazaragi"
+    "Hazaragi",
+    "哈札拉语"
   ],
   "hba": [
     "Hamba"
@@ -9435,32 +10304,39 @@
   ],
   "hca": [
     "安達曼克里奧爾印地語",
-    "Andaman Creole Hindi"
+    "Andaman Creole Hindi",
+    "安达曼克里奥尔印地语"
   ],
   "hch": [
     "惠喬爾語",
-    "Huichol"
+    "Huichol",
+    "惠乔尔语"
   ],
   "hdn": [
     "北海達語",
-    "Northern Haida"
+    "Northern Haida",
+    "北海达语"
   ],
   "hds": [
     "洪都拉斯手語",
     "宏都拉斯手語",
     "Honduras Sign Language",
-    "Honduran Sign Language"
+    "Honduran Sign Language",
+    "洪都拉斯手语",
+    "宏都拉斯手语"
   ],
   "hdy": [
     "Hadiyya"
   ],
   "he": [
-    "希伯來語"
+    "希伯來語",
+    "希伯来语"
   ],
   "hea": [
     "北部黔東苗語",
     "Northern Qiandong Miao",
-    "Black Miao"
+    "Black Miao",
+    "北部黔东苗语"
   ],
   "hed": [
     "Herdé"
@@ -9473,14 +10349,16 @@
   ],
   "hei": [
     "海爾蘇克語",
-    "Heiltsuk"
+    "Heiltsuk",
+    "海尔苏克语"
   ],
   "hem": [
     "Hemba"
   ],
   "hgm": [
     "海奧姆語",
-    "Haiǁom"
+    "Haiǁom",
+    "海奥姆语"
   ],
   "hgw": [
     "Haigwai"
@@ -9496,7 +10374,8 @@
   ],
   "hi": [
     "印地語",
-    "Hindavi"
+    "Hindavi",
+    "印地语"
   ],
   "hia": [
     "Lamang"
@@ -9506,11 +10385,13 @@
   ],
   "hid": [
     "希達沙語",
-    "Hidatsa"
+    "Hidatsa",
+    "希达沙语"
   ],
   "hif": [
     "斐濟印地語",
-    "Fiji Hindi"
+    "Fiji Hindi",
+    "斐济印地语"
   ],
   "hig": [
     "Kamwe",
@@ -9522,7 +10403,8 @@
   ],
   "hii": [
     "欣杜里語",
-    "Hinduri"
+    "Hinduri",
+    "欣杜里语"
   ],
   "hij": [
     "Hijuk"
@@ -9532,7 +10414,8 @@
   ],
   "hil": [
     "希利蓋農語",
-    "Hiligaynon"
+    "Hiligaynon",
+    "希利盖农语"
   ],
   "hio": [
     "Tshwa",
@@ -9549,7 +10432,8 @@
     "Himarimã"
   ],
   "hit": [
-    "赫梯語"
+    "赫梯語",
+    "赫梯语"
   ],
   "hiw": [
     "Hiw"
@@ -9557,7 +10441,8 @@
   "hix": [
     "希卡利亞納語",
     "Hixkaryana",
-    "Hixkaryána"
+    "Hixkaryána",
+    "希卡利亚纳语"
   ],
   "hji": [
     "Haji"
@@ -9578,14 +10463,16 @@
   ],
   "hks": [
     "香港手語",
-    "Hong Kong Sign Language"
+    "Hong Kong Sign Language",
+    "香港手语"
   ],
   "hla": [
     "Halia"
   ],
   "hlb": [
     "哈爾比語",
-    "Halbi"
+    "Halbi",
+    "哈尔比语"
   ],
   "hld": [
     "Halang Doan",
@@ -9595,7 +10482,8 @@
   "hle": [
     "山蘇語",
     "Hlersu",
-    "Sansu"
+    "Sansu",
+    "山苏语"
   ],
   "hlt": [
     "Nga La",
@@ -9604,7 +10492,8 @@
   ],
   "hma": [
     "南部麻山苗語",
-    "Southern Mashan Miao"
+    "Southern Mashan Miao",
+    "南部麻山苗语"
   ],
   "hmb": [
     "Humburi Senni",
@@ -9613,7 +10502,8 @@
   "hmc": [
     "中部惠水苗語",
     "Central Huishui Hmong",
-    "Central Huishui Miao"
+    "Central Huishui Miao",
+    "中部惠水苗语"
   ],
   "hmd": [
     "滇東北苗語",
@@ -9621,64 +10511,78 @@
     "A-Hmao",
     "A Hmao",
     "Big Flowery Miao",
-    "Large Flowery Miao"
+    "Large Flowery Miao",
+    "滇东北苗语",
+    "大花苗语"
   ],
   "hme": [
     "東部惠水苗語",
     "Eastern Huishui Hmong",
-    "Eastern Huishui Miao"
+    "Eastern Huishui Miao",
+    "东部惠水苗语"
   ],
   "hmf": [
     "Hmong Don"
   ],
   "hmg": [
     "西南貴陽苗語",
-    "Southwestern Guiyang Hmong"
+    "Southwestern Guiyang Hmong",
+    "西南贵阳苗语"
   ],
   "hmh": [
     "西南惠水苗語",
     "Southwestern Huishui Hmong",
-    "Southwestern Huishui Miao"
+    "Southwestern Huishui Miao",
+    "西南惠水苗语"
   ],
   "hmi": [
     "北部惠水苗語",
     "Northern Huishui Hmong",
-    "Northern Huishui Miao"
+    "Northern Huishui Miao",
+    "北部惠水苗语"
   ],
   "hmj": [
     "⿰亻革家語",
     "重安江苗語",
     "Ge",
-    "Gedou Miao"
+    "Gedou Miao",
+    "⿰亻革家语",
+    "重安江苗语"
   ],
   "hmk": [
     "濊貊語",
     "Maek",
     "Ye-Maek",
-    "Yemaek"
+    "Yemaek",
+    "濊貊语"
   ],
   "hml": [
     "羅泊河苗語",
-    "Luopohe Hmong"
+    "Luopohe Hmong",
+    "罗泊河苗语"
   ],
   "hmm": [
     "中部麻山苗語",
     "Central Mashan Hmong",
-    "Central Mashan Miao"
+    "Central Mashan Miao",
+    "中部麻山苗语"
   ],
   "hmn-pro": [
     "原始苗語",
-    "Proto-Hmong"
+    "Proto-Hmong",
+    "原始苗语"
   ],
   "hmp": [
     "北部麻山苗語",
     "Northern Mashan Hmong",
-    "Northern Mashan Miao"
+    "Northern Mashan Miao",
+    "北部麻山苗语"
   ],
   "hmq": [
     "東部黔東苗語",
     "Eastern Qiandong Miao",
-    "Black Miao"
+    "Black Miao",
+    "东部黔东苗语"
   ],
   "hmr": [
     "Hmar"
@@ -9686,7 +10590,8 @@
   "hms": [
     "南部黔東苗語",
     "Southern Qiandong Miao",
-    "Black Miao"
+    "Black Miao",
+    "南部黔东苗语"
   ],
   "hmt": [
     "Hamtai",
@@ -9702,24 +10607,29 @@
   "hmw": [
     "西部麻山苗語",
     "Western Mashan Hmong",
-    "Western Mashan Miao"
+    "Western Mashan Miao",
+    "西部麻山苗语"
   ],
   "hmx-mie-pro": [
     "原始瑤語",
-    "Proto-Mien"
+    "Proto-Mien",
+    "原始瑶语"
   ],
   "hmx-pro": [
     "原始苗瑤語",
-    "Proto-Hmong-Mien"
+    "Proto-Hmong-Mien",
+    "原始苗瑶语"
   ],
   "hmy": [
     "南部貴陽苗語",
-    "Southern Guiyang Hmong"
+    "Southern Guiyang Hmong",
+    "南部贵阳苗语"
   ],
   "hmz": [
     "漢苗語",
     "Hmong Shua",
-    "Hmong Sua"
+    "Hmong Sua",
+    "汉苗语"
   ],
   "hna": [
     "Mina",
@@ -9729,17 +10639,23 @@
   ],
   "hnd": [
     "南辛德科語",
-    "Southern Hindko"
+    "Southern Hindko",
+    "南辛德科语"
   ],
   "hne": [
     "恰蒂斯加爾語",
-    "Chhattisgarhi"
+    "Chhattisgarhi",
+    "恰蒂斯加尔语"
   ],
   "hnh": [
     "ǁAni"
   ],
   "hni": [
-    "Hani"
+    "哈尼語",
+    "Hani",
+    "哈尼話",
+    "哈尼语",
+    "哈尼话"
   ],
   "hnj": [
     "青苗語",
@@ -9748,30 +10664,36 @@
     "Hmong Leng",
     "Mong Leng",
     "Green Miao",
-    "Blue Hmong"
+    "Blue Hmong",
+    "青苗语"
   ],
   "hnn": [
     "哈努諾語",
-    "Hanuno'o"
+    "Hanuno'o",
+    "哈努诺语"
   ],
   "hno": [
     "北辛德科語",
     "Northern Hindko",
     "Kagani",
     "Hazara Hindko",
-    "Hindki of Hazara"
+    "Hindki of Hazara",
+    "北辛德科语"
   ],
   "hns": [
     "加勒比印度斯坦語",
     "Caribbean Hindustani",
     "加勒比博傑普爾語",
-    "Caribbean Bhojpuri"
+    "Caribbean Bhojpuri",
+    "加勒比印度斯坦语",
+    "加勒比博杰普尔语"
   ],
   "hnu": [
     "Hung"
   ],
   "ho": [
-    "希里摩圖語"
+    "希里摩圖語",
+    "希里摩图语"
   ],
   "hoa": [
     "Hoava"
@@ -9783,7 +10705,8 @@
   ],
   "hoc": [
     "霍語",
-    "Ho"
+    "Ho",
+    "霍语"
   ],
   "hod": [
     "Holma"
@@ -9813,14 +10736,16 @@
   "hop": [
     "霍皮語",
     "Hopi",
-    "Moqui"
+    "Moqui",
+    "霍皮语"
   ],
   "hor": [
     "Horo"
   ],
   "hos": [
     "胡志明市手語",
-    "Ho Chi Minh City Sign Language"
+    "Ho Chi Minh City Sign Language",
+    "胡志明市手语"
   ],
   "hot": [
     "Hote"
@@ -9849,7 +10774,9 @@
     "夏威夷手語",
     "Hawaiian Sign Language",
     "Hula",
-    "Hawaii Sign Language"
+    "Hawaii Sign Language",
+    "夏威夷皮钦手语",
+    "夏威夷手语"
   ],
   "hra": [
     "Hrangkhol"
@@ -9868,14 +10795,16 @@
   "hrm": [
     "角苗語",
     "Horned Miao",
-    "Hrê"
+    "Hrê",
+    "角苗语"
   ],
   "hro": [
     "Haroi"
   ],
   "hrp": [
     "恩希爾皮語",
-    "Nhirrpi"
+    "Nhirrpi",
+    "恩希尔皮语"
   ],
   "hrt": [
     "Hértevin"
@@ -9891,36 +10820,44 @@
     "漢斯立克語",
     "Hunsrik",
     "里奧格蘭德洪斯呂克語",
-    "Riograndenser Hunsrückisch"
+    "Riograndenser Hunsrückisch",
+    "汉斯立克语",
+    "里奥格兰德洪斯吕克语"
   ],
   "hrz": [
     "哈爾札尼語",
     "Harzani",
-    "Harzandi"
+    "Harzandi",
+    "哈尔札尼语"
   ],
   "hsb": [
     "上索布語",
     "Upper Sorbian",
     "Upper Lusatian",
-    "Upper Wendish"
+    "Upper Wendish",
+    "上索布语"
   ],
   "hsh": [
     "匈牙利手語",
-    "Hungarian Sign Language"
+    "Hungarian Sign Language",
+    "匈牙利手语"
   ],
   "hsl": [
     "豪薩手語",
-    "Hausa Sign Language"
+    "Hausa Sign Language",
+    "豪萨手语"
   ],
   "hsn": [
     "湘語",
-    "Xiang"
+    "Xiang",
+    "湘语"
   ],
   "hss": [
     "Harsusi"
   ],
   "ht": [
-    "海地克里奧爾語"
+    "海地克里奧爾語",
+    "海地克里奥尔语"
   ],
   "hti": [
     "Hoti"
@@ -9932,16 +10869,19 @@
   ],
   "hts": [
     "哈扎語",
-    "Hadza"
+    "Hadza",
+    "哈扎语"
   ],
   "htu": [
     "Hitu"
   ],
   "htx": [
-    "中古赫梯語"
+    "中古赫梯語",
+    "中古赫梯语"
   ],
   "hu": [
-    "匈牙利語"
+    "匈牙利語",
+    "匈牙利语"
   ],
   "hub": [
     "Huambisa",
@@ -9971,7 +10911,8 @@
   ],
   "huj": [
     "北部貴陽苗語",
-    "Northern Guiyang Hmong"
+    "Northern Guiyang Hmong",
+    "北部贵阳苗语"
   ],
   "huk": [
     "Hulung"
@@ -9986,7 +10927,8 @@
     "Hu"
   ],
   "hup": [
-    "胡帕語"
+    "胡帕語",
+    "胡帕语"
   ],
   "huq": [
     "回輝語",
@@ -9995,11 +10937,16 @@
     "三亞回族話",
     "Tsat",
     "Utsat",
-    "Utset"
+    "Utset",
+    "回辉语",
+    "海南占语",
+    "回辉话",
+    "三亚回族话"
   ],
   "hur": [
     "哈爾魁梅林語",
-    "Halkomelem"
+    "Halkomelem",
+    "哈尔魁梅林语"
   ],
   "hus": [
     "瓦斯特克語",
@@ -10010,7 +10957,8 @@
     "Huaxteca",
     "Huaxteco",
     "Huaxteque",
-    "Huastecan"
+    "Huastecan",
+    "瓦斯特克语"
   ],
   "huu": [
     "Murui Huitoto",
@@ -10038,13 +10986,15 @@
   ],
   "huz": [
     "洪濟布語",
-    "Hunzib"
+    "Hunzib",
+    "洪济布语"
   ],
   "hvc": [
     "海地巫毒文化語",
     "Haitian Vodoun Culture Language",
     "Langaj",
-    "Langay"
+    "Langay",
+    "海地巫毒文化语"
   ],
   "hvk": [
     "Haveke"
@@ -10065,26 +11015,34 @@
     "Hawaiian Creole English",
     "Hawai'ian Creole English",
     "Hawaiian Pidgin",
-    "Hawai'ian Creole"
+    "Hawai'ian Creole",
+    "夏威夷英语",
+    "夏威夷克里奥尔英语",
+    "夏威夷克里奥尔语",
+    "夏威夷皮钦语"
   ],
   "hwo": [
     "Hwana"
   ],
   "hy": [
-    "亞美尼亞語"
+    "亞美尼亞語",
+    "亚美尼亚语"
   ],
   "hya": [
     "Hya"
   ],
   "hyx-pro": [
     "原始亞美尼亞語",
-    "Proto-Armenian"
+    "Proto-Armenian",
+    "原始亚美尼亚语"
   ],
   "hz": [
-    "赫雷羅語"
+    "赫雷羅語",
+    "赫雷罗语"
   ],
   "ia": [
-    "因特語"
+    "因特語",
+    "因特语"
   ],
   "iai": [
     "Iaai"
@@ -10097,22 +11055,26 @@
   ],
   "iba": [
     "伊班語",
-    "Iban"
+    "Iban",
+    "伊班语"
   ],
   "ibb": [
     "伊比比奧語",
-    "Ibibio"
+    "Ibibio",
+    "伊比比奥语"
   ],
   "ibd": [
     "伊瓦加語",
-    "Iwaidja"
+    "Iwaidja",
+    "伊瓦加语"
   ],
   "ibe": [
     "Akpes"
   ],
   "ibg": [
     "伊巴納格語",
-    "Ibanag"
+    "Ibanag",
+    "伊巴纳格语"
   ],
   "ibh": [
     "Bih"
@@ -10122,7 +11084,8 @@
     "Ibaloi",
     "Ibaloy",
     "Inibaloi",
-    "Inibaloy"
+    "Inibaloy",
+    "伊巴洛伊语"
   ],
   "ibm": [
     "Agoi"
@@ -10150,22 +11113,26 @@
   ],
   "icl": [
     "冰島手語",
-    "Icelandic Sign Language"
+    "Icelandic Sign Language",
+    "冰岛手语"
   ],
   "icr": [
     "島嶼克里奧爾英語",
     "Islander Creole English",
-    "San Andrés-Providencia Creole"
+    "San Andrés-Providencia Creole",
+    "岛屿克里奥尔英语"
   ],
   "id": [
-    "印尼語"
+    "印尼語",
+    "印尼语"
   ],
   "ida": [
     "Idakho-Isukha-Tiriki"
   ],
   "idb": [
     "印度葡萄牙語",
-    "Indo-Portuguese"
+    "Indo-Portuguese",
+    "印度葡萄牙语"
   ],
   "idc": [
     "Idon"
@@ -10178,7 +11145,8 @@
   ],
   "idi": [
     "伊迪語",
-    "Idi"
+    "Idi",
+    "伊迪语"
   ],
   "idr": [
     "Indri"
@@ -10193,7 +11161,8 @@
     "Idoma"
   ],
   "ie": [
-    "西方國際語"
+    "西方國際語",
+    "西方国际语"
   ],
   "ifa": [
     "Amganad Ifugao",
@@ -10222,13 +11191,15 @@
   "ifu": [
     "馬尤瑤-伊富高語",
     "Mayoyao Ifugao",
-    "Mayoyao Ifugaw"
+    "Mayoyao Ifugaw",
+    "马尤瑶-伊富高语"
   ],
   "ify": [
     "Keley-I Kallahan"
   ],
   "ig": [
-    "伊博語"
+    "伊博語",
+    "伊博语"
   ],
   "igb": [
     "Ebira",
@@ -10273,15 +11244,18 @@
     "Iha"
   ],
   "ii": [
-    "彝語"
+    "彝語",
+    "彝语"
   ],
   "iir-nur-pro": [
     "原始努利斯坦語",
-    "Proto-Nuristani"
+    "Proto-Nuristani",
+    "原始努利斯坦语"
   ],
   "iir-pro": [
     "原始印度-伊朗語",
-    "Proto-Indo-Iranian"
+    "Proto-Indo-Iranian",
+    "原始印度-伊朗语"
   ],
   "ijc": [
     "伊宗語",
@@ -10289,7 +11263,8 @@
     "Kolokuma",
     "Ekpetiama",
     "Gbanran",
-    "Central-Western Ijo"
+    "Central-Western Ijo",
+    "伊宗语"
   ],
   "ije": [
     "Biseni"
@@ -10303,7 +11278,8 @@
   "ijo-pro": [
     "原始伊爵語",
     "Proto-Ijoid",
-    "Proto-Ijaw"
+    "Proto-Ijaw",
+    "原始伊爵语"
   ],
   "ijs": [
     "Southeast Ijo",
@@ -10311,11 +11287,13 @@
     "Nembe"
   ],
   "ik": [
-    "伊努皮克語"
+    "伊努皮克語",
+    "伊努皮克语"
   ],
   "ike": [
     "東加拿大伊努克提圖特語",
-    "Eastern Canadian Inuktitut"
+    "Eastern Canadian Inuktitut",
+    "东加拿大伊努克提图特语"
   ],
   "iki": [
     "Iko"
@@ -10337,14 +11315,16 @@
     "伊卡蘭加爾語",
     "Ikaranggal",
     "Ikarranggal",
-    "Ikarranggali"
+    "Ikarranggali",
+    "伊卡兰加尔语"
   ],
   "iks": [
     "因紐特手語",
     "Inuit Sign Language",
     "Inuit Uukturausingit",
     "ISL",
-    "IUR"
+    "IUR",
+    "因纽特手语"
   ],
   "ikt": [
     "Inuvialuktun",
@@ -10363,14 +11343,16 @@
   ],
   "ikz": [
     "伊基祖語",
-    "Ikizu"
+    "Ikizu",
+    "伊基祖语"
   ],
   "ila": [
     "Ile Ape"
   ],
   "ilb": [
     "伊拉語",
-    "Ila"
+    "Ila",
+    "伊拉语"
   ],
   "ilg": [
     "Ilgar",
@@ -10387,16 +11369,19 @@
     "Iranun",
     "Ilanun",
     "Iranun (Malaysia)",
-    "Iranun (Philippines)"
+    "Iranun (Philippines)",
+    "伊拉努语"
   ],
   "ilo": [
     "伊洛卡諾語",
     "Ilokano",
-    "Ikokano"
+    "Ikokano",
+    "伊洛卡诺语"
   ],
   "ils": [
     "國際手語",
-    "International Sign"
+    "International Sign",
+    "国际手语"
   ],
   "ilu": [
     "Ili'uun"
@@ -10417,7 +11402,8 @@
   ],
   "imn": [
     "伊蒙達語",
-    "Imonda"
+    "Imonda",
+    "伊蒙达语"
   ],
   "imo": [
     "Imbongu",
@@ -10429,150 +11415,183 @@
   ],
   "ims": [
     "馬爾西語",
-    "Marsian"
+    "Marsian",
+    "马尔西语"
   ],
   "imy": [
     "彌呂亞語",
-    "Milyan"
+    "Milyan",
+    "弥吕亚语"
   ],
   "inb": [
     "Inga"
   ],
   "inc-ash": [
     "阿輸迦普拉克里特語",
-    "Ashokan Prakrit"
+    "Ashokan Prakrit",
+    "阿输迦普拉克里特语"
   ],
   "inc-cen-pro": [
     "原始中印度-雅利安語",
-    "Proto-Central Indo-Aryan"
+    "Proto-Central Indo-Aryan",
+    "原始中印度-雅利安语"
   ],
   "inc-dar-pro": [
     "原始達爾德語",
     "Proto-Dardic",
-    "Proto-Rigvedic"
+    "Proto-Rigvedic",
+    "原始达尔德语"
   ],
   "inc-gup": [
     "古爾扎爾阿帕布拉姆沙語",
-    "Gurjar Apabhramsa"
+    "Gurjar Apabhramsa",
+    "古尔扎尔阿帕布拉姆沙语"
   ],
   "inc-kam": [
     "迦摩縷波俗語",
-    "Kamarupi Prakrit"
+    "Kamarupi Prakrit",
+    "迦摩缕波俗语"
   ],
   "inc-kha": [
     "卡薩俗語",
-    "Khasa Prakrit"
+    "Khasa Prakrit",
+    "卡萨俗语"
   ],
   "inc-kho": [
     "科羅斯語",
-    "Kholosi"
+    "Kholosi",
+    "科罗斯语"
   ],
   "inc-mas": [
     "中古阿薩姆語",
-    "Middle Assamese"
+    "Middle Assamese",
+    "中古阿萨姆语"
   ],
   "inc-mbn": [
     "中古孟加拉語",
-    "Middle Bengali"
+    "Middle Bengali",
+    "中古孟加拉语"
   ],
   "inc-mgd": [
     "摩揭陀俗語",
-    "Magadhi Prakrit"
+    "Magadhi Prakrit",
+    "摩揭陀俗语"
   ],
   "inc-mgu": [
     "中古古吉拉特語",
-    "Middle Gujarati"
+    "Middle Gujarati",
+    "中古古吉拉特语"
   ],
   "inc-mor": [
     "中古奧里亞語",
-    "Middle Oriya"
+    "Middle Oriya",
+    "中古奥里亚语"
   ],
   "inc-oas": [
     "古阿薩姆語",
     "Early Assamese",
-    "Old Assamese"
+    "Old Assamese",
+    "古阿萨姆语"
   ],
   "inc-obn": [
     "古孟加拉語",
-    "Old Bengali"
+    "Old Bengali",
+    "古孟加拉语"
   ],
   "inc-ogu": [
     "古古吉拉特語",
     "Old Gujarati",
-    "Old Western Rajasthani"
+    "Old Western Rajasthani",
+    "古古吉拉特语"
   ],
   "inc-ohi": [
     "古印地語",
-    "Old Hindi"
+    "Old Hindi",
+    "古印地语"
   ],
   "inc-oor": [
     "古奧里亞語",
-    "Old Oriya"
+    "Old Oriya",
+    "古奥里亚语"
   ],
   "inc-opa": [
     "古旁遮普語",
-    "Old Punjabi"
+    "Old Punjabi",
+    "古旁遮普语"
   ],
   "inc-ork": [
     "Old Kamta"
   ],
   "inc-pra": [
     "普拉克里特語",
-    "Prakrit"
+    "Prakrit",
+    "普拉克里特语"
   ],
   "inc-pro": [
     "原始印度-雅利安語",
-    "Proto-Indo-Aryan"
+    "Proto-Indo-Aryan",
+    "原始印度-雅利安语"
   ],
   "inc-psc": [
     "白夏基普拉克里特語",
-    "Paisaci Prakrit"
+    "Paisaci Prakrit",
+    "白夏基普拉克里特语"
   ],
   "inc-sap": [
     "索拉塞尼阿帕布拉姆沙語",
-    "Sauraseni Apabhramsa"
+    "Sauraseni Apabhramsa",
+    "索拉塞尼阿帕布拉姆沙语"
   ],
   "inc-tak": [
     "磔迦阿帕布拉姆沙語",
-    "Takka Apabhramsa"
+    "Takka Apabhramsa",
+    "磔迦阿帕布拉姆沙语"
   ],
   "inc-vra": [
     "沃拉恰達阿帕布拉姆沙語",
-    "Proto-Anatolian"
+    "Proto-Anatolian",
+    "沃拉恰达阿帕布拉姆沙语"
   ],
   "ine-ana-pro": [
     "原始安納托利亞語",
-    "Proto-Anatolian"
+    "Proto-Anatolian",
+    "原始安纳托利亚语"
   ],
   "ine-bsl-pro": [
     "原始波羅的-斯拉夫語",
-    "Proto-Balto-Slavic"
+    "Proto-Balto-Slavic",
+    "原始波罗的-斯拉夫语"
   ],
   "ine-pae": [
     "培奧尼亞語",
-    "Paeonian"
+    "Paeonian",
+    "培奥尼亚语"
   ],
   "ine-pro": [
     "原始印歐語",
-    "Proto-Indo-European"
+    "Proto-Indo-European",
+    "原始印欧语"
   ],
   "ine-toc-pro": [
     "原始吐火羅語",
-    "Proto-Tocharian"
+    "Proto-Tocharian",
+    "原始吐火罗语"
   ],
   "ing": [
     "Deg Xinag"
   ],
   "inh": [
     "印古什語",
-    "Ingush"
+    "Ingush",
+    "印古什语"
   ],
   "inj": [
     "Jungle Inga"
   ],
   "inl": [
     "印尼手語",
-    "Indonesian Sign Language"
+    "Indonesian Sign Language",
+    "印尼手语"
   ],
   "inm": [
     "Minaean"
@@ -10588,17 +11607,20 @@
   ],
   "ins": [
     "印度手語",
-    "Indian Sign Language"
+    "Indian Sign Language",
+    "印度手语"
   ],
   "int": [
     "Intha"
   ],
   "inz": [
     "伊內塞諾語",
-    "Ineseño"
+    "Ineseño",
+    "伊内塞诺语"
   ],
   "io": [
-    "伊多語"
+    "伊多語",
+    "伊多语"
   ],
   "ior": [
     "Inor"
@@ -10638,46 +11660,56 @@
   ],
   "ira-mny-pro": [
     "原始蒙賈尼伊特格哈語",
-    "Proto-Munji-Yidgha"
+    "Proto-Munji-Yidgha",
+    "原始蒙贾尼伊特格哈语"
   ],
   "ira-mpr-pro": [
     "原始米底-安息語",
-    "Proto-Medo-Parthian"
+    "Proto-Medo-Parthian",
+    "原始米底-安息语"
   ],
   "ira-pat-pro": [
     "原始普什圖語",
-    "Proto-Pathan"
+    "Proto-Pathan",
+    "原始普什图语"
   ],
   "ira-pro": [
     "原始伊朗語",
-    "Proto-Iranian"
+    "Proto-Iranian",
+    "原始伊朗语"
   ],
   "ira-sgc-pro": [
     "原始粟特語",
-    "Proto-Sogdic"
+    "Proto-Sogdic",
+    "原始粟特语"
   ],
   "ira-sgi-pro": [
     "原始桑格萊奇伊什卡什米語",
-    "Proto-Sanglechi-Ishkashimi"
+    "Proto-Sanglechi-Ishkashimi",
+    "原始桑格莱奇伊什卡什米语"
   ],
   "ira-shr-pro": [
     "原始舒格南羅尚語",
-    "Proto-Shughni-Roshani"
+    "Proto-Shughni-Roshani",
+    "原始舒格南罗尚语"
   ],
   "ira-shy-pro": [
     "原始舒格南雅茲古拉米語",
-    "Proto-Shughni-Yazghulami"
+    "Proto-Shughni-Yazghulami",
+    "原始舒格南雅兹古拉米语"
   ],
   "ira-sym-pro": [
     "原始舒格南雅茲古拉米蒙賈尼語",
-    "Proto-Shughni-Yazghulami-Munji"
+    "Proto-Shughni-Yazghulami-Munji",
+    "原始舒格南雅兹古拉米蒙贾尼语"
   ],
   "ira-wnj": [
     "Vanji"
   ],
   "ira-zgr-pro": [
     "原始扎扎其古拉尼語",
-    "Proto-Zaza-Gorani"
+    "Proto-Zaza-Gorani",
+    "原始扎扎其古拉尼语"
   ],
   "ire": [
     "Iresim"
@@ -10701,27 +11733,32 @@
   ],
   "iro-min": [
     "明戈語",
-    "Mingo"
+    "Mingo",
+    "明戈语"
   ],
   "iro-pro": [
     "原始易洛魁語",
-    "Proto-Iroquoian"
+    "Proto-Iroquoian",
+    "原始易洛魁语"
   ],
   "irr": [
     "Ir"
   ],
   "iru": [
     "伊魯拉語",
-    "Irula"
+    "Irula",
+    "伊鲁拉语"
   ],
   "irx": [
     "Kamberau"
   ],
   "iry": [
-    "伊拉雅語"
+    "伊拉雅語",
+    "伊拉雅语"
   ],
   "is": [
-    "冰島語"
+    "冰島語",
+    "冰岛语"
   ],
   "isa": [
     "Isabi"
@@ -10732,19 +11769,23 @@
   "isd": [
     "伊斯納格語",
     "Isnag",
-    "Isneg"
+    "Isneg",
+    "伊斯纳格语"
   ],
   "ise": [
     "意大利手語",
-    "Italian Sign Language"
+    "Italian Sign Language",
+    "意大利手语"
   ],
   "isg": [
     "愛爾蘭手語",
-    "Irish Sign Language"
+    "Irish Sign Language",
+    "爱尔兰手语"
   ],
   "ish": [
     "埃桑語",
-    "Esan"
+    "Esan",
+    "埃桑语"
   ],
   "isi": [
     "Nkem-Nkum",
@@ -10755,7 +11796,8 @@
   ],
   "isk": [
     "伊什卡什米語",
-    "Ishkashimi"
+    "Ishkashimi",
+    "伊什卡什米语"
   ],
   "ism": [
     "Masimasi"
@@ -10768,18 +11810,21 @@
   ],
   "isr": [
     "以色列手語",
-    "Israeli Sign Language"
+    "Israeli Sign Language",
+    "以色列手语"
   ],
   "ist": [
     "伊斯特拉語",
-    "Istriot"
+    "Istriot",
+    "伊斯特拉语"
   ],
   "isu": [
     "Isu",
     "Isu (Menchum Division)"
   ],
   "it": [
-    "意大利語"
+    "意大利語",
+    "意大利语"
   ],
   "itb": [
     "Binongan Itneg"
@@ -10790,11 +11835,13 @@
     "Archaic Latin",
     "Early Latin",
     "Pre-Classical Latin",
-    "Ante-Classical Latin"
+    "Ante-Classical Latin",
+    "古拉丁语"
   ],
   "itc-pro": [
     "原始意大利語",
-    "Proto-Italic"
+    "Proto-Italic",
+    "原始意大利语"
   ],
   "itd": [
     "Southern Tidong",
@@ -10812,13 +11859,15 @@
   ],
   "itk": [
     "猶太-意大利語",
-    "Judeo-Italian"
+    "Judeo-Italian",
+    "犹太-意大利语"
   ],
   "itl": [
     "伊捷爾緬語",
     "Itelmen",
     "Western Itelmen",
-    "Kamchadal"
+    "Kamchadal",
+    "伊捷尔缅语"
   ],
   "itm": [
     "Itu Mbon Uzo"
@@ -10848,7 +11897,8 @@
   ],
   "itx": [
     "伊蒂克語",
-    "Itik"
+    "Itik",
+    "伊蒂克语"
   ],
   "ity": [
     "Moyadan Itneg"
@@ -10858,14 +11908,17 @@
     "Itzá",
     "Itza’",
     "Itza",
-    "Itzaj"
+    "Itzaj",
+    "伊特扎语"
   ],
   "iu": [
-    "因紐特語"
+    "因紐特語",
+    "因纽特语"
   ],
   "ium": [
     "勉語",
-    "Iu Mien"
+    "Iu Mien",
+    "勉语"
   ],
   "ivb": [
     "伊巴丹語",
@@ -10875,14 +11928,16 @@
     "Itbayaten",
     "Babuyan",
     "Isamurongen",
-    "Ivatan"
+    "Ivatan",
+    "伊巴丹语"
   ],
   "ivv": [
     "伊萬特語",
     "Ivatan",
     "Ivatanen",
     "Basco Ivatan",
-    "Ivasayen"
+    "Ivasayen",
+    "伊万特语"
   ],
   "iwk": [
     "I-Wak"
@@ -10898,12 +11953,14 @@
   ],
   "ixc": [
     "伊斯卡特語",
-    "Ixcatec"
+    "Ixcatec",
+    "伊斯卡特语"
   ],
   "ixl": [
     "伊克西爾語",
     "Ixil",
-    "Ixhil"
+    "Ixhil",
+    "伊克西尔语"
   ],
   "iya": [
     "Iyayu"
@@ -10921,7 +11978,10 @@
     "伊喬里亞語",
     "伊喬拉語",
     "Ingrian",
-    "Izhorian"
+    "Izhorian",
+    "英格里亚语",
+    "伊乔里亚语",
+    "伊乔拉语"
   ],
   "izi": [
     "Izi-Ezaa-Ikwo-Mgbo"
@@ -10935,7 +11995,8 @@
     "Izzi"
   ],
   "ja": [
-    "日語"
+    "日語",
+    "日语"
   ],
   "jaa": [
     "Jamamadí",
@@ -10986,7 +12047,8 @@
     "Jamaican",
     "Jamaican Patois",
     "Patois",
-    "Patwa"
+    "Patwa",
+    "牙买加克里奥尔语"
   ],
   "jan": [
     "Janday",
@@ -11005,7 +12067,8 @@
   ],
   "jao": [
     "揚尤瓦語",
-    "Yanyuwa"
+    "Yanyuwa",
+    "扬尤瓦语"
   ],
   "jaq": [
     "Yaqay"
@@ -11030,7 +12093,8 @@
   ],
   "jbe": [
     "猶太-柏柏爾語",
-    "Judeo-Berber"
+    "Judeo-Berber",
+    "犹太-柏柏尔语"
   ],
   "jbj": [
     "Arandai"
@@ -11048,7 +12112,8 @@
   ],
   "jbo": [
     "邏輯語",
-    "Lojban"
+    "Lojban",
+    "逻辑语"
   ],
   "jbr": [
     "Jofotek-Bromnya"
@@ -11072,21 +12137,24 @@
   ],
   "jct": [
     "克里姆查克語",
-    "Krymchak"
+    "Krymchak",
+    "克里姆查克语"
   ],
   "jda": [
     "Jad"
   ],
   "jdg": [
     "賈德加里語",
-    "Jadgali"
+    "Jadgali",
+    "贾德加里语"
   ],
   "jdt": [
     "猶太-塔特語",
     "Judeo-Tat",
     "Juhuri",
     "Juvuri",
-    "Juwuri"
+    "Juwuri",
+    "犹太-塔特语"
   ],
   "jeb": [
     "Jebero"
@@ -11130,14 +12198,16 @@
     "猶太-格魯吉亞語",
     "Judeo-Georgian",
     "Kivruli",
-    "Gruzinic"
+    "Gruzinic",
+    "犹太-格鲁吉亚语"
   ],
   "jgk": [
     "Gwak",
     "Gingwak"
   ],
   "jgo": [
-    "恩格姆巴語"
+    "恩格姆巴語",
+    "恩格姆巴语"
   ],
   "jhi": [
     "Jehai"
@@ -11168,7 +12238,8 @@
   ],
   "jih": [
     "上寨語",
-    "Shangzhai"
+    "Shangzhai",
+    "上寨语"
   ],
   "jii": [
     "Jiiddu"
@@ -11183,7 +12254,8 @@
   ],
   "jio": [
     "加茂語",
-    "Jiamao"
+    "Jiamao",
+    "加茂语"
   ],
   "jiq": [
     "Guanyinqiao"
@@ -11204,7 +12276,8 @@
     "濟州語",
     "Jeju",
     "Cheju",
-    "Jejueo"
+    "Jejueo",
+    "济州语"
   ],
   "jjr": [
     "Zhár",
@@ -11236,11 +12309,13 @@
     "Zumbun"
   ],
   "jmc": [
-    "馬恰美語"
+    "馬恰美語",
+    "马恰美语"
   ],
   "jmd": [
     "延德納語",
-    "Yamdena"
+    "Yamdena",
+    "延德纳语"
   ],
   "jmi": [
     "Jimi",
@@ -11248,7 +12323,8 @@
   ],
   "jml": [
     "瓊里語",
-    "Jumli"
+    "Jumli",
+    "琼里语"
   ],
   "jmn": [
     "Makuri Naga"
@@ -11263,7 +12339,8 @@
   ],
   "jmx": [
     "西尤斯特拉瓦卡米斯特克語",
-    "Western Juxtlahuaca Mixtec"
+    "Western Juxtlahuaca Mixtec",
+    "西尤斯特拉瓦卡米斯特克语"
   ],
   "jna": [
     "Jangshung"
@@ -11273,7 +12350,8 @@
   ],
   "jng": [
     "揚曼語",
-    "Yangman"
+    "Yangman",
+    "扬曼语"
   ],
   "jni": [
     "Janji"
@@ -11293,7 +12371,8 @@
   ],
   "jns": [
     "焦恩沙里語",
-    "Jaunsari"
+    "Jaunsari",
+    "焦恩沙里语"
   ],
   "job": [
     "Joba"
@@ -11316,26 +12395,31 @@
     "Judeo-Persian",
     "Jidi",
     "Dzhidi",
-    "Djudi"
+    "Djudi",
+    "犹太-波斯语"
   ],
   "jpx-pro": [
     "原始日語",
-    "Proto-Japonic"
+    "Proto-Japonic",
+    "原始日语"
   ],
   "jpx-ryu-pro": [
     "原始琉球語",
-    "Proto-Ryukyuan"
+    "Proto-Ryukyuan",
+    "原始琉球语"
   ],
   "jqr": [
     "Jaqaru"
   ],
   "jra": [
     "嘉萊語",
-    "Jarai"
+    "Jarai",
+    "嘉莱语"
   ],
   "jrb": [
     "猶太-阿拉伯語",
-    "Judeo-Arabic"
+    "Judeo-Arabic",
+    "犹太-阿拉伯语"
   ],
   "jrr": [
     "Jiru"
@@ -11345,7 +12429,8 @@
   ],
   "jsl": [
     "日本手語",
-    "Japanese Sign Language"
+    "Japanese Sign Language",
+    "日本手语"
   ],
   "jua": [
     "Júma"
@@ -11355,7 +12440,8 @@
   ],
   "juc": [
     "女真語",
-    "Jurchen"
+    "Jurchen",
+    "女真语"
   ],
   "jud": [
     "Worodougou"
@@ -11368,14 +12454,16 @@
   ],
   "jui": [
     "恩加朱里語",
-    "Ngadjuri"
+    "Ngadjuri",
+    "恩加朱里语"
   ],
   "juk": [
     "Wapan"
   ],
   "jul": [
     "幾熱爾語",
-    "Jirel"
+    "Jirel",
+    "几热尔语"
   ],
   "jum": [
     "Jumjum"
@@ -11402,7 +12490,8 @@
   "jut": [
     "日德蘭語",
     "Jutish",
-    "Jutlandic"
+    "Jutlandic",
+    "日德兰语"
   ],
   "juu": [
     "Ju"
@@ -11414,40 +12503,47 @@
     "Juray"
   ],
   "jv": [
-    "爪哇語"
+    "爪哇語",
+    "爪哇语"
   ],
   "jvd": [
     "Javindo"
   ],
   "jvn": [
     "加勒比爪哇語",
-    "Caribbean Javanese"
+    "Caribbean Javanese",
+    "加勒比爪哇语"
   ],
   "jwi": [
     "Jwira-Pepesa"
   ],
   "jye": [
     "猶太-葉門阿拉伯語",
-    "Judeo-Yemeni Arabic"
+    "Judeo-Yemeni Arabic",
+    "犹太-叶门阿拉伯语"
   ],
   "jyy": [
     "Jaya"
   ],
   "ka": [
-    "格魯吉亞語"
+    "格魯吉亞語",
+    "格鲁吉亚语"
   ],
   "kaa": [
     "卡拉卡爾帕克語",
-    "Karakalpak"
+    "Karakalpak",
+    "卡拉卡尔帕克语"
   ],
   "kab": [
     "卡拜爾語",
-    "Kabyle"
+    "Kabyle",
+    "卡拜尔语"
   ],
   "kac": [
     "景頗語",
     "Jingpho",
-    "Kachin"
+    "Kachin",
+    "景颇语"
   ],
   "kad": [
     "Kadara"
@@ -11456,7 +12552,9 @@
     "凱達格蘭語",
     "Ketangalan",
     "Luilang",
-    "雷朗語"
+    "雷朗語",
+    "凯达格兰语",
+    "雷朗语"
   ],
   "kaf": [
     "Katso",
@@ -11473,18 +12571,23 @@
     "Karekare"
   ],
   "kaj": [
-    "卡捷語"
+    "卡捷語",
+    "卡捷语"
   ],
   "kak": [
     "卡亞帕卡拉漢語",
-    "Kayapa Kallahan"
+    "Kayapa Kallahan",
+    "卡亚帕卡拉汉语"
   ],
   "kam": [
     "卡姆巴語",
     "Kamba",
     "Kikamba",
     "坎巴語",
-    "康巴語"
+    "康巴語",
+    "卡姆巴语",
+    "坎巴语",
+    "康巴语"
   ],
   "kao": [
     "Kassonke",
@@ -11497,7 +12600,8 @@
     "Bezhta",
     "Bezheta",
     "Kapucha",
-    "Bezhita"
+    "Bezhita",
+    "别日塔语"
   ],
   "kaq": [
     "Capanahua",
@@ -11505,12 +12609,14 @@
   ],
   "kar-pro": [
     "原始克倫語",
-    "Proto-Karen"
+    "Proto-Karen",
+    "原始克伦语"
   ],
   "kaw": [
     "古爪哇語",
     "Old Javanese",
-    "Kawi"
+    "Kawi",
+    "古爪哇语"
   ],
   "kax": [
     "Kao"
@@ -11520,7 +12626,8 @@
   ],
   "kba": [
     "卡拉爾科語",
-    "Kalarko"
+    "Kalarko",
+    "卡拉尔科语"
   ],
   "kbb": [
     "Kaxuyana",
@@ -11542,7 +12649,8 @@
   "kbd": [
     "卡巴爾達語",
     "Kabardian",
-    "East Circassian"
+    "East Circassian",
+    "卡巴尔达语"
   ],
   "kbe": [
     "坎朱語",
@@ -11554,7 +12662,8 @@
     "Gandanju",
     "Kamdhue",
     "Kandyu",
-    "Kanyu"
+    "Kanyu",
+    "坎朱语"
   ],
   "kbh": [
     "Camsá"
@@ -11602,7 +12711,8 @@
   ],
   "kbu": [
     "卡布特拉語",
-    "Kabutra"
+    "Kabutra",
+    "卡布特拉语"
   ],
   "kbv": [
     "Kamberataro",
@@ -11620,7 +12730,8 @@
   ],
   "kca": [
     "漢特語",
-    "Khanty"
+    "Khanty",
+    "汉特语"
   ],
   "kcb": [
     "Kawacha"
@@ -11638,7 +12749,8 @@
     "Ukaan"
   ],
   "kcg": [
-    "卡塔布語"
+    "卡塔布語",
+    "卡塔布语"
   ],
   "kch": [
     "Vono"
@@ -11708,17 +12820,20 @@
     "Gadhang",
     "Gadjang",
     "Kattang",
-    "Kutthung"
+    "Kutthung",
+    "沃里米语"
   ],
   "kdc": [
     "Kutu"
   ],
   "kdd": [
     "揚昆塔賈拉語",
-    "Yankunytjatjara"
+    "Yankunytjatjara",
+    "扬昆塔贾拉语"
   ],
   "kde": [
-    "馬孔德語"
+    "馬孔德語",
+    "马孔德语"
   ],
   "kdf": [
     "Mamusi"
@@ -11735,7 +12850,8 @@
   ],
   "kdj": [
     "卡拉莫瓊語",
-    "Karamojong"
+    "Karamojong",
+    "卡拉莫琼语"
   ],
   "kdk": [
     "Numee"
@@ -11754,11 +12870,13 @@
   ],
   "kdq": [
     "科奇語",
-    "Koch"
+    "Koch",
+    "科奇语"
   ],
   "kdr": [
     "卡拉伊姆語",
-    "Karaim"
+    "Karaim",
+    "卡拉伊姆语"
   ],
   "kdt": [
     "Kuy"
@@ -11794,7 +12912,8 @@
     "Kriolu",
     "Creole",
     "Barlavento",
-    "Sotavento"
+    "Sotavento",
+    "佛得角克里奥尔语"
   ],
   "keb": [
     "Kélé"
@@ -11825,7 +12944,8 @@
   ],
   "kek": [
     "凱克奇語",
-    "Q'eqchi"
+    "Q'eqchi",
+    "凯克奇语"
   ],
   "kel": [
     "Kela-Yela",
@@ -11834,10 +12954,12 @@
   ],
   "kem": [
     "克馬克語",
-    "Kemak"
+    "Kemak",
+    "克马克语"
   ],
   "ken": [
-    "肯揚語"
+    "肯揚語",
+    "肯扬语"
   ],
   "keo": [
     "Kakwa"
@@ -11847,7 +12969,8 @@
   ],
   "keq": [
     "卡馬爾語",
-    "Kamar"
+    "Kamar",
+    "卡马尔语"
   ],
   "ker": [
     "Kera"
@@ -11856,7 +12979,8 @@
     "Kugbo"
   ],
   "ket": [
-    "凱特語"
+    "凱特語",
+    "凯特语"
   ],
   "keu": [
     "Akebu"
@@ -11874,11 +12998,13 @@
   ],
   "kex": [
     "庫克納語",
-    "Kukna"
+    "Kukna",
+    "库克纳语"
   ],
   "key": [
     "庫皮亞語",
-    "Kupia"
+    "Kupia",
+    "库皮亚语"
   ],
   "kez": [
     "Kukele"
@@ -11888,7 +13014,8 @@
   ],
   "kfb": [
     "科拉米語",
-    "Kolami"
+    "Kolami",
+    "科拉米语"
   ],
   "kfc": [
     "Konda-Dora"
@@ -11917,7 +13044,8 @@
   ],
   "kfk": [
     "金瑙里語",
-    "Kinnauri"
+    "Kinnauri",
+    "金瑙里语"
   ],
   "kfl": [
     "Kung"
@@ -11928,7 +13056,8 @@
   "kfo": [
     "科羅語（西非）",
     "Koro",
-    "Koro Jula"
+    "Koro Jula",
+    "科罗语（西非）"
   ],
   "kfp": [
     "Korwa"
@@ -11942,23 +13071,28 @@
     "Kutchi",
     "Cutchi",
     "Kachchhi",
-    "Kutchhi"
+    "Kutchhi",
+    "喀奇语"
   ],
   "kfs": [
     "比拉斯普里語",
-    "Bilaspuri"
+    "Bilaspuri",
+    "比拉斯普里语"
   ],
   "kft": [
     "坎賈里語",
-    "Kanjari"
+    "Kanjari",
+    "坎贾里语"
   ],
   "kfu": [
     "卡特卡里語",
-    "Katkari"
+    "Katkari",
+    "卡特卡里语"
   ],
   "kfv": [
     "庫爾穆卡爾語",
-    "Kurmukar"
+    "Kurmukar",
+    "库尔穆卡尔语"
   ],
   "kfw": [
     "Kharam Naga",
@@ -11967,7 +13101,8 @@
   "kfx": [
     "庫魯帕哈里語",
     "Kullu Pahari",
-    "Kullu"
+    "Kullu",
+    "库鲁帕哈里语"
   ],
   "kfy": [
     "Kumaoni"
@@ -11976,7 +13111,8 @@
     "Koromfé"
   ],
   "kg": [
-    "剛果語"
+    "剛果語",
+    "刚果语"
   ],
   "kga": [
     "Koyaga"
@@ -11995,11 +13131,13 @@
   ],
   "kgg": [
     "庫松達語",
-    "Kusunda"
+    "Kusunda",
+    "库松达语"
   ],
   "kgi": [
     "雪蘭莪手語",
-    "Selangor Sign Language"
+    "Selangor Sign Language",
+    "雪兰莪手语"
   ],
   "kgj": [
     "Gamale Kham"
@@ -12009,7 +13147,8 @@
   ],
   "kgl": [
     "昆加里語",
-    "Kunggari"
+    "Kunggari",
+    "昆加里语"
   ],
   "kgm": [
     "Karipúna"
@@ -12017,13 +13156,15 @@
   "kgn": [
     "卡林加里語",
     "Karingani",
-    "Keringani"
+    "Keringani",
+    "卡林加里语"
   ],
   "kgo": [
     "Krongo"
   ],
   "kgp": [
-    "坎剛語"
+    "坎剛語",
+    "坎刚语"
   ],
   "kgq": [
     "Kamoro"
@@ -12033,7 +13174,8 @@
   ],
   "kgs": [
     "貢邦加爾語",
-    "Kumbainggar"
+    "Kumbainggar",
+    "贡邦加尔语"
   ],
   "kgt": [
     "Somyev"
@@ -12054,10 +13196,12 @@
     "Kyerung"
   ],
   "kha": [
-    "卡西語"
+    "卡西語",
+    "卡西语"
   ],
   "khb": [
-    "傣仂語"
+    "傣仂語",
+    "傣仂语"
   ],
   "khc": [
     "Tukang Besi North"
@@ -12073,14 +13217,16 @@
   ],
   "khg": [
     "康巴藏語",
-    "Khams Tibetan"
+    "Khams Tibetan",
+    "康巴藏语"
   ],
   "khh": [
     "Kehu"
   ],
   "khi-kho-pro": [
     "原始科伊語",
-    "Proto-Khoe"
+    "Proto-Khoe",
+    "原始科伊语"
   ],
   "khi-kun": [
     "亢語",
@@ -12090,7 +13236,8 @@
     "Kung",
     "Ekoka ǃKung",
     "Ekoka Kung",
-    "Sekele"
+    "Sekele",
+    "亢语"
   ],
   "khj": [
     "Kuturmi"
@@ -12100,11 +13247,13 @@
   ],
   "khn": [
     "堪德斯語",
-    "Khandeshi"
+    "Khandeshi",
+    "堪德斯语"
   ],
   "kho": [
     "和闐語",
-    "Khotanese"
+    "Khotanese",
+    "和阗语"
   ],
   "khp": [
     "Kapauri"
@@ -12112,11 +13261,13 @@
   "khq": [
     "西桑海語",
     "Western Songhay",
-    "Koyra Chiini Songhay"
+    "Koyra Chiini Songhay",
+    "西桑海语"
   ],
   "khr": [
     "卡里亞語",
-    "Kharia"
+    "Kharia",
+    "卡里亚语"
   ],
   "khs": [
     "Kasua"
@@ -12124,7 +13275,8 @@
   "kht": [
     "坎底語",
     "Khamti",
-    "Tai Khamti"
+    "Tai Khamti",
+    "坎底语"
   ],
   "khu": [
     "Nkhumbi"
@@ -12134,11 +13286,13 @@
     "Khvarshi",
     "Khwarshi",
     "Xvarshi",
-    "Inkhokvari"
+    "Inkhokvari",
+    "赫瓦尔什语"
   ],
   "khw": [
     "科瓦語",
-    "Khowar"
+    "Khowar",
+    "科瓦语"
   ],
   "khy": [
     "Ekele",
@@ -12149,10 +13303,12 @@
   ],
   "khz": [
     "凱帕拉語",
-    "Keapara"
+    "Keapara",
+    "凯帕拉语"
   ],
   "ki": [
-    "基庫尤語"
+    "基庫尤語",
+    "基库尤语"
   ],
   "kia": [
     "Kim"
@@ -12184,7 +13340,8 @@
   ],
   "kij": [
     "基里維納語",
-    "Kilivila"
+    "Kilivila",
+    "基里维纳语"
   ],
   "kil": [
     "Kariya"
@@ -12193,7 +13350,8 @@
     "圖法語",
     "Tofa",
     "Tofalar",
-    "Karagas"
+    "Karagas",
+    "图法语"
   ],
   "kio": [
     "Kiowa"
@@ -12215,7 +13373,8 @@
   ],
   "kiw": [
     "東北基瓦伊語",
-    "Northeast Kiwai"
+    "Northeast Kiwai",
+    "东北基瓦伊语"
   ],
   "kix": [
     "Khiamniungan Naga"
@@ -12228,33 +13387,39 @@
     "Kisi"
   ],
   "kj": [
-    "寬亞瑪語"
+    "寬亞瑪語",
+    "宽亚玛语"
   ],
   "kja": [
     "Mlap"
   ],
   "kjb": [
     "坎霍瓦爾語",
-    "Q'anjob'al"
+    "Q'anjob'al",
+    "坎霍瓦尔语"
   ],
   "kjc": [
     "孔喬語",
-    "Coastal Konjo"
+    "Coastal Konjo",
+    "孔乔语"
   ],
   "kjd": [
     "南基瓦伊語",
-    "Southern Kiwai"
+    "Southern Kiwai",
+    "南基瓦伊语"
   ],
   "kje": [
     "Kisar"
   ],
   "kjg": [
     "克木語",
-    "Khmu"
+    "Khmu",
+    "克木语"
   ],
   "kjh": [
     "哈卡斯語",
-    "Khakas"
+    "Khakas",
+    "哈卡斯语"
   ],
   "kji": [
     "Zabana"
@@ -12265,11 +13430,13 @@
     "Khinalig",
     "Xinalug",
     "Xinalugh",
-    "Khinalugh"
+    "Khinalugh",
+    "奇纳鲁格语"
   ],
   "kjk": [
     "高地孔喬語",
-    "Highland Konjo"
+    "Highland Konjo",
+    "高地孔乔语"
   ],
   "kjl": [
     "Kham"
@@ -12292,14 +13459,17 @@
     "Kawarrangg",
     "Athima",
     "Uw",
-    "Kunjen-Undjan-Athima"
+    "Kunjen-Undjan-Athima",
+    "昆坚语"
   ],
   "kjo": [
     "哈里詹金瑙里語",
-    "Harijan Kinnauri"
+    "Harijan Kinnauri",
+    "哈里詹金瑙里语"
   ],
   "kjp": [
-    "東波克倫語"
+    "東波克倫語",
+    "东波克伦语"
   ],
   "kjq": [
     "Western Keres"
@@ -12315,7 +13485,8 @@
   ],
   "kju": [
     "卡沙亞語",
-    "Kashaya"
+    "Kashaya",
+    "卡沙亚语"
   ],
   "kjx": [
     "Ramopa",
@@ -12328,7 +13499,8 @@
     "Bumthangkha"
   ],
   "kk": [
-    "哈薩克語"
+    "哈薩克語",
+    "哈萨克语"
   ],
   "kka": [
     "Kakanda"
@@ -12350,20 +13522,23 @@
   ],
   "kkg": [
     "瑪巴佳卡林阿語",
-    "Mabaka Valley Kalinga"
+    "Mabaka Valley Kalinga",
+    "玛巴佳卡林阿语"
   ],
   "kkh": [
     "傣痕語",
     "Khün",
     "Tai Khün",
-    "Dai Kun"
+    "Dai Kun",
+    "傣痕语"
   ],
   "kki": [
     "Kagulu",
     "Kaguru"
   ],
   "kkj": [
-    "卡庫語"
+    "卡庫語",
+    "卡库语"
   ],
   "kkk": [
     "Kokota"
@@ -12386,7 +13561,8 @@
     "Koko-Bera",
     "Kok-Kaper",
     "Gugubera",
-    "Koko-Pera"
+    "Koko-Pera",
+    "古古-贝拉语"
   ],
   "kkq": [
     "Kaiku"
@@ -12415,14 +13591,17 @@
     "Kohin"
   ],
   "kky": [
-    "辜古依密舍語"
+    "辜古依密舍語",
+    "辜古依密舍语"
   ],
   "kkz": [
     "卡斯卡語",
-    "Kaska"
+    "Kaska",
+    "卡斯卡语"
   ],
   "kl": [
-    "格陵蘭語"
+    "格陵蘭語",
+    "格陵兰语"
   ],
   "kla": [
     "Klamath-Modoc",
@@ -12441,7 +13620,9 @@
     "Kamilaroi",
     "Kamilarai",
     "Kamalarai",
-    "Gamilaroi"
+    "Gamilaroi",
+    "卡米拉瑞语",
+    "加米拉拉埃语"
   ],
   "kle": [
     "Kulung"
@@ -12451,7 +13632,8 @@
   ],
   "klg": [
     "達雅高路加拉岸語",
-    "Tagakaulu Kalagan"
+    "Tagakaulu Kalagan",
+    "达雅高路加拉岸语"
   ],
   "klh": [
     "Weliki"
@@ -12463,7 +13645,8 @@
     "哈拉吉語",
     "Khalaj",
     "Turkic Khalaj",
-    "Arghu"
+    "Arghu",
+    "哈拉吉语"
   ],
   "klk": [
     "Kono (Nigeria)",
@@ -12478,7 +13661,8 @@
   ],
   "kln": [
     "卡倫金語",
-    "Kalenjin"
+    "Kalenjin",
+    "卡伦金语"
   ],
   "klo": [
     "Kapya"
@@ -12491,11 +13675,13 @@
   ],
   "klr": [
     "喀靈語",
-    "Khaling"
+    "Khaling",
+    "喀灵语"
   ],
   "kls": [
     "卡拉什語",
-    "Kalasha"
+    "Kalasha",
+    "卡拉什语"
   ],
   "klt": [
     "Nukna"
@@ -12505,12 +13691,14 @@
   ],
   "klv": [
     "馬斯克林斯語",
-    "Maskelynes"
+    "Maskelynes",
+    "马斯克林斯语"
   ],
   "klw": [
     "林杜語",
     "Lindu",
-    "Tado"
+    "Tado",
+    "林杜语"
   ],
   "klx": [
     "Koluwawa"
@@ -12522,22 +13710,26 @@
     "Kabola"
   ],
   "km": [
-    "高棉語"
+    "高棉語",
+    "高棉语"
   ],
   "kma": [
     "孔尼語",
-    "Konni"
+    "Konni",
+    "孔尼语"
   ],
   "kmb": [
     "金邦杜語",
     "Kimbundu",
-    "North Mbundu"
+    "North Mbundu",
+    "金邦杜语"
   ],
   "kmc": [
     "南侗語",
     "Southern Kam",
     "Southern Gam",
-    "Southern Dong"
+    "Southern Dong",
+    "南侗语"
   ],
   "kmd": [
     "Madukayang Kalinga"
@@ -12568,13 +13760,15 @@
   ],
   "kmk": [
     "利莫斯卡林阿語",
-    "Limos Kalinga"
+    "Limos Kalinga",
+    "利莫斯卡林阿语"
   ],
   "kml": [
     "大努丹卡林阿語",
     "Tanudan Kalinga",
     "Lower Tanudan Kalinga",
-    "Upper Tanudan Kalinga"
+    "Upper Tanudan Kalinga",
+    "大努丹卡林阿语"
   ],
   "kmm": [
     "Kom (India)",
@@ -12595,7 +13789,8 @@
   "kmr": [
     "北庫爾德語",
     "Northern Kurdish",
-    "Kurmanji"
+    "Kurmanji",
+    "北库尔德语"
   ],
   "kms": [
     "Kamasau"
@@ -12627,10 +13822,12 @@
   "kmz": [
     "呼羅珊尼土耳其語",
     "Khorasani Turkish",
-    "Khorasani Turkic"
+    "Khorasani Turkic",
+    "呼罗珊尼土耳其语"
   ],
   "kn": [
-    "卡納達語"
+    "卡納達語",
+    "卡纳达语"
   ],
   "kna": [
     "Kanakuru",
@@ -12639,18 +13836,21 @@
   ],
   "knb": [
     "盧布阿甘卡林阿語",
-    "Lubuagan Kalinga"
+    "Lubuagan Kalinga",
+    "卢布阿甘卡林阿语"
   ],
   "knd": [
     "Konda"
   ],
   "kne": [
     "坎卡奈語",
-    "Kankanaey"
+    "Kankanaey",
+    "坎卡奈语"
   ],
   "knf": [
     "曼卡尼亞語",
-    "Mankanya"
+    "Mankanya",
+    "曼卡尼亚语"
   ],
   "kni": [
     "Kanufi"
@@ -12725,11 +13925,13 @@
     "Kalamsé"
   ],
   "ko": [
-    "朝鮮語"
+    "朝鮮語",
+    "朝鲜语"
   ],
   "ko-ear": [
     "近世朝鮮語",
-    "Early Modern Korean"
+    "Early Modern Korean",
+    "近世朝鲜语"
   ],
   "koa": [
     "Konomala"
@@ -12761,11 +13963,15 @@
     "彼爾姆科米語",
     "Komi-Permyak",
     "科米-彼爾米亞克語",
-    "彼爾米亞克語"
+    "彼爾米亞克語",
+    "彼尔姆科米语",
+    "科米-彼尔米亚克语",
+    "彼尔米亚克语"
   ],
   "kok": [
     "孔卡尼語",
-    "Konkani"
+    "Konkani",
+    "孔卡尼语"
   ],
   "kol": [
     "Kol (New Guinea)",
@@ -12787,7 +13993,8 @@
     "Kota"
   ],
   "kos": [
-    "科斯雷恩語"
+    "科斯雷恩語",
+    "科斯雷恩语"
   ],
   "kot": [
     "Lagwan"
@@ -12822,14 +14029,16 @@
     "Koba"
   ],
   "kpe": [
-    "克佩列語"
+    "克佩列語",
+    "克佩列语"
   ],
   "kpf": [
     "Komba"
   ],
   "kpg": [
     "卡平阿馬朗伊語",
-    "Kapingamarangi"
+    "Kapingamarangi",
+    "卡平阿马朗伊语"
   ],
   "kph": [
     "Kplang"
@@ -12848,7 +14057,8 @@
   ],
   "kpm": [
     "格賀語",
-    "Koho"
+    "Koho",
+    "格贺语"
   ],
   "kpn": [
     "Kepkiriwát"
@@ -12870,7 +14080,8 @@
   ],
   "kpt": [
     "卡拉塔語",
-    "Karata"
+    "Karata",
+    "卡拉塔语"
   ],
   "kpu": [
     "Kafoa"
@@ -12881,11 +14092,16 @@
     "Komi",
     "茲梁語",
     "科米-齊良語",
-    "齊良語"
+    "齊良語",
+    "兹梁科米语",
+    "兹梁语",
+    "科米-齐良语",
+    "齐良语"
   ],
   "kpw": [
     "科邦語",
-    "Kobon"
+    "Kobon",
+    "科邦语"
   ],
   "kpx": [
     "Mountain Koiari",
@@ -12893,7 +14109,8 @@
   ],
   "kpy": [
     "科里亞克語",
-    "Koryak"
+    "Koryak",
+    "科里亚克语"
   ],
   "kpz": [
     "Kupsabiny"
@@ -12912,11 +14129,13 @@
   ],
   "kqe": [
     "卡拉甘語",
-    "Kalagan"
+    "Kalagan",
+    "卡拉甘语"
   ],
   "kqf": [
     "卡卡拜語",
-    "Kakabai"
+    "Kakabai",
+    "卡卡拜语"
   ],
   "kqg": [
     "Khe"
@@ -12943,7 +14162,8 @@
     "卡翁德語",
     "Kaonde",
     "Chikaonde",
-    "Kawonde"
+    "Kawonde",
+    "卡翁德语"
   ],
   "kqo": [
     "Eastern Krahn"
@@ -12956,7 +14176,8 @@
   ],
   "kqr": [
     "基馬拉岡語",
-    "Kimaragang"
+    "Kimaragang",
+    "基马拉冈语"
   ],
   "kqs": [
     "Northern Kissi"
@@ -12983,7 +14204,8 @@
     "Korana"
   ],
   "kr": [
-    "卡努里語"
+    "卡努里語",
+    "卡努里语"
   ],
   "kra": [
     "Kumhali"
@@ -12993,7 +14215,8 @@
   ],
   "krc": [
     "卡拉恰伊-巴爾卡爾語",
-    "Karachay-Balkar"
+    "Karachay-Balkar",
+    "卡拉恰伊-巴尔卡尔语"
   ],
   "krd": [
     "Kairui-Midiki"
@@ -13011,18 +14234,23 @@
   "kri": [
     "塞拉利昂克里奧爾語",
     "克里奧語",
-    "Sierra Leonean Creole"
+    "Sierra Leonean Creole",
+    "塞拉利昂克里奥尔语",
+    "克里奥语"
   ],
   "krj": [
-    "基那來阿語"
+    "基那來阿語",
+    "基那来阿语"
   ],
   "krk": [
     "克列克語",
-    "Kerek"
+    "Kerek",
+    "克列克语"
   ],
   "krl": [
     "卡累利阿語",
-    "Karelian"
+    "Karelian",
+    "卡累利阿语"
   ],
   "krm": [
     "Krim"
@@ -13032,7 +14260,8 @@
   ],
   "kro-pro": [
     "原始克魯語",
-    "Proto-Kru"
+    "Proto-Kru",
+    "原始克鲁语"
   ],
   "krp": [
     "Korop"
@@ -13050,7 +14279,8 @@
   "kru": [
     "庫魯克語",
     "Kurukh",
-    "Kurux"
+    "Kurux",
+    "库鲁克语"
   ],
   "krv": [
     "Kavet",
@@ -13066,41 +14296,50 @@
     "克里茨語",
     "Kryts",
     "Kryc",
-    "Kryz"
+    "Kryz",
+    "克里茨语"
   ],
   "krz": [
     "Sota Kanum"
   ],
   "ks": [
-    "克什米爾語"
+    "克什米爾語",
+    "克什米尔语"
   ],
   "ksa": [
     "Shuwa-Zamani"
   ],
   "ksb": [
     "尚巴拉語",
-    "Shambaa"
+    "Shambaa",
+    "尚巴拉语"
   ],
   "ksc": [
     "南卡林阿語",
-    "Southern Kalinga"
+    "Southern Kalinga",
+    "南卡林阿语"
   ],
   "ksd": [
     "庫阿努阿語",
     "Tolai",
-    "Kuanua"
+    "Kuanua",
+    "库阿努阿语"
   ],
   "kse": [
     "Kuni"
   ],
   "ksf": [
-    "巴菲亞語"
+    "巴菲亞語",
+    "巴菲亚语"
   ],
   "ksg": [
     "Kusaghe"
   ],
   "ksi": [
-    "Krisa"
+    "伊薩卡語",
+    "Krisa",
+    "I'saka",
+    "伊萨卡语"
   ],
   "ksj": [
     "Uare"
@@ -13111,7 +14350,8 @@
   "ksl": [
     "庫馬爾語",
     "Kumalu",
-    "Kumal"
+    "Kumal",
+    "库马尔语"
   ],
   "ksm": [
     "Kumba"
@@ -13130,7 +14370,8 @@
   ],
   "ksr": [
     "博隆語",
-    "Borong"
+    "Borong",
+    "博隆语"
   ],
   "kss": [
     "Southern Kissi"
@@ -13140,20 +14381,23 @@
   ],
   "ksu": [
     "坎佯語",
-    "Khamyang"
+    "Khamyang",
+    "坎佯语"
   ],
   "ksv": [
     "Kusu"
   ],
   "ksw": [
-    "斯高克倫語"
+    "斯高克倫語",
+    "斯高克伦语"
   ],
   "ksx": [
     "Kedang"
   ],
   "ksy": [
     "卡里亞塔爾語",
-    "Kharia Thar"
+    "Kharia Thar",
+    "卡里亚塔尔语"
   ],
   "ksz": [
     "Kodaku"
@@ -13163,14 +14407,16 @@
   ],
   "ktb": [
     "卡姆巴塔語",
-    "Kambaata"
+    "Kambaata",
+    "卡姆巴塔语"
   ],
   "ktc": [
     "Kholok"
   ],
   "ktd": [
     "科卡塔語",
-    "Kokata"
+    "Kokata",
+    "科卡塔语"
   ],
   "ktf": [
     "Kwami"
@@ -13182,7 +14428,8 @@
     "Galgadungu",
     "Kalkutung",
     "Kalkadoon",
-    "Galgaduun"
+    "Galgaduun",
+    "卡尔库通语"
   ],
   "kth": [
     "Karanga"
@@ -13236,7 +14483,8 @@
     "Kibulamatadi",
     "Kikwango",
     "Ikeleve",
-    "Kizabave"
+    "Kizabave",
+    "吉土巴语"
   ],
   "ktv": [
     "Eastern Katu"
@@ -13268,14 +14516,19 @@
     "‡Kx'auǁ'ei",
     "ǂKx'auǁ'ein",
     "ǁX'auǁ'e",
-    "Juǀ'hoansi"
+    "Juǀ'hoansi",
+    "朱洪语",
+    "朱胡亚斯",
+    "朱胡亚斯语"
   ],
   "ku": [
-    "庫爾德語"
+    "庫爾德語",
+    "库尔德语"
   ],
   "ku-pro": [
     "原始庫爾德語",
-    "Proto-Kurdish"
+    "Proto-Kurdish",
+    "原始库尔德语"
   ],
   "kub": [
     "Kutep"
@@ -13287,7 +14540,9 @@
     "奧赫拉瓦語",
     "庫拉達語",
     "Auhelawa",
-    "'Auhelawa"
+    "'Auhelawa",
+    "奥赫拉瓦语",
+    "库拉达语"
   ],
   "kue": [
     "Kuman",
@@ -13326,7 +14581,8 @@
   ],
   "kum": [
     "庫梅克語",
-    "Kumyk"
+    "Kumyk",
+    "库梅克语"
   ],
   "kun": [
     "Kunama"
@@ -13344,7 +14600,8 @@
     "Kusaal"
   ],
   "kut": [
-    "庫特奈語"
+    "庫特奈語",
+    "库特奈语"
   ],
   "kuu": [
     "Upper Kuskokwim"
@@ -13357,19 +14614,23 @@
   ],
   "kux": [
     "庫卡吉語",
-    "Kukatja"
+    "Kukatja",
+    "库卡吉语"
   ],
   "kuy": [
     "庫庫-亞烏語",
-    "Kuuku-Ya'u"
+    "Kuuku-Ya'u",
+    "库库-亚乌语"
   ],
   "kuz": [
     "坤扎語",
-    "Kunza"
+    "Kunza",
+    "坤扎语"
   ],
   "kva": [
     "巴格瓦拉爾語",
-    "Bagvalal"
+    "Bagvalal",
+    "巴格瓦拉尔语"
   ],
   "kvb": [
     "Kubu"
@@ -13392,7 +14653,8 @@
   ],
   "kvh": [
     "科莫多語",
-    "Komodo"
+    "Komodo",
+    "科莫多语"
   ],
   "kvi": [
     "Kwang"
@@ -13438,7 +14700,8 @@
   ],
   "kvx": [
     "帕卡里科里語",
-    "Parkari Koli"
+    "Parkari Koli",
+    "帕卡里科里语"
   ],
   "kvy": [
     "Yintale Karen"
@@ -13447,7 +14710,8 @@
     "Tsakwambo"
   ],
   "kw": [
-    "康沃爾語"
+    "康沃爾語",
+    "康沃尔语"
   ],
   "kwa": [
     "Dâw"
@@ -13467,7 +14731,8 @@
   ],
   "kwf": [
     "夸拉阿埃語",
-    "Kwara'ae"
+    "Kwara'ae",
+    "夸拉阿埃语"
   ],
   "kwg": [
     "Sara Kaba Deme"
@@ -13490,7 +14755,8 @@
   ],
   "kwk": [
     "夸加特爾語",
-    "Kwak'wala"
+    "Kwak'wala",
+    "夸加特尔语"
   ],
   "kwl": [
     "Kofyar"
@@ -13540,7 +14806,8 @@
   ],
   "kxb": [
     "克羅布語",
-    "Krobu"
+    "Krobu",
+    "克罗布语"
   ],
   "kxc": [
     "Khonso"
@@ -13548,7 +14815,8 @@
   "kxd": [
     "汶萊馬來語",
     "Brunei",
-    "Brunei Malay"
+    "Brunei Malay",
+    "汶莱马来语"
   ],
   "kxe": [
     "Kakihum"
@@ -13577,7 +14845,8 @@
     "北部高棉語",
     "Northern Khmer",
     "Thai Khmer",
-    "Surin Khmer"
+    "Surin Khmer",
+    "北部高棉语"
   ],
   "kxn": [
     "Kanowit",
@@ -13589,7 +14858,8 @@
   ],
   "kxp": [
     "瓦迪雅拉科里語",
-    "Wadiyara Koli"
+    "Wadiyara Koli",
+    "瓦迪雅拉科里语"
   ],
   "kxq": [
     "Smärky Kanum"
@@ -13626,7 +14896,8 @@
     "Kerewo"
   ],
   "ky": [
-    "吉爾吉斯語"
+    "吉爾吉斯語",
+    "吉尔吉斯语"
   ],
   "kya": [
     "Kwaya"
@@ -13655,19 +14926,23 @@
   ],
   "kyi": [
     "基普特語",
-    "Kiput"
+    "Kiput",
+    "基普特语"
   ],
   "kyj": [
     "加勞語",
-    "Karao"
+    "Karao",
+    "加劳语"
   ],
   "kyk": [
     "卡馬尤語",
-    "Kamayo"
+    "Kamayo",
+    "卡马尤语"
   ],
   "kyl": [
     "卡拉普亞語",
-    "Kalapuya"
+    "Kalapuya",
+    "卡拉普亚语"
   ],
   "kym": [
     "Kpatili"
@@ -13698,7 +14973,8 @@
   ],
   "kyu": [
     "西克耶語",
-    "Western Kayah"
+    "Western Kayah",
+    "西克耶语"
   ],
   "kyv": [
     "Kayort"
@@ -13706,7 +14982,8 @@
   "kyw": [
     "庫德馬里語",
     "Kudmali",
-    "Kurmali"
+    "Kurmali",
+    "库德马里语"
   ],
   "kyx": [
     "Rapoisi",
@@ -13742,7 +15019,8 @@
   ],
   "kzg": [
     "喜界語",
-    "Kikai"
+    "Kikai",
+    "喜界语"
   ],
   "kzh": [
     "Dongolawi",
@@ -13820,19 +15098,23 @@
     "Kalabra"
   ],
   "la": [
-    "拉丁語"
+    "拉丁語",
+    "拉丁语"
   ],
   "laa": [
-    "拉布揚-蘇巴農語"
+    "拉布揚-蘇巴農語",
+    "拉布扬-苏巴农语"
   ],
   "lab": [
-    "線形文字A"
+    "線形文字A",
+    "线形文字A"
   ],
   "lac": [
     "拉坎敦語",
     "Lacandon",
     "Jach t’aan",
-    "Hach t’an"
+    "Hach t’an",
+    "拉坎敦语"
   ],
   "lad": [
     "拉蒂諾語",
@@ -13841,7 +15123,10 @@
     "Ladino",
     "Judaeo-Spanish",
     "Judæo-Spanish",
-    "Judeo-Spanish"
+    "Judeo-Spanish",
+    "拉蒂诺语",
+    "拉迪诺语",
+    "拉地诺语"
   ],
   "lae": [
     "Pattani"
@@ -13850,12 +15135,14 @@
     "Lafofa"
   ],
   "lag": [
-    "朗吉語"
+    "朗吉語",
+    "朗吉语"
   ],
   "lah": [
     "蘭達語",
     "Lahnda",
-    "Western Punjabi"
+    "Western Punjabi",
+    "兰达语"
   ],
   "lai": [
     "Lambya"
@@ -13871,7 +15158,8 @@
     "Laka (Nigeria)"
   ],
   "lam": [
-    "蘭巴語"
+    "蘭巴語",
+    "兰巴语"
   ],
   "lan": [
     "Laru"
@@ -13885,7 +15173,8 @@
   "laq": [
     "普標語",
     "Qabiao",
-    "Laqua"
+    "Laqua",
+    "普标语"
   ],
   "lar": [
     "Larteh"
@@ -13895,7 +15184,8 @@
     "Gur Lama",
     "Lama (West Africa)",
     "Lama (Togo)",
-    "Lama"
+    "Lama",
+    "古尔拉玛语"
   ],
   "lau": [
     "Laba"
@@ -13906,7 +15196,8 @@
   "lax": [
     "提瓦語",
     "Tiwa",
-    "Lalung"
+    "Lalung",
+    "提瓦语"
   ],
   "lay": [
     "拉瑪白語",
@@ -13916,13 +15207,15 @@
     "Lama (Myanmar)",
     "Lama",
     "Northern Bai",
-    "Laemae"
+    "Laemae",
+    "拉玛白语"
   ],
   "laz": [
     "Aribwatsa"
   ],
   "lb": [
-    "盧森堡語"
+    "盧森堡語",
+    "卢森堡语"
   ],
   "lbb": [
     "Label"
@@ -13930,11 +15223,13 @@
   "lbc": [
     "拉珈語",
     "Lakkia",
-    "Lakkja"
+    "Lakkja",
+    "拉珈语"
   ],
   "lbe": [
     "拉克語",
-    "Lak"
+    "Lak",
+    "拉克语"
   ],
   "lbf": [
     "Tinani"
@@ -13948,7 +15243,8 @@
   "lbj": [
     "拉達克語",
     "Ladakhi",
-    "Bhoti"
+    "Bhoti",
+    "拉达克语"
   ],
   "lbk": [
     "中邦托克語",
@@ -13959,15 +15255,18 @@
     "Bontok Igorot",
     "Bontoc",
     "Bontok",
-    "Finallig"
+    "Finallig",
+    "中邦托克语"
   ],
   "lbl": [
     "利邦比科爾語",
-    "Libon Bikol"
+    "Libon Bikol",
+    "利邦比科尔语"
   ],
   "lbm": [
     "洛迪語",
-    "Lodhi"
+    "Lodhi",
+    "洛迪语"
   ],
   "lbn": [
     "Lamet"
@@ -13993,11 +15292,13 @@
   ],
   "lbs": [
     "利比亞手語",
-    "Libyan Sign Language"
+    "Libyan Sign Language",
+    "利比亚手语"
   ],
   "lbt": [
     "拉基語",
-    "Lachi"
+    "Lachi",
+    "拉基语"
   ],
   "lbu": [
     "Labu"
@@ -14023,7 +15324,8 @@
     "Leerdil",
     "Leertil",
     "Damin",
-    "Demiin"
+    "Demiin",
+    "拉尔迪尔语"
   ],
   "lcc": [
     "Legenyem"
@@ -14049,7 +15351,8 @@
     "Tungak"
   ],
   "lcp": [
-    "西拉威語"
+    "西拉威語",
+    "西拉威语"
   ],
   "lcq": [
     "Luhu",
@@ -14087,7 +15390,8 @@
   ],
   "ldn": [
     "拉丹語",
-    "Láadan"
+    "Láadan",
+    "拉丹语"
   ],
   "ldo": [
     "Loo"
@@ -14148,7 +15452,8 @@
   ],
   "leh": [
     "倫杰語",
-    "Lenje"
+    "Lenje",
+    "伦杰语"
   ],
   "lei": [
     "Lemio"
@@ -14181,7 +15486,9 @@
   "lep": [
     "絨巴語",
     "Lepcha",
-    "雷布查語"
+    "雷布查語",
+    "绒巴语",
+    "雷布查语"
   ],
   "leq": [
     "Lembena"
@@ -14232,17 +15539,20 @@
     "列茲金語",
     "Lezgi",
     "Lezgian",
-    "Lezgin"
+    "Lezgin",
+    "列兹金语"
   ],
   "lfa": [
     "Lefa"
   ],
   "lfn": [
     "新共同語言",
-    "Lingua Franca Nova"
+    "Lingua Franca Nova",
+    "新共同语言"
   ],
   "lg": [
-    "盧干達語"
+    "盧干達語",
+    "卢干达语"
   ],
   "lga": [
     "Lungga"
@@ -14264,7 +15574,8 @@
   "lgk": [
     "林加拉克語",
     "Neverver",
-    "Lingarak"
+    "Lingarak",
+    "林加拉克语"
   ],
   "lgl": [
     "Wala"
@@ -14318,7 +15629,8 @@
     "拉哈語（越南）",
     "Laha (Vietnam)",
     "Laha",
-    "La Ha"
+    "La Ha",
+    "拉哈语（越南）"
   ],
   "lhh": [
     "Laha (Indonesia)",
@@ -14330,7 +15642,8 @@
   ],
   "lhl": [
     "拉胡爾洛哈爾語",
-    "Lahul Lohar"
+    "Lahul Lohar",
+    "拉胡尔洛哈尔语"
   ],
   "lhn": [
     "Lahanan"
@@ -14346,10 +15659,12 @@
   ],
   "lhu": [
     "拉祜語",
-    "Lahu"
+    "Lahu",
+    "拉祜语"
   ],
   "li": [
-    "林堡語"
+    "林堡語",
+    "林堡语"
   ],
   "lia": [
     "West-Central Limba"
@@ -14376,7 +15691,8 @@
     "Moyjaw",
     "Xifang",
     "Baisha",
-    "Yuanmen"
+    "Yuanmen",
+    "黎语"
   ],
   "lid": [
     "Nyindrou"
@@ -14386,7 +15702,8 @@
   ],
   "lif": [
     "林布語",
-    "Limbu"
+    "Limbu",
+    "林布语"
   ],
   "lig": [
     "Ligbi"
@@ -14399,7 +15716,8 @@
   ],
   "lij": [
     "利古里亞語",
-    "Ligurian"
+    "Ligurian",
+    "利古里亚语"
   ],
   "lik": [
     "Lika"
@@ -14419,18 +15737,22 @@
   "lir": [
     "利比里亞英語",
     "賴比瑞亞英語",
-    "Liberian English"
+    "Liberian English",
+    "利比里亚英语",
+    "赖比瑞亚英语"
   ],
   "lis": [
     "傈僳語",
-    "Lisu"
+    "Lisu",
+    "傈僳语"
   ],
   "liu": [
     "Logorik"
   ],
   "liv": [
     "立窩尼亞語",
-    "Livonian"
+    "Livonian",
+    "立窝尼亚语"
   ],
   "liw": [
     "Col"
@@ -14458,14 +15780,16 @@
   ],
   "ljp": [
     "楠榜阿皮語",
-    "Lampung Api"
+    "Lampung Api",
+    "楠榜阿皮语"
   ],
   "ljw": [
     "Yirandali"
   ],
   "ljx": [
     "尤魯語",
-    "Yuru"
+    "Yuru",
+    "尤鲁语"
   ],
   "lka": [
     "Lakalei"
@@ -14487,7 +15811,8 @@
   ],
   "lki": [
     "拉科語",
-    "Laki"
+    "Laki",
+    "拉科语"
   ],
   "lkj": [
     "Remun"
@@ -14497,7 +15822,8 @@
   ],
   "lkm": [
     "卡拉馬雅語",
-    "Kalaamaya"
+    "Kalaamaya",
+    "卡拉马雅语"
   ],
   "lkn": [
     "Lakon"
@@ -14514,11 +15840,13 @@
   "lkt": [
     "拉科塔語",
     "Lakota",
-    "Lakhota"
+    "Lakhota",
+    "拉科塔语"
   ],
   "lku": [
     "昆卡里語",
-    "Kungkari"
+    "Kungkari",
+    "昆卡里语"
   ],
   "lky": [
     "Lokoya"
@@ -14536,7 +15864,9 @@
   "lld": [
     "拉登語",
     "拉汀語",
-    "Ladin"
+    "Ladin",
+    "拉登语",
+    "拉汀语"
   ],
   "lle": [
     "Lele (New Guinea)",
@@ -14559,7 +15889,8 @@
   "llj": [
     "拉吉拉吉語",
     "Ladji-Ladji",
-    "Ledji-Ledji"
+    "Ledji-Ledji",
+    "拉吉拉吉语"
   ],
   "llk": [
     "Lelak"
@@ -14589,7 +15920,8 @@
   ],
   "lls": [
     "立陶宛手語",
-    "Lithuanian Sign Language"
+    "Lithuanian Sign Language",
+    "立陶宛手语"
   ],
   "llu": [
     "Lau"
@@ -14605,7 +15937,8 @@
   ],
   "lmc": [
     "利米爾甘語",
-    "Limilngan"
+    "Limilngan",
+    "利米尔甘语"
   ],
   "lmd": [
     "Lumun"
@@ -14643,12 +15976,15 @@
     "蘭巴蒂語",
     "Lambadi",
     "Banjari",
-    "Goar-boali"
+    "Goar-boali",
+    "兰巴蒂语"
   ],
   "lmo": [
     "倫巴底語",
     "倫巴第語",
-    "Lombard"
+    "Lombard",
+    "伦巴底语",
+    "伦巴第语"
   ],
   "lmp": [
     "Limbum"
@@ -14674,13 +16010,15 @@
   "lmy": [
     "拉姆博亞語",
     "Laboya",
-    "Lamboya"
+    "Lamboya",
+    "拉姆博亚语"
   ],
   "lmz": [
     "Lumbee"
   ],
   "ln": [
-    "林加拉語"
+    "林加拉語",
+    "林加拉语"
   ],
   "lna": [
     "Langbashe"
@@ -14690,7 +16028,8 @@
   ],
   "lnd": [
     "弄巴灣語",
-    "Lun Bawang"
+    "Lun Bawang",
+    "弄巴湾语"
   ],
   "lnh": [
     "Lanoh"
@@ -14728,7 +16067,8 @@
     "Lanima"
   ],
   "lo": [
-    "老撾語"
+    "老撾語",
+    "老挝语"
   ],
   "loa": [
     "Loloda"
@@ -14752,7 +16092,8 @@
   ],
   "loe": [
     "薩盧安語",
-    "Saluan"
+    "Saluan",
+    "萨卢安语"
   ],
   "lof": [
     "Logol"
@@ -14769,13 +16110,15 @@
   ],
   "loj": [
     "露語",
-    "Lou"
+    "Lou",
+    "露语"
   ],
   "lok": [
     "Loko"
   ],
   "lol": [
-    "芒戈語"
+    "芒戈語",
+    "芒戈语"
   ],
   "lom": [
     "Looma",
@@ -14803,10 +16146,11 @@
     "Lotuko"
   ],
   "lou": [
-    "路易斯安納克里奧爾法語",
+    "路易斯安那克里奧爾法語",
     "Louisiana Creole French",
     "Louisiana Creole",
-    "Kréyol"
+    "Kréyol",
+    "路易斯安那克里奥尔法语"
   ],
   "lov": [
     "Lopi"
@@ -14819,7 +16163,8 @@
   ],
   "loz": [
     "洛齊語",
-    "Lozi"
+    "Lozi",
+    "洛齐语"
   ],
   "lpa": [
     "Lelepa"
@@ -14833,7 +16178,8 @@
   "lpo": [
     "里潑語",
     "Lipo",
-    "Eastern Lisu"
+    "Eastern Lisu",
+    "里泼语"
   ],
   "lpx": [
     "Lopit"
@@ -14843,7 +16189,8 @@
   ],
   "lrc": [
     "北盧里語",
-    "Northern Luri"
+    "Northern Luri",
+    "北卢里语"
   ],
   "lre": [
     "Laurentian",
@@ -14851,7 +16198,8 @@
   ],
   "lrg": [
     "拉拉吉亞語",
-    "Laragia"
+    "Laragia",
+    "拉拉吉亚语"
   ],
   "lri": [
     "Marachi"
@@ -14859,12 +16207,14 @@
   "lrk": [
     "洛亞基語",
     "Loarki",
-    "Gade Lohar"
+    "Gade Lohar",
+    "洛亚基语"
   ],
   "lrl": [
     "拉里語",
     "Lari",
-    "Achomi"
+    "Achomi",
+    "拉里语"
   ],
   "lrm": [
     "Marama"
@@ -14893,7 +16243,8 @@
   ],
   "lsa": [
     "拉斯格爾迪語",
-    "Lasgerdi"
+    "Lasgerdi",
+    "拉斯格尔迪语"
   ],
   "lsd": [
     "Lishana Deni",
@@ -14910,11 +16261,13 @@
     "Lashi",
     "Lacid",
     "Lachik",
-    "Leqi"
+    "Leqi",
+    "勒期语"
   ],
   "lsl": [
     "拉脫維亞手語",
-    "Latvian Sign Language"
+    "Latvian Sign Language",
+    "拉脱维亚手语"
   ],
   "lsm": [
     "Saamia"
@@ -14923,11 +16276,14 @@
     "老撾手語",
     "寮國手語",
     "Laos Sign Language",
-    "Laotian Sign Language"
+    "Laotian Sign Language",
+    "老挝手语",
+    "寮国手语"
   ],
   "lsp": [
     "巴拿馬手語",
-    "Panamanian Sign Language"
+    "Panamanian Sign Language",
+    "巴拿马手语"
   ],
   "lsr": [
     "Aruop",
@@ -14937,33 +16293,41 @@
   ],
   "lss": [
     "臘斯語",
-    "Lasi"
+    "Lasi",
+    "腊斯语"
   ],
   "lst": [
     "千里達及托巴哥手語",
-    "Trinidad and Tobago Sign Language"
+    "Trinidad and Tobago Sign Language",
+    "千里达及托巴哥手语"
   ],
   "lsy": [
     "毛里求斯手語",
     "模里西斯手語",
-    "Mauritian Sign Language"
+    "Mauritian Sign Language",
+    "毛里求斯手语",
+    "模里西斯手语"
   ],
   "lt": [
-    "立陶宛語"
+    "立陶宛語",
+    "立陶宛语"
   ],
   "ltc": [
     "中古漢語",
     "Middle Chinese",
     "Late Middle Chinese",
-    "Early Middle Chinese"
+    "Early Middle Chinese",
+    "中古汉语"
   ],
   "ltg": [
     "拉特加萊語",
-    "Latgalian"
+    "Latgalian",
+    "拉特加莱语"
   ],
   "lti": [
     "勒蒂語",
-    "Leti"
+    "Leti",
+    "勒蒂语"
   ],
   "ltn": [
     "Latundê"
@@ -14978,12 +16342,14 @@
     "Latu"
   ],
   "lu": [
-    "盧巴卡丹加語"
+    "盧巴卡丹加語",
+    "卢巴卡丹加语"
   ],
   "lua": [
     "魯巴魯魯亞語",
     "Tshiluba",
-    "Luba"
+    "Luba",
+    "鲁巴鲁鲁亚语"
   ],
   "luc": [
     "Aringa"
@@ -14992,7 +16358,8 @@
     "盧迪茨語",
     "Ludian",
     "Ludic",
-    "Lude"
+    "Lude",
+    "卢迪茨语"
   ],
   "lue": [
     "Luvale"
@@ -15004,7 +16371,8 @@
     "路易塞諾語",
     "Luiseno",
     "Juaneño",
-    "Juaneno"
+    "Juaneno",
+    "路易塞诺语"
   ],
   "luj": [
     "Luna"
@@ -15019,12 +16387,14 @@
     "Luimbi"
   ],
   "lun": [
-    "盧恩達語"
+    "盧恩達語",
+    "卢恩达语"
   ],
   "luo": [
     "盧歐語",
     "Luo",
-    "Dholuo"
+    "Dholuo",
+    "卢欧语"
   ],
   "lup": [
     "Lumbu"
@@ -15039,29 +16409,35 @@
     "米佐語",
     "Mizo",
     "Lushai",
-    "Lushei"
+    "Lushei",
+    "米佐语"
   ],
   "lut": [
     "盧紹錫德語",
-    "Lushootseed"
+    "Lushootseed",
+    "卢绍锡德语"
   ],
   "luu": [
     "Lumba-Yakkha"
   ],
   "luv": [
     "魯瓦蒂語",
-    "Luwati"
+    "Luwati",
+    "鲁瓦蒂语"
   ],
   "luy": [
     "盧希亞語",
-    "Luhya"
+    "Luhya",
+    "卢希亚语"
   ],
   "luz": [
     "南盧里語",
-    "Southern Luri"
+    "Southern Luri",
+    "南卢里语"
   ],
   "lv": [
-    "拉脫維亞語"
+    "拉脫維亞語",
+    "拉脱维亚语"
   ],
   "lva": [
     "Maku'a"
@@ -15093,15 +16469,18 @@
   ],
   "lwh": [
     "白拉基語",
-    "White Lachi"
+    "White Lachi",
+    "白拉基语"
   ],
   "lwl": [
     "東拉威語",
-    "Eastern Lawa"
+    "Eastern Lawa",
+    "东拉威语"
   ],
   "lwm": [
     "老緬語",
-    "Laomian"
+    "Laomian",
+    "老缅语"
   ],
   "lwo": [
     "Luwo",
@@ -15110,7 +16489,8 @@
   ],
   "lws": [
     "馬拉威手語",
-    "Malawian Sign Language"
+    "Malawian Sign Language",
+    "马拉威手语"
   ],
   "lwt": [
     "Lewotobi"
@@ -15126,7 +16506,8 @@
   ],
   "lyg": [
     "林甘語",
-    "Lyngngam"
+    "Lyngngam",
+    "林甘语"
   ],
   "lyn": [
     "Luyana"
@@ -15144,119 +16525,147 @@
   ],
   "lzz": [
     "拉茲語",
-    "Laz"
+    "Laz",
+    "拉兹语"
   ],
   "maa": [
     "聖赫羅尼莫特科阿特爾馬薩特克語",
-    "San Jerónimo Tecóatl Mazatec"
+    "San Jerónimo Tecóatl Mazatec",
+    "圣赫罗尼莫特科阿特尔马萨特克语"
   ],
   "mab": [
     "尤坦杜奇米斯特克語",
-    "Yutanduchi Mixtec"
+    "Yutanduchi Mixtec",
+    "尤坦杜奇米斯特克语"
   ],
   "mad": [
     "馬都拉語",
-    "Madurese"
+    "Madurese",
+    "马都拉语"
   ],
   "mae": [
     "Bo-Rukul"
   ],
   "maf": [
-    "馬法語"
+    "馬法語",
+    "马法语"
   ],
   "mag": [
     "馬加希語",
-    "Magahi"
+    "Magahi",
+    "马加希语"
   ],
   "mai": [
     "邁蒂利語",
     "Maithili",
-    "邁提利語"
+    "邁提利語",
+    "迈蒂利语",
+    "迈提利语"
   ],
   "maj": [
     "哈拉佩德迪亞茲馬薩特克語",
-    "Jalapa de Díaz Mazatec"
+    "Jalapa de Díaz Mazatec",
+    "哈拉佩德迪亚兹马萨特克语"
   ],
   "mak": [
     "望加錫語",
-    "Makasar"
+    "Makasar",
+    "望加锡语"
   ],
   "mam": [
     "馬姆語",
-    "Mam"
+    "Mam",
+    "马姆语"
   ],
   "man": [
-    "曼丁哥語"
+    "曼丁哥語",
+    "曼丁哥语"
   ],
   "map-ata-pro": [
     "原始泰雅語",
-    "Proto-Atayalic"
+    "Proto-Atayalic",
+    "原始泰雅语"
   ],
   "map-bms": [
     "班尤馬山語",
-    "Banyumasan"
+    "Banyumasan",
+    "班尤马山语"
   ],
   "map-kxv": [
     "噶哈巫語",
     "Kaxabu",
     "Kahabu",
-    "Kahapu"
+    "Kahapu",
+    "噶哈巫语"
   ],
   "map-pro": [
     "原始南島語",
-    "Proto-Austronesian"
+    "Proto-Austronesian",
+    "原始南岛语"
   ],
   "map-trv": [
     "太魯閣語",
     "Truku",
-    "Taroko"
+    "Taroko",
+    "太鲁阁语"
   ],
   "map-twk": [
     "道卡斯語",
     "Taokas",
     "Taukat",
-    "Taukan"
+    "Taukan",
+    "道卡斯语"
   ],
   "maq": [
     "奇危特蘭馬薩特克語",
-    "Chiquihuitlán Mazatec"
+    "Chiquihuitlán Mazatec",
+    "奇危特兰马萨特克语"
   ],
   "mas": [
     "馬賽語",
-    "Maasai"
+    "Maasai",
+    "马赛语"
   ],
   "mat": [
     "馬特拉爾辛卡語",
     "Matlatzinca",
     "聖弗朗西斯科馬特拉爾辛卡語",
     "San Francisco Matlatzinca",
-    "San Francisco Oxtotilpa Matlatzinca"
+    "San Francisco Oxtotilpa Matlatzinca",
+    "马特拉尔辛卡语",
+    "圣弗朗西斯科马特拉尔辛卡语"
   ],
   "mau": [
     "瓦烏特拉馬薩特克語",
-    "Huautla Mazatec"
+    "Huautla Mazatec",
+    "瓦乌特拉马萨特克语"
   ],
   "mav": [
     "Sateré-Mawé"
   ],
   "maw": [
     "曼普魯西語",
-    "Mampruli"
+    "Mampruli",
+    "曼普鲁西语"
   ],
   "max": [
     "北摩鹿加馬來語",
-    "North Moluccan Malay"
+    "North Moluccan Malay",
+    "北摩鹿加马来语"
   ],
   "maz": [
     "中馬薩瓦語",
-    "Central Mazahua"
+    "Central Mazahua",
+    "中马萨瓦语"
   ],
   "mba": [
     "希高農語",
-    "Higaonon"
+    "Higaonon",
+    "希高农语"
   ],
   "mbb": [
-    "西布基農-馬諾博語"
+    "西布基農-馬諾博語",
+    "西布基农-马诺博语"
   ],
   "mbc": [
     "Macushi",
@@ -15269,7 +16678,8 @@
   ],
   "mbd": [
     "迪巴巴旺-馬諾博語",
-    "Dibabawon Manobo"
+    "Dibabawon Manobo",
+    "迪巴巴旺-马诺博语"
   ],
   "mbe": [
     "Molale",
@@ -15279,13 +16689,15 @@
   ],
   "mbf": [
     "峇峇馬來語",
-    "Baba Malay"
+    "Baba Malay",
+    "峇峇马来语"
   ],
   "mbh": [
     "Mangseng"
   ],
   "mbi": [
-    "伊利亞農-馬諾博語"
+    "伊利亞農-馬諾博語",
+    "伊利亚农-马诺博语"
   ],
   "mbj": [
     "Nadëb"
@@ -15318,10 +16730,12 @@
     "Nukak Makú"
   ],
   "mbs": [
-    "薩蘭加尼-馬諾博語"
+    "薩蘭加尼-馬諾博語",
+    "萨兰加尼-马诺博语"
   ],
   "mbt": [
-    "馬蒂沙祿-馬諾博語"
+    "馬蒂沙祿-馬諾博語",
+    "马蒂沙禄-马诺博语"
   ],
   "mbu": [
     "Mbula-Bwazza"
@@ -15338,11 +16752,13 @@
   ],
   "mby": [
     "梅莫尼語",
-    "Memoni"
+    "Memoni",
+    "梅莫尼语"
   ],
   "mbz": [
     "阿莫爾特佩卡米斯特克語",
-    "Amoltepec Mixtec"
+    "Amoltepec Mixtec",
+    "阿莫尔特佩卡米斯特克语"
   ],
   "mca": [
     "Maca"
@@ -15358,7 +16774,8 @@
   ],
   "mce": [
     "伊通杜希亞米斯特克語",
-    "Itundujia Mixtec"
+    "Itundujia Mixtec",
+    "伊通杜希亚米斯特克语"
   ],
   "mcf": [
     "Matsés"
@@ -15392,7 +16809,8 @@
     "馬六甲克里奧爾葡萄牙語",
     "Kristang",
     "Malacca Creole Portuguese",
-    "Malaccan Creole Portuguese"
+    "Malaccan Creole Portuguese",
+    "马六甲克里奥尔葡萄牙语"
   ],
   "mcn": [
     "Masana",
@@ -15401,14 +16819,16 @@
   ],
   "mco": [
     "科阿特蘭米塞語",
-    "Coatlán Mixe"
+    "Coatlán Mixe",
+    "科阿特兰米塞语"
   ],
   "mcp": [
     "Makaa"
   ],
   "mcq": [
     "埃塞語",
-    "Ese"
+    "Ese",
+    "埃塞语"
   ],
   "mcr": [
     "Menya"
@@ -15450,19 +16870,22 @@
     "Mbum"
   ],
   "mde": [
-    "馬巴語"
+    "馬巴語",
+    "马巴语"
   ],
   "mdf": [
     "莫克沙語",
     "Moksha",
-    "Mordvin"
+    "Mordvin",
+    "莫克沙语"
   ],
   "mdg": [
     "Massalat"
   ],
   "mdh": [
     "馬京達瑙語",
-    "Maguindanao"
+    "Maguindanao",
+    "马京达瑙语"
   ],
   "mdi": [
     "Mamvu"
@@ -15475,7 +16898,8 @@
   ],
   "mdl": [
     "馬爾他手語",
-    "Maltese Sign Language"
+    "Maltese Sign Language",
+    "马尔他手语"
   ],
   "mdm": [
     "Mayogo"
@@ -15491,7 +16915,8 @@
   ],
   "mdr": [
     "曼達爾語",
-    "Mandar"
+    "Mandar",
+    "曼达尔语"
   ],
   "mds": [
     "Maria",
@@ -15506,7 +16931,8 @@
   ],
   "mdv": [
     "聖盧西亞蒙泰韋爾米斯特克語",
-    "Santa Lucía Monteverde Mixtec"
+    "Santa Lucía Monteverde Mixtec",
+    "圣卢西亚蒙泰韦尔米斯特克语"
   ],
   "mdw": [
     "Mbosi"
@@ -15535,7 +16961,8 @@
     "Leelawarra",
     "Leelalwarra",
     "Mala",
-    "Marra"
+    "Marra",
+    "玛拉语"
   ],
   "med": [
     "Melpa"
@@ -15551,7 +16978,8 @@
   ],
   "meh": [
     "西南特拉夏科米斯特克語",
-    "Southwestern Tlaxiaco Mixtec"
+    "Southwestern Tlaxiaco Mixtec",
+    "西南特拉夏科米斯特克语"
   ],
   "mei": [
     "Midob"
@@ -15563,21 +16991,25 @@
   ],
   "mek": [
     "梅凱奧語",
-    "Mekeo"
+    "Mekeo",
+    "梅凯奥语"
   ],
   "mel": [
     "中馬蘭諾語",
-    "Central Melanau"
+    "Central Melanau",
+    "中马兰诺语"
   ],
   "mem": [
     "Mangala"
   ],
   "men": [
-    "門德語"
+    "門德語",
+    "门德语"
   ],
   "meo": [
     "吉打馬來語",
-    "Kedah Malay"
+    "Kedah Malay",
+    "吉打马来语"
   ],
   "mep": [
     "Miriwung"
@@ -15587,7 +17019,8 @@
   ],
   "mer": [
     "梅魯語",
-    "Meru"
+    "Meru",
+    "梅鲁语"
   ],
   "mes": [
     "Masmaje"
@@ -15602,7 +17035,8 @@
     "莫圖語",
     "Motu",
     "Pure Motu",
-    "True Motu"
+    "True Motu",
+    "莫图语"
   ],
   "mev": [
     "Mano"
@@ -15612,14 +17046,16 @@
   ],
   "mey": [
     "哈桑語",
-    "Hassaniya"
+    "Hassaniya",
+    "哈桑语"
   ],
   "mez": [
     "Menominee"
   ],
   "mfa": [
     "北大年馬來語",
-    "Pattani Malay"
+    "Pattani Malay",
+    "北大年马来语"
   ],
   "mfb": [
     "Bangka"
@@ -15633,7 +17069,8 @@
   "mfe": [
     "毛里求斯克里奧爾語",
     "Mauritian Creole",
-    "Mauritian"
+    "Mauritian",
+    "毛里求斯克里奥尔语"
   ],
   "mff": [
     "Naki",
@@ -15646,7 +17083,8 @@
   ],
   "mfh": [
     "馬特爾語",
-    "Matal"
+    "Matal",
+    "马特尔语"
   ],
   "mfi": [
     "Wandala",
@@ -15672,7 +17110,8 @@
   ],
   "mfp": [
     "望加錫馬來語",
-    "Makassar Malay"
+    "Makassar Malay",
+    "望加锡马来语"
   ],
   "mfq": [
     "Moba"
@@ -15700,11 +17139,13 @@
     "Marramanindjdji",
     "Marramaninydyi",
     "Marimanindji",
-    "Mariyedi"
+    "Mariyedi",
+    "马里蒂尔语"
   ],
   "mfs": [
     "墨西哥手語",
-    "Mexican Sign Language"
+    "Mexican Sign Language",
+    "墨西哥手语"
   ],
   "mft": [
     "Mokerang"
@@ -15723,17 +17164,20 @@
   ],
   "mfy": [
     "馬約語",
-    "Mayo"
+    "Mayo",
+    "马约语"
   ],
   "mfz": [
     "Mabaan"
   ],
   "mg": [
-    "馬拉加斯語"
+    "馬拉加斯語",
+    "马拉加斯语"
   ],
   "mga": [
     "中古愛爾蘭語",
-    "Middle Irish"
+    "Middle Irish",
+    "中古爱尔兰语"
   ],
   "mgb": [
     "Mararit"
@@ -15754,7 +17198,8 @@
     "Mpongmpong"
   ],
   "mgh": [
-    "馬夸語"
+    "馬夸語",
+    "马夸语"
   ],
   "mgi": [
     "Jili",
@@ -15778,25 +17223,29 @@
     "Mbangi"
   ],
   "mgo": [
-    "美塔語"
+    "美塔語",
+    "美塔语"
   ],
   "mgp": [
     "東馬嘉爾語",
-    "Eastern Magar"
+    "Eastern Magar",
+    "东马嘉尔语"
   ],
   "mgq": [
     "Malila"
   ],
   "mgr": [
     "曼布韋-倫古語",
-    "Mambwe-Lungu"
+    "Mambwe-Lungu",
+    "曼布韦-伦古语"
   ],
   "mgs": [
     "曼達語（坦桑尼亞）",
     "Manda (Tanzania)",
     "Kimanda",
     "Kinyasa",
-    "Nyasa"
+    "Nyasa",
+    "曼达语（坦桑尼亚）"
   ],
   "mgt": [
     "Mongol"
@@ -15820,18 +17269,21 @@
     "Mbugwe"
   ],
   "mh": [
-    "馬紹爾語"
+    "馬紹爾語",
+    "马绍尔语"
   ],
   "mha": [
     "曼達語（印度）",
-    "Manda (India)"
+    "Manda (India)",
+    "曼达语（印度）"
   ],
   "mhb": [
     "Mahongwe"
   ],
   "mhc": [
     "莫喬語",
-    "Mocho"
+    "Mocho",
+    "莫乔语"
   ],
   "mhd": [
     "Mbugu",
@@ -15847,7 +17299,8 @@
   ],
   "mhg": [
     "馬爾古語",
-    "Margu"
+    "Margu",
+    "马尔古语"
   ],
   "mhi": [
     "Ma'di"
@@ -15855,7 +17308,8 @@
   "mhj": [
     "蒙戈勒語",
     "Mogholi",
-    "Moghol"
+    "Moghol",
+    "蒙戈勒语"
   ],
   "mhk": [
     "Mungaka"
@@ -15868,14 +17322,16 @@
   ],
   "mhn": [
     "默切諾語",
-    "Mòcheno"
+    "Mòcheno",
+    "默切诺语"
   ],
   "mho": [
     "Mashi"
   ],
   "mhp": [
     "峇里馬來語",
-    "Balinese Malay"
+    "Balinese Malay",
+    "峇里马来语"
   ],
   "mhq": [
     "Mandan"
@@ -15916,41 +17372,49 @@
     "Austronesian Mor"
   ],
   "mi": [
-    "毛利語"
+    "毛利語",
+    "毛利语"
   ],
   "mia": [
     "Miami"
   ],
   "mib": [
     "阿塔特拉烏卡米斯特克語",
-    "Atatláhuca Mixtec"
+    "Atatláhuca Mixtec",
+    "阿塔特拉乌卡米斯特克语"
   ],
   "mic": [
     "密克馬克語",
-    "Mi'kmaq"
+    "Mi'kmaq",
+    "密克马克语"
   ],
   "mid": [
     "曼達安語",
-    "Mandaic"
+    "Mandaic",
+    "曼达安语"
   ],
   "mie": [
     "奧科特佩克米斯特克語",
-    "Ocotepec Mixtec"
+    "Ocotepec Mixtec",
+    "奥科特佩克米斯特克语"
   ],
   "mif": [
     "Mofu-Gudur"
   ],
   "mig": [
     "大聖米蓋爾米斯特克語",
-    "San Miguel el Grande Mixtec"
+    "San Miguel el Grande Mixtec",
+    "大圣米盖尔米斯特克语"
   ],
   "mih": [
     "查尤科米斯特克語",
-    "Chayuco Mixtec"
+    "Chayuco Mixtec",
+    "查尤科米斯特克语"
   ],
   "mii": [
     "奇格梅卡蒂特蘭米斯特克語",
-    "Chigmecatitlán Mixtec"
+    "Chigmecatitlán Mixtec",
+    "奇格梅卡蒂特兰米斯特克语"
   ],
   "mij": [
     "Mungbam",
@@ -15961,61 +17425,76 @@
   ],
   "mik": [
     "密卡蘇奇語",
-    "Mikasuki"
+    "Mikasuki",
+    "密卡苏奇语"
   ],
   "mil": [
     "佩諾爾斯米斯特克語",
-    "Peñoles Mixtec"
+    "Peñoles Mixtec",
+    "佩诺尔斯米斯特克语"
   ],
   "mim": [
     "阿拉卡特拉扎拉米斯特克語",
-    "Alacatlatzala Mixtec"
+    "Alacatlatzala Mixtec",
+    "阿拉卡特拉扎拉米斯特克语"
   ],
   "min": [
     "米南佳保語",
     "米南加保語",
     "米南卡保語",
-    "Minangkabau"
+    "Minangkabau",
+    "米南佳保语",
+    "米南加保语",
+    "米南卡保语"
   ],
   "mio": [
     "皮諾特帕納雄耐爾米斯特克語",
-    "Pinotepa Nacional Mixtec"
+    "Pinotepa Nacional Mixtec",
+    "皮诺特帕纳雄耐尔米斯特克语"
   ],
   "mip": [
     "阿帕斯科-阿波亞拉米斯特克語",
-    "Apasco-Apoala Mixtec"
+    "Apasco-Apoala Mixtec",
+    "阿帕斯科-阿波亚拉米斯特克语"
   ],
   "miq": [
     "米斯基托語",
     "Miskito",
-    "Miskitu"
+    "Miskitu",
+    "米斯基托语"
   ],
   "mir": [
     "地峽米塞語",
-    "Isthmus Mixe"
+    "Isthmus Mixe",
+    "地峡米塞语"
   ],
   "mit": [
     "南普埃布拉米斯特克語",
-    "Southern Puebla Mixtec"
+    "Southern Puebla Mixtec",
+    "南普埃布拉米斯特克语"
   ],
   "miu": [
     "卡卡洛斯特佩克米斯特克語",
-    "Cacaloxtepec Mixtec"
+    "Cacaloxtepec Mixtec",
+    "卡卡洛斯特佩克米斯特克语"
   ],
   "miw": [
     "Akoye"
   ],
   "mix": [
     "米斯特佩克米斯特克語",
-    "Mixtepec Mixtec"
+    "Mixtepec Mixtec",
+    "米斯特佩克米斯特克语"
   ],
   "miy": [
     "阿尤特拉米斯特克語",
-    "Ayutla Mixtec"
+    "Ayutla Mixtec",
+    "阿尤特拉米斯特克语"
   ],
   "miz": [
     "科亞佐斯潘米斯特克語",
-    "Coatzospan Mixtec"
+    "Coatzospan Mixtec",
+    "科亚佐斯潘米斯特克语"
   ],
   "mjb": [
     "Makalero",
@@ -16023,22 +17502,26 @@
   ],
   "mjc": [
     "聖胡安科羅拉多米斯特克語",
-    "San Juan Colorado Mixtec"
+    "San Juan Colorado Mixtec",
+    "圣胡安科罗拉多米斯特克语"
   ],
   "mjd": [
     "西北邁杜語",
-    "Northwest Maidu"
+    "Northwest Maidu",
+    "西北迈杜语"
   ],
   "mje": [
     "Muskum"
   ],
   "mjg": [
     "土族語",
-    "Monguor"
+    "Monguor",
+    "土族语"
   ],
   "mji": [
     "金門語",
-    "Kim Mun"
+    "Kim Mun",
+    "金门语"
   ],
   "mjj": [
     "Mawak"
@@ -16048,7 +17531,8 @@
   ],
   "mjl": [
     "曼迪阿里語",
-    "Mandeali"
+    "Mandeali",
+    "曼迪阿里语"
   ],
   "mjm": [
     "Medebur"
@@ -16100,28 +17584,33 @@
   ],
   "mjy": [
     "莫希干語",
-    "Mahican"
+    "Mahican",
+    "莫希干语"
   ],
   "mjz": [
     "邁希語",
-    "Majhi"
+    "Majhi",
+    "迈希语"
   ],
   "mk": [
-    "馬其頓語"
+    "馬其頓語",
+    "马其顿语"
   ],
   "mka": [
     "Mbre"
   ],
   "mkb": [
     "馬爾帕哈里亞語",
-    "Mal Paharia"
+    "Mal Paharia",
+    "马尔帕哈里亚语"
   ],
   "mkc": [
     "Siliput"
   ],
   "mke": [
     "茂奇語",
-    "Mawchi"
+    "Mawchi",
+    "茂奇语"
   ],
   "mkf": [
     "Miya"
@@ -16129,66 +17618,81 @@
   "mkg": [
     "莫語",
     "Mak (China)",
-    "Mak"
+    "Mak",
+    "莫语"
   ],
   "mkh-asl-pro": [
     "原始亞斯里語",
-    "Proto-Aslian"
+    "Proto-Aslian",
+    "原始亚斯里语"
   ],
   "mkh-ban-pro": [
     "原始巴拿語",
-    "Proto-Bahnaric"
+    "Proto-Bahnaric",
+    "原始巴拿语"
   ],
   "mkh-kat-pro": [
     "原始戈都語",
-    "Proto-Katuic"
+    "Proto-Katuic",
+    "原始戈都语"
   ],
   "mkh-khm-pro": [
     "原始克木語",
-    "Proto-Khmuic"
+    "Proto-Khmuic",
+    "原始克木语"
   ],
   "mkh-kmr-pro": [
     "原始高棉語",
-    "Proto-Khmeric"
+    "Proto-Khmeric",
+    "原始高棉语"
   ],
   "mkh-mmn": [
     "中古孟語",
-    "Middle Mon"
+    "Middle Mon",
+    "中古孟语"
   ],
   "mkh-mnc-pro": [
     "原始孟語",
-    "Proto-Monic"
+    "Proto-Monic",
+    "原始孟语"
   ],
   "mkh-mvi": [
     "中古越南語",
-    "Middle Vietnamese"
+    "Middle Vietnamese",
+    "中古越南语"
   ],
   "mkh-okm": [
     "古高棉語",
-    "Old Khmer"
+    "Old Khmer",
+    "古高棉语"
   ],
   "mkh-pal-pro": [
     "原始佤德昂語",
-    "Proto-Palaungic"
+    "Proto-Palaungic",
+    "原始佤德昂语"
   ],
   "mkh-pea-pro": [
     "原始比爾語",
-    "Proto-Pearic"
+    "Proto-Pearic",
+    "原始比尔语"
   ],
   "mkh-pkn-pro": [
     "Proto-Pakanic"
   ],
   "mkh-pro": [
     "原始孟-高棉語",
-    "Proto-Mon-Khmer"
+    "Proto-Mon-Khmer",
+    "原始孟-高棉语"
   ],
   "mkh-vie-pro": [
     "原始越語",
-    "Proto-Vietic"
+    "Proto-Vietic",
+    "原始越语"
   ],
   "mki": [
     "達特基語",
-    "Dhatki"
+    "Dhatki",
+    "达特基语"
   ],
   "mkj": [
     "Mokilese"
@@ -16204,7 +17708,8 @@
   ],
   "mkn": [
     "古邦馬來語",
-    "Kupang Malay"
+    "Kupang Malay",
+    "古邦马来语"
   ],
   "mko": [
     "Mingang Doso"
@@ -16220,7 +17725,8 @@
   ],
   "mks": [
     "西拉卡約亞潘米斯特克語",
-    "Silacayoapan Mixtec"
+    "Silacayoapan Mixtec",
+    "西拉卡约亚潘米斯特克语"
   ],
   "mkt": [
     "Vamale"
@@ -16232,7 +17738,8 @@
     "Mafea"
   ],
   "mkx": [
-    "甘米銀-馬諾博語"
+    "甘米銀-馬諾博語",
+    "甘米银-马诺博语"
   ],
   "mky": [
     "East Makian"
@@ -16241,7 +17748,8 @@
     "Makasae"
   ],
   "ml": [
-    "馬拉雅拉姆語"
+    "馬拉雅拉姆語",
+    "马拉雅拉姆语"
   ],
   "mla": [
     "Tamambo",
@@ -16255,7 +17763,8 @@
   "mlc": [
     "高欄語",
     "Caolan",
-    "Man Cao Lan"
+    "Man Cao Lan",
+    "高栏语"
   ],
   "mle": [
     "Manambu"
@@ -16281,7 +17790,8 @@
   ],
   "mlm": [
     "仫佬語",
-    "Mulam"
+    "Mulam",
+    "仫佬语"
   ],
   "mln": [
     "Malango"
@@ -16328,11 +17838,13 @@
   ],
   "mmc": [
     "米卻肯馬薩瓦語",
-    "Michoacán Mazahua"
+    "Michoacán Mazahua",
+    "米却肯马萨瓦语"
   ],
   "mmd": [
     "毛南語",
-    "Maonan"
+    "Maonan",
+    "毛南语"
   ],
   "mme": [
     "Mae"
@@ -16360,11 +17872,13 @@
   ],
   "mmm": [
     "邁伊語",
-    "Maii"
+    "Maii",
+    "迈伊语"
   ],
   "mmn": [
     "瑪曼瓦語",
-    "Mamanwa"
+    "Mamanwa",
+    "玛曼瓦语"
   ],
   "mmo": [
     "Mangga Buang"
@@ -16377,11 +17891,13 @@
     "Aisi",
     "Musak",
     "Mabɨŋ",
-    "Mabing"
+    "Mabing",
+    "艾西语"
   ],
   "mmr": [
     "西部湘西苗語",
-    "Western Xiangxi Miao"
+    "Western Xiangxi Miao",
+    "西部湘西苗语"
   ],
   "mmt": [
     "Malalamai"
@@ -16405,7 +17921,8 @@
     "Mabaale"
   ],
   "mn": [
-    "蒙古語"
+    "蒙古語",
+    "蒙古语"
   ],
   "mna": [
     "Mbula"
@@ -16414,7 +17931,8 @@
     "Muna"
   ],
   "mnc": [
-    "滿語"
+    "滿語",
+    "满语"
   ],
   "mnd": [
     "Mondé",
@@ -16433,7 +17951,8 @@
     "Mundani"
   ],
   "mng": [
-    "東墨儂語"
+    "東墨儂語",
+    "东墨侬语"
   ],
   "mnh": [
     "Mono (Congo)",
@@ -16444,7 +17963,8 @@
     "曼尼普爾語",
     "Manipuri",
     "Meitei",
-    "Meithei"
+    "Meithei",
+    "曼尼普尔语"
   ],
   "mnj": [
     "蒙賈尼語",
@@ -16452,12 +17972,14 @@
     "Munjani",
     "Mundzhan",
     "Mundzhani",
-    "Mundzi"
+    "Mundzi",
+    "蒙贾尼语"
   ],
   "mnk": [
     "曼丁哥語",
     "Mandinka",
-    "Mandingo"
+    "Mandingo",
+    "曼丁哥语"
   ],
   "mnl": [
     "Tiale"
@@ -16466,14 +17988,17 @@
     "Mapena"
   ],
   "mnn": [
-    "南墨儂語"
+    "南墨儂語",
+    "南墨侬语"
   ],
   "mnp": [
     "閩北語",
     "Mâing-bă̤-ngṳ̌",
     "閩北事",
     "Mâing-bă̤-dī",
-    "Min Bei"
+    "Min Bei",
+    "闽北语",
+    "闽北事"
   ],
   "mnq": [
     "Minriq"
@@ -16490,7 +18015,8 @@
   ],
   "mns": [
     "曼西語",
-    "Mansi"
+    "Mansi",
+    "曼西语"
   ],
   "mnt": [
     "馬伊庫蘭語",
@@ -16498,7 +18024,8 @@
     "Mayi-Kulan",
     "Wunumara",
     "Mayi-Yapi",
-    "Mayi-Thakurti"
+    "Mayi-Thakurti",
+    "马伊库兰语"
   ],
   "mnu": [
     "Mer"
@@ -16507,14 +18034,17 @@
     "拉納爾語",
     "倫內爾語",
     "Rennellese",
-    "Rennell-Bellona"
+    "Rennell-Bellona",
+    "拉纳尔语",
+    "伦内尔语"
   ],
   "mnw": [
     "孟語",
     "Mon",
     "Peguan",
     "Talaing",
-    "Raman"
+    "Raman",
+    "孟语"
   ],
   "mnx": [
     "Manikion",
@@ -16542,15 +18072,18 @@
   ],
   "moe": [
     "蒙大拿語",
-    "Montagnais"
+    "Montagnais",
+    "蒙大拿语"
   ],
   "mog": [
     "蒙貢多語",
-    "Mongondow"
+    "Mongondow",
+    "蒙贡多语"
   ],
   "moh": [
     "莫霍克語",
-    "Mohawk"
+    "Mohawk",
+    "莫霍克语"
   ],
   "moi": [
     "Mboi"
@@ -16574,7 +18107,8 @@
     "Mopan Maya",
     "Mopan",
     "Mopán Maya",
-    "Mopán"
+    "Mopán",
+    "莫潘玛雅语"
   ],
   "moq": [
     "Mor (Papuan)",
@@ -16593,7 +18127,8 @@
     "Mòoré",
     "Mooré",
     "Moré",
-    "Möré"
+    "Möré",
+    "莫西语"
   ],
   "mot": [
     "Barí",
@@ -16629,26 +18164,31 @@
   "mpb": [
     "馬拉克馬拉克語",
     "Mullukmulluk",
-    "Malak-Malak"
+    "Malak-Malak",
+    "马拉克马拉克语"
   ],
   "mpc": [
     "曼加拉伊語",
-    "Mangarayi"
+    "Mangarayi",
+    "曼加拉伊语"
   ],
   "mpd": [
     "Machinere"
   ],
   "mpe": [
     "馬江語",
-    "Majang"
+    "Majang",
+    "马江语"
   ],
   "mpg": [
     "馬爾巴語",
-    "Marba"
+    "Marba",
+    "马尔巴语"
   ],
   "mph": [
     "毛翁語",
-    "Maung"
+    "Maung",
+    "毛翁语"
   ],
   "mpi": [
     "Mpade"
@@ -16657,19 +18197,22 @@
     "馬圖汪加語",
     "Martu Wangka",
     "Yulparija",
-    "Yulparitja"
+    "Yulparitja",
+    "马图汪加语"
   ],
   "mpk": [
     "姆巴拉語（乍得）",
     "Mbara (Chad)",
-    "Mbara"
+    "Mbara",
+    "姆巴拉语（乍得）"
   ],
   "mpl": [
     "Middle Watut"
   ],
   "mpm": [
     "約松杜亞米斯特克語",
-    "Yosondúa Mixtec"
+    "Yosondúa Mixtec",
+    "约松杜亚米斯特克语"
   ],
   "mpn": [
     "Mindiri"
@@ -16735,24 +18278,28 @@
   ],
   "mqh": [
     "特拉索亞爾特佩克米斯特克語",
-    "Yosondúa Mixtec"
+    "Yosondúa Mixtec",
+    "特拉索亚尔特佩克米斯特克语"
   ],
   "mqi": [
     "Mariri"
   ],
   "mqj": [
     "馬馬薩語",
-    "Mamasa"
+    "Mamasa",
+    "马马萨语"
   ],
   "mqk": [
-    "拉賈卡本選-馬諾博語"
+    "拉賈卡本選-馬諾博語",
+    "拉贾卡本选-马诺博语"
   ],
   "mql": [
     "Mbelime"
   ],
   "mqm": [
     "南馬克薩斯語",
-    "South Marquesan"
+    "South Marquesan",
+    "南马克萨斯语"
   ],
   "mqn": [
     "Moronene"
@@ -16771,7 +18318,8 @@
   ],
   "mqs": [
     "西馬基安語",
-    "West Makian"
+    "West Makian",
+    "西马基安语"
   ],
   "mqt": [
     "Mok"
@@ -16790,14 +18338,16 @@
   ],
   "mqy": [
     "芒加萊語",
-    "Manggarai"
+    "Manggarai",
+    "芒加莱语"
   ],
   "mqz": [
     "Malasanga",
     "Pano"
   ],
   "mr": [
-    "馬拉地語"
+    "馬拉地語",
+    "马拉地语"
   ],
   "mra": [
     "Mlabri"
@@ -16807,15 +18357,18 @@
   ],
   "mrc": [
     "馬里科帕語",
-    "Maricopa"
+    "Maricopa",
+    "马里科帕语"
   ],
   "mrd": [
     "西馬嘉爾語",
-    "Western Magar"
+    "Western Magar",
+    "西马嘉尔语"
   ],
   "mre": [
     "瑪莎葡萄園島手語",
-    "Martha's Vineyard Sign Language"
+    "Martha's Vineyard Sign Language",
+    "玛莎葡萄园岛手语"
   ],
   "mrf": [
     "Elseng"
@@ -16843,7 +18396,9 @@
     "Western Mari",
     "Hill Mari",
     "Mountain Mari",
-    "Highland Mari"
+    "Highland Mari",
+    "山地马里语",
+    "西部马里语"
   ],
   "mrk": [
     "Hmwaveke"
@@ -16857,7 +18412,8 @@
   "mrn": [
     "切克霍羅語",
     "Cheke Holo",
-    "Maringe"
+    "Maringe",
+    "切克霍罗语"
   ],
   "mro": [
     "Mru"
@@ -16867,7 +18423,8 @@
   ],
   "mrq": [
     "北馬克薩斯語",
-    "North Marquesan"
+    "North Marquesan",
+    "北马克萨斯语"
   ],
   "mrr": [
     "Hill Maria",
@@ -16894,11 +18451,13 @@
   ],
   "mrw": [
     "馬拉瑙語",
-    "Maranao"
+    "Maranao",
+    "马拉瑙语"
   ],
   "mrx": [
     "迪內奧爾語",
-    "Dineor"
+    "Dineor",
+    "迪内奥尔语"
   ],
   "mry": [
     "Karaga Mandaya"
@@ -16907,21 +18466,24 @@
     "Marind"
   ],
   "ms": [
-    "馬來語"
+    "馬來語",
+    "马来语"
   ],
   "msb": [
     "馬斯巴特語",
     "Masbatenyo",
     "Masbateño",
     "Masbateno",
-    "Minasbate"
+    "Minasbate",
+    "马斯巴特语"
   ],
   "msc": [
     "Sankaran Maninka"
   ],
   "msd": [
     "猶加敦瑪雅手語",
-    "Yucatec Maya Sign Language"
+    "Yucatec Maya Sign Language",
+    "犹加敦玛雅手语"
   ],
   "mse": [
     "Musey"
@@ -16936,7 +18498,8 @@
   ],
   "msi": [
     "沙巴馬來語",
-    "Sabah Malay"
+    "Sabah Malay",
+    "沙巴马来语"
   ],
   "msj": [
     "Ma",
@@ -16944,17 +18507,20 @@
   ],
   "msk": [
     "曼薩卡語",
-    "Mansaka"
+    "Mansaka",
+    "曼萨卡语"
   ],
   "msl": [
     "Molof"
   ],
   "msm": [
-    "阿古桑-馬諾博語"
+    "阿古桑-馬諾博語",
+    "阿古桑-马诺博语"
   ],
   "msn": [
     "烏雷斯語",
-    "Vurës"
+    "Vurës",
+    "乌雷斯语"
   ],
   "mso": [
     "Mombum"
@@ -16969,7 +18535,8 @@
   ],
   "msr": [
     "蒙古手語",
-    "Mongolian Sign Language"
+    "Mongolian Sign Language",
+    "蒙古手语"
   ],
   "mss": [
     "West Masela"
@@ -16993,10 +18560,12 @@
     "Momare"
   ],
   "mt": [
-    "馬爾他語"
+    "馬爾他語",
+    "马尔他语"
   ],
   "mta": [
-    "哥打巴托-馬諾博語"
+    "哥打巴托-馬諾博語",
+    "哥打巴托-马诺博语"
   ],
   "mtb": [
     "Anyin Morofo"
@@ -17043,24 +18612,28 @@
     "Mator",
     "Taygi",
     "Karagas",
-    "Mator-Taygi-Karagas"
+    "Mator-Taygi-Karagas",
+    "马托尔语"
   ],
   "mtn": [
     "Matagalpa"
   ],
   "mto": [
     "特通特佩克米塞語",
-    "Totontepec Mixe"
+    "Totontepec Mixe",
+    "特通特佩克米塞语"
   ],
   "mtp": [
     "Wichí Lhamtés Nocten"
   ],
   "mtq": [
     "芒語",
-    "Muong"
+    "Muong",
+    "芒语"
   ],
   "mtr": [
-    "梅瓦爾語"
+    "梅瓦爾語",
+    "梅瓦尔语"
   ],
   "mts": [
     "Yora"
@@ -17070,27 +18643,31 @@
   ],
   "mtu": [
     "圖圖特佩克米斯特克語",
-    "Tututepec Mixtec"
+    "Tututepec Mixtec",
+    "图图特佩克米斯特克语"
   ],
   "mtv": [
     "阿薩羅奧語",
     "Asaro'o",
     "Molet",
     "Molet Kasu",
-    "Molet Mur"
+    "Molet Mur",
+    "阿萨罗奥语"
   ],
   "mtw": [
     "Magahat"
   ],
   "mtx": [
     "蒂達亞米斯特克語",
-    "Tidaá Mixtec"
+    "Tidaá Mixtec",
+    "蒂达亚米斯特克语"
   ],
   "mty": [
     "Nabi"
   ],
   "mua": [
-    "蒙當語"
+    "蒙當語",
+    "蒙当语"
   ],
   "mub": [
     "Mubi"
@@ -17122,24 +18699,28 @@
   ],
   "mul": [
     "跨語言",
-    "Translingual"
+    "Translingual",
+    "跨语言"
   ],
   "mum": [
     "Maiwala"
   ],
   "mun-pro": [
-    "原始蒙達語"
+    "原始蒙達語",
+    "原始蒙达语"
   ],
   "muo": [
     "Nyong"
   ],
   "mup": [
     "馬爾瓦語",
-    "Malvi"
+    "Malvi",
+    "马尔瓦语"
   ],
   "muq": [
     "西部湘西苗語",
-    "Eastern Xiangxi Miao"
+    "Eastern Xiangxi Miao",
+    "西部湘西苗语"
   ],
   "mur": [
     "Murle"
@@ -17147,11 +18728,13 @@
   "mus": [
     "克里克語",
     "Creek",
-    "Muscogee"
+    "Muscogee",
+    "克里克语"
   ],
   "mut": [
     "西穆里亞語",
-    "Western Muria"
+    "Western Muria",
+    "西穆里亚语"
   ],
   "muu": [
     "Yaaku"
@@ -17179,14 +18762,16 @@
   ],
   "mvg": [
     "尤夸涅米斯特克語",
-    "Yucuañe Mixtec"
+    "Yucuañe Mixtec",
+    "尤夸涅米斯特克语"
   ],
   "mvh": [
     "Mire"
   ],
   "mvi": [
     "宮古語",
-    "Miyako"
+    "Miyako",
+    "宫古语"
   ],
   "mvk": [
     "Mekmek"
@@ -17195,7 +18780,8 @@
     "姆巴拉語（澳洲）",
     "Mbara (Australia)",
     "Mbara",
-    "Midjamba"
+    "Midjamba",
+    "姆巴拉语（澳洲）"
   ],
   "mvm": [
     "Muya"
@@ -17226,7 +18812,8 @@
   ],
   "mvv": [
     "塔戈爾語",
-    "Tagal Murut"
+    "Tagal Murut",
+    "塔戈尔语"
   ],
   "mvw": [
     "Machinga"
@@ -17236,7 +18823,8 @@
   ],
   "mvy": [
     "印度河科希斯坦語",
-    "Indus Kohistani"
+    "Indus Kohistani",
+    "印度河科希斯坦语"
   ],
   "mvz": [
     "Mesqan"
@@ -17258,7 +18846,8 @@
   ],
   "mwf": [
     "穆林帕塔語",
-    "Murrinh-Patha"
+    "Murrinh-Patha",
+    "穆林帕塔语"
   ],
   "mwg": [
     "Aiklep"
@@ -17274,7 +18863,8 @@
   ],
   "mwl": [
     "米蘭德斯語",
-    "Mirandese"
+    "Mirandese",
+    "米兰德斯语"
   ],
   "mwm": [
     "Sar"
@@ -17287,7 +18877,8 @@
   ],
   "mwp": [
     "卡拉拉高雅語",
-    "Kala Lagaw Ya"
+    "Kala Lagaw Ya",
+    "卡拉拉高雅语"
   ],
   "mwq": [
     "Mün Chin",
@@ -17303,7 +18894,8 @@
     "Shekhawati",
     "Harauti",
     "Goaria",
-    "Gurgula"
+    "Gurgula",
+    "马瓦里语"
   ],
   "mws": [
     "Mwimbi-Muthambi"
@@ -17315,24 +18907,28 @@
     "Mittu"
   ],
   "mwv": [
-    "明打威語"
+    "明打威語",
+    "明打威语"
   ],
   "mww": [
     "白苗語",
     "White Hmong",
     "Hmong Daw",
-    "Hmoob Dawb"
+    "Hmoob Dawb",
+    "白苗语"
   ],
   "mwz": [
     "Moingi"
   ],
   "mxa": [
     "西北瓦哈卡米斯特克語",
-    "Northwest Oaxaca Mixtec"
+    "Northwest Oaxaca Mixtec",
+    "西北瓦哈卡米斯特克语"
   ],
   "mxb": [
     "特索亞特蘭米斯特克語",
-    "Tezoatlán Mixtec"
+    "Tezoatlán Mixtec",
+    "特索亚特兰米斯特克语"
   ],
   "mxd": [
     "Modang"
@@ -17351,7 +18947,8 @@
   ],
   "mxi": [
     "莫札拉布語",
-    "Mozarabic"
+    "Mozarabic",
+    "莫札拉布语"
   ],
   "mxj": [
     "格曼語",
@@ -17362,7 +18959,8 @@
     "Geman",
     "Kaman",
     "Kman",
-    "Midzu"
+    "Midzu",
+    "格曼语"
   ],
   "mxk": [
     "Monumbo"
@@ -17383,11 +18981,13 @@
   ],
   "mxp": [
     "特拉惠托爾特佩克米塞語",
-    "Tlahuitoltepec Mixe"
+    "Tlahuitoltepec Mixe",
+    "特拉惠托尔特佩克米塞语"
   ],
   "mxq": [
     "胡基拉米塞語",
-    "Juquila Mixe"
+    "Juquila Mixe",
+    "胡基拉米塞语"
   ],
   "mxr": [
     "Murik (Malaysia)",
@@ -17396,11 +18996,13 @@
   ],
   "mxs": [
     "惠特佩克米斯特克語",
-    "Huitepec Mixtec"
+    "Huitepec Mixtec",
+    "惠特佩克米斯特克语"
   ],
   "mxt": [
     "哈米爾特佩克米斯特克語",
-    "Jamiltepec Mixtec"
+    "Jamiltepec Mixtec",
+    "哈米尔特佩克米斯特克语"
   ],
   "mxu": [
     "Mada (Cameroon)",
@@ -17408,7 +19010,8 @@
   ],
   "mxv": [
     "梅特拉托諾克米斯特克語",
-    "Metlatónoc Mixtec"
+    "Metlatónoc Mixtec",
+    "梅特拉托诺克米斯特克语"
   ],
   "mxw": [
     "Namo"
@@ -17423,13 +19026,15 @@
   ],
   "mxy": [
     "東南諾奇斯特蘭米斯特克語",
-    "Southeastern Nochixtlán Mixtec"
+    "Southeastern Nochixtlán Mixtec",
+    "东南诺奇斯特兰米斯特克语"
   ],
   "mxz": [
     "Central Masela"
   ],
   "my": [
-    "緬甸語"
+    "緬甸語",
+    "缅甸语"
   ],
   "myb": [
     "Mbay"
@@ -17438,7 +19043,8 @@
     "Mayeka"
   ],
   "mye": [
-    "姆耶內語"
+    "姆耶內語",
+    "姆耶内语"
   ],
   "myf": [
     "Bambassi"
@@ -17470,14 +19076,16 @@
   "myn-pro": [
     "原始瑪雅語",
     "Proto-Mayan",
-    "Proto-Maya"
+    "Proto-Maya",
+    "原始玛雅语"
   ],
   "myo": [
     "Anfillo"
   ],
   "myp": [
     "皮拉罕語",
-    "Pirahã"
+    "Pirahã",
+    "皮拉罕语"
   ],
   "myr": [
     "Muniche"
@@ -17491,7 +19099,8 @@
   "myv": [
     "埃爾齊亞語",
     "Erzya",
-    "Mordvin"
+    "Mordvin",
+    "埃尔齐亚语"
   ],
   "myw": [
     "Muyuw"
@@ -17508,11 +19117,13 @@
   ],
   "myz": [
     "古典曼達安語",
-    "Classical Mandaic"
+    "Classical Mandaic",
+    "古典曼达安语"
   ],
   "mza": [
     "聖瑪利亞薩卡特佩克米斯特克語",
-    "Santa María Zacatepec Mixtec"
+    "Santa María Zacatepec Mixtec",
+    "圣玛利亚萨卡特佩克米斯特克语"
   ],
   "mzb": [
     "Tumzabt",
@@ -17521,7 +19132,8 @@
   ],
   "mzc": [
     "馬達加斯加手語",
-    "Madagascar Sign Language"
+    "Madagascar Sign Language",
+    "马达加斯加手语"
   ],
   "mzd": [
     "Malimba"
@@ -17531,25 +19143,29 @@
   ],
   "mzg": [
     "修道院手語",
-    "Monastic Sign Language"
+    "Monastic Sign Language",
+    "修道院手语"
   ],
   "mzh": [
     "Wichí Lhamtés Güisnay"
   ],
   "mzi": [
     "伊斯卡特蘭馬薩特克語",
-    "Ixcatlán Mazatec"
+    "Ixcatlán Mazatec",
+    "伊斯卡特兰马萨特克语"
   ],
   "mzj": [
     "Manya"
   ],
   "mzk": [
     "尼日利亞曼比拉語",
-    "Nigeria Mambila"
+    "Nigeria Mambila",
+    "尼日利亚曼比拉语"
   ],
   "mzl": [
     "馬薩特蘭米塞語",
-    "Mazatlán Mixe"
+    "Mazatlán Mixe",
+    "马萨特兰米塞语"
   ],
   "mzm": [
     "Mumuye"
@@ -17558,7 +19174,8 @@
     "馬贊德蘭語",
     "Mazanderani",
     "Mazandarani",
-    "Tabari"
+    "Tabari",
+    "马赞德兰语"
   ],
   "mzo": [
     "Matipuhy"
@@ -17574,7 +19191,8 @@
   ],
   "mzs": [
     "澳門土生葡語",
-    "Macanese"
+    "Macanese",
+    "澳门土生葡语"
   ],
   "mzt": [
     "Mintil"
@@ -17594,13 +19212,16 @@
   "mzy": [
     "莫桑比克手語",
     "莫三比克手語",
-    "Mozambican Sign Language"
+    "Mozambican Sign Language",
+    "莫桑比克手语",
+    "莫三比克手语"
   ],
   "mzz": [
     "Maiadomu"
   ],
   "na": [
-    "瑙魯語"
+    "瑙魯語",
+    "瑙鲁语"
   ],
   "naa": [
     "Namla"
@@ -17627,7 +19248,8 @@
   ],
   "nah": [
     "納瓦特爾語",
-    "Nahuatl"
+    "Nahuatl",
+    "纳瓦特尔语"
   ],
   "nai-ala": [
     "Alazapa",
@@ -17707,7 +19329,8 @@
   ],
   "nai-klp-pro": [
     "原始卡拉普亞語",
-    "Proto-Kalapuyan"
+    "Proto-Kalapuyan",
+    "原始卡拉普亚语"
   ],
   "nai-knm": [
     "Konomihu"
@@ -17738,7 +19361,8 @@
   "nai-miz-pro": [
     "原始米塞-索克語",
     "Proto-Mixe-Zoque",
-    "Proto-Mixe-Zoquean"
+    "Proto-Mixe-Zoquean",
+    "原始米塞-索克语"
   ],
   "nai-nao": [
     "Naolan"
@@ -17780,14 +19404,16 @@
   "nai-pom-pro": [
     "原始波莫語",
     "Proto-Pomo",
-    "Proto-Pomoan"
+    "Proto-Pomoan",
+    "原始波莫语"
   ],
   "nai-qng": [
     "Quinigua"
   ],
   "nai-sca-pro": [
     "原始蘇-卡托巴語",
-    "Proto-Siouan-Catawban"
+    "Proto-Siouan-Catawban",
+    "原始苏-卡托巴语"
   ],
   "nai-sin": [
     "Sinacantán"
@@ -17846,7 +19472,8 @@
   ],
   "nai-tot-pro": [
     "原始托托索克語",
-    "Proto-Totozoquean"
+    "Proto-Totozoquean",
+    "原始托托索克语"
   ],
   "nai-tsi-pro": [
     "Proto-Tsimshianic"
@@ -17876,7 +19503,8 @@
   ],
   "nal": [
     "納利克語",
-    "Nalik"
+    "Nalik",
+    "纳利克语"
   ],
   "nam": [
     "Ngan'gityemerri",
@@ -17891,7 +19519,11 @@
     "Hokkien",
     "Taiwanese",
     "Amoy",
-    "Xiamenese"
+    "Xiamenese",
+    "闽南语",
+    "福建话",
+    "台湾话",
+    "厦门话"
   ],
   "nao": [
     "Naaba",
@@ -17901,7 +19533,9 @@
   "nap": [
     "那不勒斯語",
     "拿坡里語",
-    "Neapolitan"
+    "Neapolitan",
+    "那不勒斯语",
+    "拿坡里语"
   ],
   "naq": [
     "科伊科伊語",
@@ -17911,7 +19545,9 @@
     "Hottentot",
     "Khoekhoegowab",
     "Damara",
-    "Namagowab"
+    "Namagowab",
+    "科伊科伊语",
+    "纳马语"
   ],
   "nar": [
     "Iguta"
@@ -17932,14 +19568,17 @@
   "nay": [
     "恩加林杰里語",
     "Ngarrindjeri",
-    "Yaraldi"
+    "Yaraldi",
+    "恩加林杰里语"
   ],
   "naz": [
     "科阿特佩克納瓦特爾語",
-    "Coatepec Nahuatl"
+    "Coatepec Nahuatl",
+    "科阿特佩克纳瓦特尔语"
   ],
   "nb": [
-    "書面挪威語"
+    "書面挪威語",
+    "书面挪威语"
   ],
   "nba": [
     "Nyemba"
@@ -17994,7 +19633,8 @@
   ],
   "nbs": [
     "納米比亞手語",
-    "Namibian Sign Language"
+    "Namibian Sign Language",
+    "纳米比亚手语"
   ],
   "nbt": [
     "Na",
@@ -18023,7 +19663,8 @@
     "Camorta",
     "Kamorta",
     "Katchal",
-    "Tehnu"
+    "Tehnu",
+    "中尼科巴语"
   ],
   "ncc": [
     "Ponam"
@@ -18039,26 +19680,31 @@
   ],
   "ncg": [
     "尼斯加亞語",
-    "Nisga'a"
+    "Nisga'a",
+    "尼斯加亚语"
   ],
   "nch": [
     "中瓦斯特卡納瓦特爾語",
-    "Central Huasteca Nahuatl"
+    "Central Huasteca Nahuatl",
+    "中瓦斯特卡纳瓦特尔语"
   ],
   "nci": [
     "古典納瓦特爾語",
-    "Classical Nahuatl"
+    "Classical Nahuatl",
+    "古典纳瓦特尔语"
   ],
   "ncj": [
     "北普埃布拉納瓦特爾語",
-    "Northern Puebla Nahuatl"
+    "Northern Puebla Nahuatl",
+    "北普埃布拉纳瓦特尔语"
   ],
   "nck": [
     "Nakara"
   ],
   "ncl": [
     "米卻肯納瓦特爾語",
-    "Michoacán Nahuatl"
+    "Michoacán Nahuatl",
+    "米却肯纳瓦特尔语"
   ],
   "ncm": [
     "Nambo"
@@ -18074,7 +19720,8 @@
   ],
   "ncs": [
     "尼加拉瓜手語",
-    "Nicaraguan Sign Language"
+    "Nicaraguan Sign Language",
+    "尼加拉瓜手语"
   ],
   "nct": [
     "Chothe Naga",
@@ -18085,13 +19732,15 @@
   ],
   "ncx": [
     "中普埃布拉納瓦特爾語",
-    "Central Puebla Nahuatl"
+    "Central Puebla Nahuatl",
+    "中普埃布拉纳瓦特尔语"
   ],
   "ncz": [
     "Natchez"
   ],
   "nd": [
-    "北恩德貝勒語"
+    "北恩德貝勒語",
+    "北恩德贝勒语"
   ],
   "nda": [
     "Ndasa"
@@ -18148,15 +19797,19 @@
     "Low German",
     "低地薩克森語",
     "Low Saxon",
-    "Modern Low German"
+    "Modern Low German",
+    "低地德语",
+    "低地萨克森语"
   ],
   "nds-de": [
     "德國低地德語",
-    "German Low German"
+    "German Low German",
+    "德国低地德语"
   ],
   "nds-nl": [
     "下薩克森荷蘭語",
-    "Dutch Low Saxon"
+    "Dutch Low Saxon",
+    "下萨克森荷兰语"
   ],
   "ndt": [
     "Ndunga"
@@ -18180,7 +19833,8 @@
     "Ndogo"
   ],
   "ne": [
-    "尼泊爾語"
+    "尼泊爾語",
+    "尼泊尔语"
   ],
   "nea": [
     "Eastern Ngad'a"
@@ -18206,7 +19860,8 @@
   ],
   "neg": [
     "涅吉達爾語",
-    "Negidal"
+    "Negidal",
+    "涅吉达尔语"
   ],
   "neh": [
     "Nyenkha",
@@ -18240,7 +19895,8 @@
   ],
   "neq": [
     "中北部米塞語",
-    "North Central Mixe"
+    "North Central Mixe",
+    "中北部米塞语"
   ],
   "ner": [
     "Yahadian"
@@ -18260,7 +19916,8 @@
   "new": [
     "尼瓦爾語",
     "Newar",
-    "Newari"
+    "Newari",
+    "尼瓦尔语"
   ],
   "nex": [
     "Neme"
@@ -18285,13 +19942,15 @@
   ],
   "nfr": [
     "納凡拉語",
-    "Nafaanra"
+    "Nafaanra",
+    "纳凡拉语"
   ],
   "nfu": [
     "Mfumte"
   ],
   "ng": [
-    "恩敦加語"
+    "恩敦加語",
+    "恩敦加语"
   ],
   "nga": [
     "Ngbaka",
@@ -18317,7 +19976,8 @@
   ],
   "ngf-pro": [
     "原始跨新幾內亞語",
-    "Proto-Trans-New Guinea"
+    "Proto-Trans-New Guinea",
+    "原始跨新几内亚语"
   ],
   "ngg": [
     "Ngbaka Manza"
@@ -18325,7 +19985,8 @@
   "ngh": [
     "努語",
     "Nǀuu",
-    "Nǁng"
+    "Nǁng",
+    "努语"
   ],
   "ngi": [
     "Ngizim"
@@ -18370,7 +20031,8 @@
   ],
   "ngu": [
     "格雷羅納瓦特爾語",
-    "Guerrero Nahuatl"
+    "Guerrero Nahuatl",
+    "格雷罗纳瓦特尔语"
   ],
   "ngv": [
     "Nagumi"
@@ -18395,46 +20057,54 @@
   ],
   "nhc": [
     "塔巴斯科納瓦特爾語",
-    "Tabasco Nahuatl"
+    "Tabasco Nahuatl",
+    "塔巴斯科纳瓦特尔语"
   ],
   "nhd": [
     "奇里帕語",
     "Chiripá",
     "Ava Guarani",
     "Chiripá Guarani",
-    "Nhandéva"
+    "Nhandéva",
+    "奇里帕语"
   ],
   "nhe": [
     "東瓦斯特卡納瓦特爾語",
-    "Eastern Huasteca Nahuatl"
+    "Eastern Huasteca Nahuatl",
+    "东瓦斯特卡纳瓦特尔语"
   ],
   "nhf": [
     "Nhuwala"
   ],
   "nhg": [
     "特萊爾辛戈納瓦特爾語",
-    "Tetelcingo Nahuatl"
+    "Tetelcingo Nahuatl",
+    "特莱尔辛戈纳瓦特尔语"
   ],
   "nhh": [
     "Nahari"
   ],
   "nhi": [
     "扎卡特蘭-阿華卡特蘭-特佩欽特拉-納瓦特爾語",
-    "Zacatlán-Ahuacatlán-Tepetzintla Nahuatl"
+    "Zacatlán-Ahuacatlán-Tepetzintla Nahuatl",
+    "扎卡特兰-阿华卡特兰-特佩钦特拉-纳瓦特尔语"
   ],
   "nhk": [
     "科索萊阿克納瓦特爾語",
     "Cosoleacaque Nahuatl",
     "Isthmus-Cosoleacaque Nahuatl",
-    "Cosoleacaque Isthmus Nahuatl"
+    "Cosoleacaque Isthmus Nahuatl",
+    "科索莱阿克纳瓦特尔语"
   ],
   "nhm": [
     "莫雷洛斯納瓦特爾語",
-    "Morelos Nahuatl"
+    "Morelos Nahuatl",
+    "莫雷洛斯纳瓦特尔语"
   ],
   "nhn": [
     "中納瓦特爾語",
-    "Central Nahuatl"
+    "Central Nahuatl",
+    "中纳瓦特尔语"
   ],
   "nho": [
     "Takuu"
@@ -18443,59 +20113,71 @@
     "帕哈潘納瓦特爾語",
     "Pajapan Nahuatl",
     "Isthmus-Pajapan Nahuatl",
-    "Pajapan Isthmus Nahuatl"
+    "Pajapan Isthmus Nahuatl",
+    "帕哈潘纳瓦特尔语"
   ],
   "nhq": [
     "瓦斯卡勒卡納瓦特爾語",
-    "Huaxcaleca Nahuatl"
+    "Huaxcaleca Nahuatl",
+    "瓦斯卡勒卡纳瓦特尔语"
   ],
   "nhr": [
     "納羅語",
-    "Naro"
+    "Naro",
+    "纳罗语"
   ],
   "nht": [
     "奧梅特佩克納瓦特爾語",
-    "Ometepec Nahuatl"
+    "Ometepec Nahuatl",
+    "奥梅特佩克纳瓦特尔语"
   ],
   "nhu": [
     "Noone"
   ],
   "nhv": [
     "特馬斯卡爾特佩克納瓦特爾語",
-    "Temascaltepec Nahuatl"
+    "Temascaltepec Nahuatl",
+    "特马斯卡尔特佩克纳瓦特尔语"
   ],
   "nhw": [
     "西瓦斯特卡納瓦特爾語",
-    "Western Huasteca Nahuatl"
+    "Western Huasteca Nahuatl",
+    "西瓦斯特卡纳瓦特尔语"
   ],
   "nhx": [
     "梅卡亞潘納瓦特爾語",
     "Mecayapan Nahuatl",
     "Isthmus-Mecayapan Nahuatl",
-    "Mecayapan Isthmus Nahuatl"
+    "Mecayapan Isthmus Nahuatl",
+    "梅卡亚潘纳瓦特尔语"
   ],
   "nhy": [
     "北瓦哈卡納瓦特爾語",
-    "Northern Oaxaca Nahuatl"
+    "Northern Oaxaca Nahuatl",
+    "北瓦哈卡纳瓦特尔语"
   ],
   "nhz": [
     "聖瑪利亞山區納瓦特爾語",
-    "Santa María La Alta Nahuatl"
+    "Santa María La Alta Nahuatl",
+    "圣玛利亚山区纳瓦特尔语"
   ],
   "nia": [
     "尼亞斯語",
-    "Nias"
+    "Nias",
+    "尼亚斯语"
   ],
   "nib": [
     "Nakame"
   ],
   "nic-bco-pro": [
     "原始貝努埃-剛果語",
-    "Proto-Benue-Congo"
+    "Proto-Benue-Congo",
+    "原始贝努埃-刚果语"
   ],
   "nic-bod-pro": [
     "原始類班圖語",
-    "Proto-Bantoid"
+    "Proto-Bantoid",
+    "原始类班图语"
   ],
   "nic-eov-pro": [
     "Proto-Eastern Oti-Volta"
@@ -18526,18 +20208,21 @@
   ],
   "nic-pro": [
     "原始尼日爾-剛果語",
-    "Proto-Niger-Congo"
+    "Proto-Niger-Congo",
+    "原始尼日尔-刚果语"
   ],
   "nic-ubg-pro": [
     "Proto-Ubangian"
   ],
   "nic-ucr-pro": [
     "原始上克羅斯河語",
-    "Proto-Upper Cross River"
+    "Proto-Upper Cross River",
+    "原始上克罗斯河语"
   ],
   "nic-vco-pro": [
     "原始沃爾特-剛果語",
-    "Proto-Volta-Congo"
+    "Proto-Volta-Congo",
+    "原始沃尔特-刚果语"
   ],
   "nid": [
     "Ngandi"
@@ -18559,11 +20244,13 @@
   ],
   "nij": [
     "恩加朱語",
-    "Ngaju"
+    "Ngaju",
+    "恩加朱语"
   ],
   "nik": [
     "南尼科巴語",
-    "Southern Nicobarese"
+    "Southern Nicobarese",
+    "南尼科巴语"
   ],
   "nil": [
     "Nila"
@@ -18576,7 +20263,8 @@
   ],
   "nio": [
     "恩加納桑語",
-    "Nganasan"
+    "Nganasan",
+    "恩加纳桑语"
   ],
   "niq": [
     "Nandi"
@@ -18593,11 +20281,13 @@
   ],
   "niu": [
     "紐埃語",
-    "Niuean"
+    "Niuean",
+    "纽埃语"
   ],
   "niv": [
     "尼夫赫語",
-    "Nivkh"
+    "Nivkh",
+    "尼夫赫语"
   ],
   "niw": [
     "Nimo"
@@ -18631,7 +20321,8 @@
   ],
   "njm": [
     "安加米語",
-    "Angami"
+    "Angami",
+    "安加米语"
   ],
   "njn": [
     "Liangmai Naga"
@@ -18639,7 +20330,8 @@
   "njo": [
     "阿沃那加語",
     "Mongsen Ao",
-    "Ao Naga"
+    "Ao Naga",
+    "阿沃那加语"
   ],
   "njr": [
     "Njerep"
@@ -18670,11 +20362,13 @@
     "Bangni",
     "Dafla",
     "Daphla",
-    "Lel"
+    "Lel",
+    "尼西语"
   ],
   "nka": [
     "恩科亞語",
-    "Nkoya"
+    "Nkoya",
+    "恩科亚语"
   ],
   "nkb": [
     "Khoibu Naga"
@@ -18717,15 +20411,18 @@
   ],
   "nkp": [
     "紐阿托普塔普語",
-    "Niuatoputapu"
+    "Niuatoputapu",
+    "纽阿托普塔普语"
   ],
   "nkq": [
     "恩卡米語",
-    "Nkami"
+    "Nkami",
+    "恩卡米语"
   ],
   "nkr": [
     "努庫奧羅語",
-    "Nukuoro"
+    "Nukuoro",
+    "努库奥罗语"
   ],
   "nks": [
     "North Asmat"
@@ -18751,7 +20448,8 @@
     "Nkari"
   ],
   "nl": [
-    "荷蘭語"
+    "荷蘭語",
+    "荷兰语"
   ],
   "nla": [
     "Ngombale"
@@ -18777,7 +20475,8 @@
   ],
   "nlk": [
     "尼尼亞亞利語",
-    "Ninia Yali"
+    "Ninia Yali",
+    "尼尼亚亚利语"
   ],
   "nll": [
     "Nihali"
@@ -18802,7 +20501,8 @@
     "Orizaba Nahuatl",
     "Tarawara",
     "Tarawari",
-    "Trawara"
+    "Trawara",
+    "奥里萨巴纳瓦特尔语"
   ],
   "nlw": [
     "Walangama"
@@ -18836,7 +20536,8 @@
     "Tangkhul"
   ],
   "nmg": [
-    "夸西奧語"
+    "夸西奧語",
+    "夸西奥语"
   ],
   "nmh": [
     "Monsang Naga"
@@ -18870,7 +20571,8 @@
     "宏語",
     "ǃXóõ",
     "Xoo",
-    "Taa"
+    "Taa",
+    "宏语"
   ],
   "nmo": [
     "Moyon Naga",
@@ -18903,13 +20605,15 @@
   ],
   "nmy": [
     "納木依語",
-    "Namuyi"
+    "Namuyi",
+    "纳木依语"
   ],
   "nmz": [
     "Nawdm"
   ],
   "nn": [
-    "新挪威語"
+    "新挪威語",
+    "新挪威语"
   ],
   "nna": [
     "Nyangumarta"
@@ -18935,7 +20639,8 @@
     "Maring Naga"
   ],
   "nnh": [
-    "恩甘澎語"
+    "恩甘澎語",
+    "恩甘澎语"
   ],
   "nni": [
     "North Nuaulu"
@@ -18963,11 +20668,13 @@
   ],
   "nnr": [
     "納倫加語",
-    "Narungga"
+    "Narungga",
+    "纳伦加语"
   ],
   "nnt": [
     "南蒂科克語",
-    "Nanticoke"
+    "Nanticoke",
+    "南蒂科克语"
   ],
   "nnu": [
     "Dwang"
@@ -18988,7 +20695,8 @@
     "Nda'nda'"
   ],
   "no": [
-    "挪威語"
+    "挪威語",
+    "挪威语"
   ],
   "noa": [
     "Woun Meu"
@@ -19002,11 +20710,14 @@
     "Northern Thai",
     "Kam Mueang",
     "Kam Muang",
-    "Lanna"
+    "Lanna",
+    "北部泰语",
+    "兰纳语"
   ],
   "noe": [
     "尼馬迪語",
-    "Nimadi"
+    "Nimadi",
+    "尼马迪语"
   ],
   "nof": [
     "Nomane"
@@ -19014,7 +20725,8 @@
   "nog": [
     "諾蓋語",
     "Nogai",
-    "Nogay"
+    "Nogay",
+    "诺盖语"
   ],
   "noh": [
     "Nomu"
@@ -19040,7 +20752,10 @@
     "Old Icelandic",
     "Old Norwegian",
     "古冰島語",
-    "古挪威語"
+    "古挪威語",
+    "古诺尔斯语",
+    "古冰岛语",
+    "古挪威语"
   ],
   "nop": [
     "Numanggang"
@@ -19059,7 +20774,8 @@
   ],
   "nov": [
     "諾維亞語",
-    "Novial"
+    "Novial",
+    "诺维亚语"
   ],
   "now": [
     "Nyambo"
@@ -19086,7 +20802,8 @@
   ],
   "npl": [
     "東南普埃布拉納瓦特爾語",
-    "Southeastern Puebla Nahuatl"
+    "Southeastern Puebla Nahuatl",
+    "东南普埃布拉纳瓦特尔语"
   ],
   "npn": [
     "Mondropolon"
@@ -19129,7 +20846,8 @@
     "Akyaung Ari Naga"
   ],
   "nr": [
-    "南恩德貝勒語"
+    "南恩德貝勒語",
+    "南恩德贝勒语"
   ],
   "nra": [
     "Ngom"
@@ -19162,7 +20880,8 @@
     "Auregnais",
     "Cotentinais",
     "Brayon",
-    "Roumois"
+    "Roumois",
+    "诺曼语"
   ],
   "nrg": [
     "Narango"
@@ -19181,19 +20900,23 @@
   ],
   "nrn": [
     "諾恩語",
-    "Norn"
+    "Norn",
+    "诺恩语"
   ],
   "nrp": [
     "北皮賽恩語",
-    "North Picene"
+    "North Picene",
+    "北皮赛恩语"
   ],
   "nrr": [
     "諾拉語",
-    "Norra"
+    "Norra",
+    "诺拉语"
   ],
   "nrt": [
     "北卡拉普亞語",
-    "Northern Kalapuya"
+    "Northern Kalapuya",
+    "北卡拉普亚语"
   ],
   "nru": [
     "Narua"
@@ -19203,7 +20926,8 @@
   ],
   "nrz": [
     "拉拉語（新幾內亞）",
-    "Lala (New Guinea)"
+    "Lala (New Guinea)",
+    "拉拉语（新几内亚）"
   ],
   "nsa": [
     "Sangtam Naga"
@@ -19229,14 +20953,17 @@
   "nsi": [
     "尼日利亞手語",
     "奈及利亞手語",
-    "Nigerian Sign Language"
+    "Nigerian Sign Language",
+    "尼日利亚手语",
+    "奈及利亚手语"
   ],
   "nsk": [
     "Naskapi"
   ],
   "nsl": [
     "挪威手語",
-    "Norwegian Sign Language"
+    "Norwegian Sign Language",
+    "挪威手语"
   ],
   "nsm": [
     "Sema"
@@ -19246,18 +20973,21 @@
   ],
   "nso": [
     "北索托語",
-    "Northern Sotho"
+    "Northern Sotho",
+    "北索托语"
   ],
   "nsp": [
     "尼泊爾手語",
-    "Nepalese Sign Language"
+    "Nepalese Sign Language",
+    "尼泊尔手语"
   ],
   "nsq": [
     "Northern Sierra Miwok"
   ],
   "nsr": [
     "海事手語",
-    "Maritime Sign Language"
+    "Maritime Sign Language",
+    "海事手语"
   ],
   "nss": [
     "Nali"
@@ -19267,7 +20997,8 @@
   ],
   "nsu": [
     "內格拉山區納瓦特爾語",
-    "Sierra Negra Nahuatl"
+    "Sierra Negra Nahuatl",
+    "内格拉山区纳瓦特尔语"
   ],
   "nsv": [
     "Southwestern Nisu"
@@ -19314,7 +21045,8 @@
   ],
   "ntp": [
     "北特佩瓦語",
-    "Northern Tepehuan"
+    "Northern Tepehuan",
+    "北特佩瓦语"
   ],
   "ntr": [
     "Delo"
@@ -19345,7 +21077,8 @@
   ],
   "nub-pro": [
     "原始努比亞語",
-    "Proto-Nubian"
+    "Proto-Nubian",
+    "原始努比亚语"
   ],
   "nuc": [
     "Nukuini"
@@ -19381,14 +21114,16 @@
     "Nootka",
     "Nuu-chah-nulth",
     "Nuuchahnulth",
-    "T'aat'aaqsapa"
+    "T'aat'aaqsapa",
+    "努特卡语"
   ],
   "nul": [
     "Nusa Laut"
   ],
   "num": [
     "紐阿富語",
-    "Niuafo'ou"
+    "Niuafo'ou",
+    "纽阿富语"
   ],
   "nun": [
     "Anong",
@@ -19401,7 +21136,9 @@
     "努佩語",
     "努培語",
     "Nupe",
-    "Nupe-Nupe-Tako"
+    "Nupe-Nupe-Tako",
+    "努佩语",
+    "努培语"
   ],
   "nuq": [
     "Nukumanu"
@@ -19411,11 +21148,13 @@
     "Nukuria"
   ],
   "nus": [
-    "努埃爾語"
+    "努埃爾語",
+    "努埃尔语"
   ],
   "nut": [
     "儂語",
-    "Nung"
+    "Nung",
+    "侬语"
   ],
   "nuu": [
     "Ngbundu"
@@ -19435,10 +21174,12 @@
   ],
   "nuz": [
     "特拉馬卡薩帕納瓦特爾語",
-    "Tlamacazapa Nahuatl"
+    "Tlamacazapa Nahuatl",
+    "特拉马卡萨帕纳瓦特尔语"
   ],
   "nv": [
-    "納瓦霍語"
+    "納瓦霍語",
+    "纳瓦霍语"
   ],
   "nvh": [
     "Nasarian"
@@ -19458,7 +21199,8 @@
   "nwc": [
     "古典尼瓦爾語",
     "Classical Newar",
-    "Classical Newari"
+    "Classical Newari",
+    "古典尼瓦尔语"
   ],
   "nwe": [
     "Ngwe"
@@ -19480,7 +21222,8 @@
   "nwx": [
     "中古尼瓦爾語",
     "Middle Newar",
-    "Middle Newari"
+    "Middle Newari",
+    "中古尼瓦尔语"
   ],
   "nwy": [
     "Nottoway-Meherrin"
@@ -19517,7 +21260,8 @@
   ],
   "nxq": [
     "納西語",
-    "Naxi"
+    "Naxi",
+    "纳西语"
   ],
   "nxr": [
     "Ninggerum"
@@ -19529,7 +21273,8 @@
     "Nafri"
   ],
   "ny": [
-    "齊切瓦語"
+    "齊切瓦語",
+    "齐切瓦语"
   ],
   "nyb": [
     "Nyangbo"
@@ -19574,7 +21319,8 @@
     "Nyeu"
   ],
   "nym": [
-    "尼揚韋齊語"
+    "尼揚韋齊語",
+    "尼扬韦齐语"
   ],
   "nyn": [
     "尼揚科萊語",
@@ -19588,10 +21334,12 @@
     "Ankole",
     "Banyankole",
     "Lunyankole",
-    "Rukiga"
+    "Rukiga",
+    "尼扬科莱语"
   ],
   "nyo": [
-    "尼奧囉語"
+    "尼奧囉語",
+    "尼奥啰语"
   ],
   "nyp": [
     "Nyang'i"
@@ -19600,7 +21348,8 @@
     "尼揚加語",
     "Nyunga",
     "Noongar",
-    "Nyuunga"
+    "Nyuunga",
+    "尼扬加语"
   ],
   "nyt": [
     "Nyawaygi"
@@ -19612,7 +21361,8 @@
     "Nyulnyul"
   ],
   "nyw": [
-    "僥語"
+    "僥語",
+    "侥语"
   ],
   "nyx": [
     "Nganyaywana"
@@ -19621,11 +21371,13 @@
     "尼亞庫薩語",
     "Nyakyusa",
     "Kinyakyusa",
-    "Nyakyusa-Ngonde"
+    "Nyakyusa-Ngonde",
+    "尼亚库萨语"
   ],
   "nza": [
     "梯貢-姆本貝語",
-    "Tigon Mbembe"
+    "Tigon Mbembe",
+    "梯贡-姆本贝语"
   ],
   "nzb": [
     "Njebi"
@@ -19635,11 +21387,13 @@
     "Nzadi",
     "Ngiemba",
     "Lensibun",
-    "Ndzé Ntaa"
+    "Ndzé Ntaa",
+    "恩扎迪语"
   ],
   "nzi": [
     "尼茲馬語",
-    "Appolo"
+    "Appolo",
+    "尼兹马语"
   ],
   "nzk": [
     "Nzakara"
@@ -19650,7 +21404,9 @@
   "nzs": [
     "新西蘭手語",
     "紐西蘭手語",
-    "New Zealand Sign Language"
+    "New Zealand Sign Language",
+    "新西兰手语",
+    "纽西兰手语"
   ],
   "nzu": [
     "Central Teke"
@@ -19663,14 +21419,17 @@
   ],
   "oaa": [
     "鄂羅克語",
-    "Orok"
+    "Orok",
+    "鄂罗克语"
   ],
   "oac": [
     "奧羅奇語",
-    "Oroch"
+    "Oroch",
+    "奥罗奇语"
   ],
   "oav": [
-    "古阿瓦爾語"
+    "古阿瓦爾語",
+    "古阿瓦尔语"
   ],
   "obi": [
     "Obispeño"
@@ -19684,36 +21443,43 @@
   ],
   "obm": [
     "摩押語",
-    "Moabite"
+    "Moabite",
+    "摩押语"
   ],
   "obo": [
     "歐波-馬諾博語",
-    "Obo"
+    "Obo",
+    "欧波-马诺博语"
   ],
   "obr": [
     "上古緬甸語",
-    "Old Burmese"
+    "Old Burmese",
+    "上古缅甸语"
   ],
   "obt": [
     "上古布列塔尼語",
-    "Old Breton"
+    "Old Breton",
+    "上古布列塔尼语"
   ],
   "obu": [
     "Obulom"
   ],
   "oc": [
-    "奧克語"
+    "奧克語",
+    "奥克语"
   ],
   "oca": [
     "Ocaina"
   ],
   "och": [
     "上古漢語",
-    "Old Chinese"
+    "Old Chinese",
+    "上古汉语"
   ],
   "oco": [
     "上古康沃爾語",
-    "Old Cornish"
+    "Old Cornish",
+    "上古康沃尔语"
   ],
   "ocu": [
     "Tlahuica",
@@ -19725,11 +21491,13 @@
   ],
   "odk": [
     "奧德語",
-    "Od"
+    "Od",
+    "奥德语"
   ],
   "odt": [
     "古荷蘭語",
-    "Old Dutch"
+    "Old Dutch",
+    "古荷兰语"
   ],
   "odu": [
     "Odual"
@@ -19740,7 +21508,9 @@
   "ofs": [
     "古弗里斯蘭語",
     "Old Frisian",
-    "上古菲士蘭語"
+    "上古菲士蘭語",
+    "古弗里斯兰语",
+    "上古菲士兰语"
   ],
   "ofu": [
     "Efutop"
@@ -19753,7 +21523,8 @@
   ],
   "oge": [
     "上古格魯吉亞語",
-    "Old Georgian"
+    "Old Georgian",
+    "上古格鲁吉亚语"
   ],
   "ogg": [
     "Ogbogolo"
@@ -19766,7 +21537,8 @@
   ],
   "ohu": [
     "上古匈牙利語",
-    "Old Hungarian"
+    "Old Hungarian",
+    "上古匈牙利语"
   ],
   "oia": [
     "Oirata"
@@ -19775,39 +21547,49 @@
     "Inebu One"
   ],
   "oj": [
-    "奧吉布瓦語"
+    "奧吉布瓦語",
+    "奥吉布瓦语"
   ],
   "ojb": [
     "西北奧吉布瓦語",
-    "Northwestern Ojibwa"
+    "Northwestern Ojibwa",
+    "西北奥吉布瓦语"
   ],
   "ojc": [
     "中奧吉布瓦語",
-    "Central Ojibwa"
+    "Central Ojibwa",
+    "中奥吉布瓦语"
   ],
   "ojg": [
     "東奧吉布瓦語",
-    "Eastern Ojibwa"
+    "Eastern Ojibwa",
+    "东奥吉布瓦语"
   ],
   "ojp": [
     "古典日語",
-    "Old Japanese"
+    "Old Japanese",
+    "古典日语"
   ],
   "ojs": [
-    "Severn Ojibwa"
+    "塞文奧吉布瓦語",
+    "Severn Ojibwa",
+    "塞文奥吉布瓦语"
   ],
   "ojv": [
     "Ontong Java"
   ],
   "ojw": [
-    "Western Ojibwa"
+    "西奧吉布瓦語",
+    "Western Ojibwa",
+    "西奥吉布瓦语"
   ],
   "oka": [
     "歐肯納根語",
     "Okanagan",
     "Okanagan Salish",
     "Okanagan-Colville",
-    "Colville-Okanagan"
+    "Colville-Okanagan",
+    "欧肯纳根语"
   ],
   "okb": [
     "Okobo"
@@ -19828,7 +21610,8 @@
   ],
   "okh": [
     "科雷斯埃羅斯塔姆語",
-    "Koresh-e Rostam"
+    "Koresh-e Rostam",
+    "科雷斯埃罗斯塔姆语"
   ],
   "oki": [
     "Okiek",
@@ -19851,21 +21634,25 @@
   ],
   "okl": [
     "古肯特手語",
-    "Old Kentish Sign Language"
+    "Old Kentish Sign Language",
+    "古肯特手语"
   ],
   "okm": [
     "中古朝鮮語",
-    "Middle Korean"
+    "Middle Korean",
+    "中古朝鲜语"
   ],
   "okn": [
     "沖永良部語",
     "Oki-No-Erabu",
     "Okino-Erabu",
-    "Okinoerabu"
+    "Okinoerabu",
+    "冲永良部语"
   ],
   "oko": [
     "上古朝鮮語",
-    "Old Korean"
+    "Old Korean",
+    "上古朝鲜语"
   ],
   "okr": [
     "Kirike"
@@ -19886,7 +21673,8 @@
   ],
   "okz": [
     "古高棉語",
-    "Old Khmer"
+    "Old Khmer",
+    "古高棉语"
   ],
   "old": [
     "Mochi"
@@ -19903,20 +21691,23 @@
     "Livvi-Karelian",
     "Livvikovian",
     "Olonets",
-    "Southern Olonetsian"
+    "Southern Olonetsian",
+    "利维卡累利阿语"
   ],
   "olr": [
     "Olrat"
   ],
   "olt": [
     "古立陶宛語",
-    "Old Lithuanian"
+    "Old Lithuanian",
+    "古立陶宛语"
   ],
   "olu": [
     "Kuvale"
   ],
   "om": [
-    "奧羅莫語"
+    "奧羅莫語",
+    "奥罗莫语"
   ],
   "oma": [
     "Omaha-Ponca",
@@ -19949,66 +21740,81 @@
   ],
   "omk": [
     "奧莫克語",
-    "Omok"
+    "Omok",
+    "奥莫克语"
   ],
   "oml": [
     "Ombo"
   ],
   "omn": [
     "米諾斯語",
-    "Minoan"
+    "Minoan",
+    "米诺斯语"
   ],
   "omo": [
     "Utarmbung"
   ],
   "omp": [
     "上古曼尼普爾語",
-    "Old Manipuri"
+    "Old Manipuri",
+    "上古曼尼普尔语"
   ],
   "omq-cha-pro": [
-    "原始查蒂諾語"
+    "原始查蒂諾語",
+    "原始查蒂诺语"
   ],
   "omq-maz-pro": [
-    "原始馬薩特克語"
+    "原始馬薩特克語",
+    "原始马萨特克语"
   ],
   "omq-mix-pro": [
-    "原始類米斯特克語"
+    "原始類米斯特克語",
+    "原始类米斯特克语"
   ],
   "omq-mxt-pro": [
-    "原始米斯特克語"
+    "原始米斯特克語",
+    "原始米斯特克语"
   ],
   "omq-otp-pro": [
-    "原始歐托-帕梅語"
+    "原始歐托-帕梅語",
+    "原始欧托-帕梅语"
   ],
   "omq-pro": [
     "原始歐托-曼格語",
     "Proto-Oto-Manguean",
     "Proto-Otomanguean",
-    "Proto-Oto-Mangue"
+    "Proto-Oto-Mangue",
+    "原始欧托-曼格语"
   ],
   "omq-tel": [
     "特波斯科盧拉米斯特克語",
-    "Teposcolula Mixtec"
+    "Teposcolula Mixtec",
+    "特波斯科卢拉米斯特克语"
   ],
   "omq-teo": [
     "特奧霍姆爾科查蒂諾語",
-    "Teojomulco Chatino"
+    "Teojomulco Chatino",
+    "特奥霍姆尔科查蒂诺语"
   ],
   "omq-tri-pro": [
     "原始特里基語",
-    "Proto-Trique"
+    "Proto-Trique",
+    "原始特里基语"
   ],
   "omq-zap-pro": [
     "原始類薩波特克語",
-    "Proto-Zapotecan"
+    "Proto-Zapotecan",
+    "原始类萨波特克语"
   ],
   "omq-zpc-pro": [
     "原始薩波特克語",
-    "Proto-Zapotec"
+    "Proto-Zapotec",
+    "原始萨波特克语"
   ],
   "omr": [
     "上古馬拉地語",
-    "Old Marathi"
+    "Old Marathi",
+    "上古马拉地语"
   ],
   "omt": [
     "Omotik"
@@ -20030,7 +21836,8 @@
   ],
   "omx": [
     "上古孟語",
-    "Old Mon"
+    "Old Mon",
+    "上古孟语"
   ],
   "ona": [
     "Selk'nam",
@@ -20040,11 +21847,13 @@
     "Shelknam"
   ],
   "onb": [
-    "臨高語"
+    "臨高語",
+    "临高语"
   ],
   "one": [
     "歐內達語",
-    "Oneida"
+    "Oneida",
+    "欧内达语"
   ],
   "ong": [
     "Olo"
@@ -20082,7 +21891,8 @@
   ],
   "onw": [
     "上古努比亞語",
-    "Old Nubian"
+    "Old Nubian",
+    "上古努比亚语"
   ],
   "onx": [
     "Pidgin Onin"
@@ -20090,14 +21900,16 @@
   "ood": [
     "歐罕語",
     "O'odham",
-    "Papago"
+    "Papago",
+    "欧罕语"
   ],
   "oog": [
     "Ong"
   ],
   "oon": [
     "翁奇語",
-    "Önge"
+    "Önge",
+    "翁奇语"
   ],
   "oor": [
     "Oorlams"
@@ -20107,7 +21919,8 @@
     "Old Ossetic",
     "Old Ossetian",
     "Alanic",
-    "Sarmatian"
+    "Sarmatian",
+    "上古奥塞提亚语"
   ],
   "opa": [
     "Okpamheri",
@@ -20134,7 +21947,8 @@
     "Ofayé"
   ],
   "or": [
-    "奧利亞語"
+    "奧利亞語",
+    "奥利亚语"
   ],
   "ora": [
     "Oroha"
@@ -20147,7 +21961,8 @@
   ],
   "orh": [
     "鄂倫春語",
-    "Oroqen"
+    "Oroqen",
+    "鄂伦春语"
   ],
   "orr": [
     "Oruma"
@@ -20157,13 +21972,16 @@
   ],
   "oru": [
     "奧爾穆里語",
-    "Ormuri"
+    "Ormuri",
+    "奥尔穆里语"
   ],
   "orv": [
     "古東斯拉夫語",
     "Old East Slavic",
     "古俄羅斯語",
-    "Old Russian"
+    "Old Russian",
+    "古东斯拉夫语",
+    "古俄罗斯语"
   ],
   "orw": [
     "Oro Win"
@@ -20175,20 +21993,24 @@
     "Ormu"
   ],
   "os": [
-    "奧塞梯語"
+    "奧塞梯語",
+    "奥塞梯语"
   ],
   "os-pro": [
     "原始奧塞提亞語",
     "Proto-Ossetic",
-    "Sarmatian"
+    "Sarmatian",
+    "原始奥塞提亚语"
   ],
   "osa": [
     "奧沙格語",
-    "Osage"
+    "Osage",
+    "奥沙格语"
   ],
   "osc": [
     "奧斯坎語",
-    "Oscan"
+    "Oscan",
+    "奥斯坎语"
   ],
   "osi": [
     "Osing"
@@ -20200,7 +22022,10 @@
     "中世紀西班牙語",
     "Old Spanish",
     "古西班牙語",
-    "古卡斯蒂利亞語"
+    "古卡斯蒂利亞語",
+    "中世纪西班牙语",
+    "古西班牙语",
+    "古卡斯蒂利亚语"
   ],
   "ost": [
     "Osatu"
@@ -20213,13 +22038,18 @@
     "Old Saxon",
     "Old Low German",
     "古低地德語",
-    "古低地日耳曼語"
+    "古低地日耳曼語",
+    "古撒克逊语",
+    "古低地德语",
+    "古低地日耳曼语"
   ],
   "ota": [
     "鄂圖曼土耳其語",
     "Ottoman Turkish",
     "Ottoman",
-    "鄂圖曼語"
+    "鄂圖曼語",
+    "鄂图曼土耳其语",
+    "鄂图曼语"
   ],
   "otd": [
     "Ot Danum",
@@ -20227,7 +22057,8 @@
   ],
   "ote": [
     "梅斯基塔爾奧托米語",
-    "Mezquital Otomi"
+    "Mezquital Otomi",
+    "梅斯基塔尔奥托米语"
   ],
   "oti": [
     "Oti"
@@ -20237,61 +22068,75 @@
     "Old Turkic",
     "Orkhon Turkic",
     "Orkhon",
-    "古代突厥語"
+    "古代突厥語",
+    "古突厥语",
+    "古代突厥语"
   ],
   "otl": [
     "蒂拉帕奧托米語",
-    "Tilapa Otomi"
+    "Tilapa Otomi",
+    "蒂拉帕奥托米语"
   ],
   "otm": [
     "東部高地奧托米語",
-    "Eastern Highland Otomi"
+    "Eastern Highland Otomi",
+    "东部高地奥托米语"
   ],
   "otn": [
     "特南戈奧托米語",
-    "Tenango Otomi"
+    "Tenango Otomi",
+    "特南戈奥托米语"
   ],
   "oto-otm-pro": [
     "原始奧托米語",
-    "Proto-Otomi"
+    "Proto-Otomi",
+    "原始奥托米语"
   ],
   "oto-pro": [
     "原始類奧托米語",
-    "Proto-Otomian"
+    "Proto-Otomian",
+    "原始类奥托米语"
   ],
   "otq": [
     "克雷塔羅奧托米語",
-    "Querétaro Otomi"
+    "Querétaro Otomi",
+    "克雷塔罗奥托米语"
   ],
   "otr": [
     "Otoro"
   ],
   "ots": [
     "墨西哥州奧托米語",
-    "Estado de México Otomi"
+    "Estado de México Otomi",
+    "墨西哥州奥托米语"
   ],
   "ott": [
     "特莫亞雅奧托米語",
-    "Temoaya Otomi"
+    "Temoaya Otomi",
+    "特莫亚雅奥托米语"
   ],
   "otu": [
     "Otuke"
   ],
   "otw": [
     "渥太華語",
-    "Ottawa"
+    "Ottawa",
+    "渥太华语"
   ],
   "otx": [
     "特斯卡特佩克奧托米語",
-    "Texcatepec Otomi"
+    "Texcatepec Otomi",
+    "特斯卡特佩克奥托米语"
   ],
   "oty": [
     "上古泰米爾語",
-    "Old Tamil"
+    "Old Tamil",
+    "上古泰米尔语"
   ],
   "otz": [
     "伊斯坦科奧托米語",
-    "Old Tamil"
+    "Old Tamil",
+    "伊斯坦科奥托米语"
   ],
   "oua": [
     "Tagargrent",
@@ -20308,7 +22153,8 @@
   "oui": [
     "古回鶻語",
     "Old Uyghur",
-    "Old Uighur"
+    "Old Uighur",
+    "古回鹘语"
   ],
   "oum": [
     "Ouma"
@@ -20316,14 +22162,16 @@
   "ovd": [
     "埃爾夫達利安語",
     "Elfdalian",
-    "Övdalian"
+    "Övdalian",
+    "埃尔夫达利安语"
   ],
   "owi": [
     "Owiniga"
   ],
   "owl": [
     "古威爾士語",
-    "Old Welsh"
+    "Old Welsh",
+    "古威尔士语"
   ],
   "oyb": [
     "Oy",
@@ -20346,7 +22194,8 @@
     "Koonzime"
   ],
   "pa": [
-    "旁遮普語"
+    "旁遮普語",
+    "旁遮普语"
   ],
   "paa-kom": [
     "Kómnzo"
@@ -20366,7 +22215,8 @@
   ],
   "pac": [
     "帕戈語",
-    "Pacoh"
+    "Pacoh",
+    "帕戈语"
   ],
   "pad": [
     "Paumarí"
@@ -20379,7 +22229,8 @@
   ],
   "pag": [
     "班詩蘭語",
-    "Pangasinan"
+    "Pangasinan",
+    "班诗兰语"
   ],
   "pah": [
     "Tenharim",
@@ -20396,12 +22247,14 @@
     "中古波斯語",
     "Middle Persian",
     "Pahlavi",
-    "Manichaean Middle Persian"
+    "Manichaean Middle Persian",
+    "中古波斯语"
   ],
   "pam": [
     "卡片片甘語",
     "Kapampangan",
-    "Pampango"
+    "Pampango",
+    "卡片片甘语"
   ],
   "pao": [
     "北派伍特語",
@@ -20410,12 +22263,14 @@
     "Paviotso",
     "Mono-Paviotso",
     "Mono-Bannock",
-    "Bannock"
+    "Bannock",
+    "北派伍特语"
   ],
   "pap": [
     "帕皮阿門托語",
     "Papiamentu",
-    "Papiamento"
+    "Papiamento",
+    "帕皮阿门托语"
   ],
   "paq": [
     "Parya"
@@ -20425,7 +22280,9 @@
     "帕納明特休休尼語",
     "Timbisha",
     "Tümpisha",
-    "Koso"
+    "Koso",
+    "帕纳明特语",
+    "帕纳明特休休尼语"
   ],
   "pas": [
     "Papasena"
@@ -20435,7 +22292,8 @@
   ],
   "pau": [
     "帕勞語",
-    "Palauan"
+    "Palauan",
+    "帕劳语"
   ],
   "pav": [
     "Wari'"
@@ -20473,11 +22331,13 @@
   ],
   "pbe": [
     "梅松特拉波波洛卡語",
-    "Mezontla Popoloca"
+    "Mezontla Popoloca",
+    "梅松特拉波波洛卡语"
   ],
   "pbf": [
     "科約特佩克波波洛卡語",
-    "Coyotepec Popoloca"
+    "Coyotepec Popoloca",
+    "科约特佩克波波洛卡语"
   ],
   "pbg": [
     "Paraujano"
@@ -20499,7 +22359,8 @@
   "pbm": [
     "普埃布拉馬薩特克語",
     "Puebla Mazatec",
-    "Mazateco de Puebla y del Noroeste"
+    "Mazateco de Puebla y del Noroeste",
+    "普埃布拉马萨特克语"
   ],
   "pbn": [
     "Kpasam"
@@ -20515,11 +22376,13 @@
   ],
   "pbs": [
     "中帕梅語",
-    "Central Pame"
+    "Central Pame",
+    "中帕梅语"
   ],
   "pbv": [
     "布那語",
-    "Pnar"
+    "Pnar",
+    "布那语"
   ],
   "pby": [
     "Pyu",
@@ -20529,7 +22392,8 @@
   ],
   "pca": [
     "聖伊內斯阿瓦特姆潘波波洛卡語",
-    "Santa Inés Ahuatempan Popoloca"
+    "Santa Inés Ahuatempan Popoloca",
+    "圣伊内斯阿瓦特姆潘波波洛卡语"
   ],
   "pcb": [
     "Pear"
@@ -20541,7 +22405,8 @@
     "Buyei",
     "Puyi",
     "Giay",
-    "Yay"
+    "Yay",
+    "布依语"
   ],
   "pcd": [
     "皮卡第語",
@@ -20549,7 +22414,8 @@
     "Chti",
     "Ch'ti",
     "Rouchi",
-    "Rouchy"
+    "Rouchy",
+    "皮卡第语"
   ],
   "pce": [
     "Ruching Palaung"
@@ -20578,7 +22444,8 @@
   ],
   "pcm": [
     "尼日利亞皮欽語",
-    "Nigerian Pidgin"
+    "Nigerian Pidgin",
+    "尼日利亚皮钦语"
   ],
   "pcn": [
     "Piti"
@@ -20596,7 +22463,9 @@
     "賓夕法尼亞德語",
     "賓州德語",
     "Pennsylvania German",
-    "Pennsylvania Dutch"
+    "Pennsylvania Dutch",
+    "宾夕法尼亚德语",
+    "宾州德语"
   ],
   "pdi": [
     "Pa Di"
@@ -20615,7 +22484,8 @@
     "Chortitza",
     "Molotschna",
     "Chortica",
-    "Molotcha"
+    "Molotcha",
+    "门诺低地德语"
   ],
   "pdu": [
     "Kayan"
@@ -20641,11 +22511,13 @@
     "Pengo"
   ],
   "peh": [
-    "保安語"
+    "保安語",
+    "保安语"
   ],
   "pei": [
     "奇奇梅克-喬納斯語",
-    "Chichimeca-Jonaz"
+    "Chichimeca-Jonaz",
+    "奇奇梅克-乔纳斯语"
   ],
   "pej": [
     "Northern Pomo"
@@ -20661,7 +22533,8 @@
   ],
   "peo": [
     "古波斯語",
-    "Old Persian"
+    "Old Persian",
+    "古波斯语"
   ],
   "pep": [
     "Kunja"
@@ -20690,7 +22563,8 @@
   ],
   "pga": [
     "朱巴阿拉伯語",
-    "Juba Arabic"
+    "Juba Arabic",
+    "朱巴阿拉伯语"
   ],
   "pgd": [
     "Gandhari",
@@ -20708,11 +22582,13 @@
   ],
   "pgl": [
     "原始愛爾蘭語",
-    "Primitive Irish"
+    "Primitive Irish",
+    "原始爱尔兰语"
   ],
   "pgn": [
     "帕埃利尼語",
-    "Paelignian"
+    "Paelignian",
+    "帕埃利尼语"
   ],
   "pgs": [
     "Pangseng"
@@ -20727,11 +22603,14 @@
     "Melanesian Sign Language",
     "PNGSL",
     "巴布亚新几内亚手语",
-    "巴布亞新畿內亞手語"
+    "巴布亞新畿內亞手語",
+    "巴布亚纽几内亚手语",
+    "巴布亚新畿内亚手语"
   ],
   "pha": [
     "巴哼語",
-    "Pa-Hng"
+    "Pa-Hng",
+    "巴哼语"
   ],
   "phd": [
     "Phudagi"
@@ -20753,11 +22632,13 @@
   ],
   "phi-pro": [
     "原始菲律賓語",
-    "Proto-Philippine"
+    "Proto-Philippine",
+    "原始菲律宾语"
   ],
   "phk": [
     "帕克傣語",
-    "Phake"
+    "Phake",
+    "帕克傣语"
   ],
   "phl": [
     "Phalura",
@@ -20771,7 +22652,8 @@
   ],
   "phn": [
     "腓尼基語",
-    "Phoenician"
+    "Phoenician",
+    "腓尼基语"
   ],
   "pho": [
     "Phunoi"
@@ -20786,7 +22668,8 @@
   ],
   "pht": [
     "普泰語",
-    "Phu Thai"
+    "Phu Thai",
+    "普泰语"
   ],
   "phu": [
     "Phuan"
@@ -20798,11 +22681,13 @@
     "Phangduwali"
   ],
   "pi": [
-    "巴利語"
+    "巴利語",
+    "巴利语"
   ],
   "pia": [
     "皮馬巴霍語",
-    "Pima Bajo"
+    "Pima Bajo",
+    "皮马巴霍语"
   ],
   "pib": [
     "Yine",
@@ -20836,7 +22721,8 @@
     "Pitcairn",
     "Pitkern",
     "Norfolk",
-    "Norfuk"
+    "Norfuk",
+    "皮特凯恩语"
   ],
   "pii": [
     "Pini"
@@ -20849,7 +22735,8 @@
   ],
   "pim": [
     "波瓦坦語",
-    "Powhatan"
+    "Powhatan",
+    "波瓦坦语"
   ],
   "pin": [
     "Piame"
@@ -20879,7 +22766,8 @@
   "piv": [
     "皮勒尼語",
     "Pileni",
-    "Vaeakau-Taumako"
+    "Vaeakau-Taumako",
+    "皮勒尼语"
   ],
   "piw": [
     "Pimbwe"
@@ -20895,18 +22783,21 @@
   ],
   "pjt": [
     "皮詹加加拉語",
-    "Pitjantjatjara"
+    "Pitjantjatjara",
+    "皮詹加加拉语"
   ],
   "pka": [
     "半摩揭陀俗語",
-    "Ardhamagadhi Prakrit"
+    "Ardhamagadhi Prakrit",
+    "半摩揭陀俗语"
   ],
   "pkb": [
     "Kipfokomo"
   ],
   "pkc": [
     "百濟語",
-    "Baekje"
+    "Baekje",
+    "百济语"
   ],
   "pkg": [
     "Pak-Tong"
@@ -20926,7 +22817,8 @@
     "Pökoot"
   ],
   "pkp": [
-    "普卡普卡語"
+    "普卡普卡語",
+    "普卡普卡语"
   ],
   "pkr": [
     "Attapady Kurumba"
@@ -20934,7 +22826,8 @@
   "pks": [
     "巴基斯坦手語",
     "Pakistan Sign Language",
-    "Pakistani Sign Language"
+    "Pakistani Sign Language",
+    "巴基斯坦手语"
   ],
   "pkt": [
     "Maleng"
@@ -20943,7 +22836,8 @@
     "Paku"
   ],
   "pl": [
-    "波蘭語"
+    "波蘭語",
+    "波兰语"
   ],
   "pla": [
     "Miani"
@@ -20952,11 +22846,13 @@
     "Polonombauk"
   ],
   "plc": [
-    "中巴拉望語"
+    "中巴拉望語",
+    "中巴拉望语"
   ],
   "ple": [
     "帕盧厄語",
-    "Palu'e"
+    "Palu'e",
+    "帕卢厄语"
   ],
   "plg": [
     "Pilagá",
@@ -20964,7 +22860,8 @@
   ],
   "plh": [
     "保洛希語",
-    "Paulohi"
+    "Paulohi",
+    "保洛希语"
   ],
   "plj": [
     "Polci"
@@ -20980,7 +22877,8 @@
   ],
   "plo": [
     "奧魯塔波波魯卡語",
-    "Oluta Popoluca"
+    "Oluta Popoluca",
+    "奥鲁塔波波鲁卡语"
   ],
   "plp": [
     "Palpa"
@@ -20993,17 +22891,20 @@
   ],
   "pls": [
     "聖馬科斯特拉爾科亞爾科波波洛卡語",
-    "San Marcos Tlalcoyalco Popoloca"
+    "San Marcos Tlalcoyalco Popoloca",
+    "圣马科斯特拉尔科亚尔科波波洛卡语"
   ],
   "plu": [
     "Palikur",
     "Palikúr"
   ],
   "plv": [
-    "西南巴拉望語"
+    "西南巴拉望語",
+    "西南巴拉望语"
   ],
   "plw": [
-    "布魯克波因特巴拉望語"
+    "布魯克波因特巴拉望語",
+    "布鲁克波因特巴拉望语"
   ],
   "ply": [
     "Bolyu"
@@ -21013,7 +22914,8 @@
   ],
   "pma": [
     "帕馬語",
-    "Paama"
+    "Paama",
+    "帕马语"
   ],
   "pmb": [
     "Pambia"
@@ -21027,26 +22929,30 @@
   "pmf": [
     "帕莫納語",
     "Pamona",
-    "Bare'e"
+    "Bare'e",
+    "帕莫纳语"
   ],
   "pmh": [
     "馬哈拉施特拉俗語",
     "Maharastri Prakrit",
     "Maharashtri Prakrit",
     "Maharastri",
-    "Maharashtri"
+    "Maharashtri",
+    "马哈拉施特拉俗语"
   ],
   "pmi": [
     "北普米語",
     "Northern Pumi",
     "Northern Prinmi",
-    "Northern Pimi"
+    "Northern Pimi",
+    "北普米语"
   ],
   "pmj": [
     "南普米語",
     "Southern Pumi",
     "Southern Prinmi",
-    "Southern Pimi"
+    "Southern Pimi",
+    "南普米语"
   ],
   "pmk": [
     "Pamlico"
@@ -21069,18 +22975,21 @@
   ],
   "pmq": [
     "北帕梅語",
-    "Northern Pame"
+    "Northern Pame",
+    "北帕梅语"
   ],
   "pmr": [
     "Paynamar"
   ],
   "pms": [
     "皮埃蒙特語",
-    "Piedmontese"
+    "Piedmontese",
+    "皮埃蒙特语"
   ],
   "pmt": [
     "土阿莫土語",
-    "Tuamotuan"
+    "Tuamotuan",
+    "土阿莫土语"
   ],
   "pmu": [
     "Mirpur Panjabi"
@@ -21093,18 +23002,21 @@
   ],
   "pmy": [
     "巴布亞馬來語",
-    "Papuan Malay"
+    "Papuan Malay",
+    "巴布亚马来语"
   ],
   "pmz": [
     "南帕梅語",
-    "Southern Pame"
+    "Southern Pame",
+    "南帕梅语"
   ],
   "pna": [
     "Punan Bah-Biau"
   ],
   "pnb": [
     "西旁遮普語",
-    "Western Panjabi"
+    "Western Panjabi",
+    "西旁遮普语"
   ],
   "pnc": [
     "Pannei"
@@ -21163,12 +23075,14 @@
   "pnt": [
     "旁狄希臘語",
     "Pontic Greek",
-    "Pontic"
+    "Pontic",
+    "旁狄希腊语"
   ],
   "pnu": [
     "炯奈語",
     "Jiongnai Bunu",
-    "Kiong Nai"
+    "Kiong Nai",
+    "炯奈语"
   ],
   "pnv": [
     "Pinigura"
@@ -21192,7 +23106,8 @@
   ],
   "poe": [
     "聖胡安阿欽戈波波洛卡語",
-    "San Juan Atzingo Popoloca"
+    "San Juan Atzingo Popoloca",
+    "圣胡安阿钦戈波波洛卡语"
   ],
   "pof": [
     "Poke"
@@ -21205,7 +23120,8 @@
   ],
   "poi": [
     "高地波波魯卡語",
-    "Highland Popoluca"
+    "Highland Popoluca",
+    "高地波波鲁卡语"
   ],
   "pok": [
     "Pokangá"
@@ -21215,7 +23131,8 @@
   ],
   "pon": [
     "波納佩語",
-    "Pohnpeian"
+    "Pohnpeian",
+    "波纳佩语"
   ],
   "poo": [
     "Central Pomo"
@@ -21225,16 +23142,19 @@
   ],
   "poq": [
     "特西斯特佩克波波魯卡語",
-    "Texistepec Popoluca"
+    "Texistepec Popoluca",
+    "特西斯特佩克波波鲁卡语"
   ],
   "pos": [
     "薩約拉波波魯卡語",
-    "Sayula Popoluca"
+    "Sayula Popoluca",
+    "萨约拉波波鲁卡语"
   ],
   "pot": [
     "珀塔瓦托米語",
     "Potawatomi",
-    "Pottawatomie"
+    "Pottawatomie",
+    "珀塔瓦托米语"
   ],
   "pov": [
     "幾內亞比紹克里奧爾語",
@@ -21245,14 +23165,17 @@
     "Crioulo",
     "Kriolu",
     "Kriyol",
-    "Kiriol"
+    "Kiriol",
+    "几内亚比绍克里奥尔语"
   ],
   "pow": [
     "聖費利佩奧特拉特佩克波波洛卡語",
-    "San Felipe Otlaltepec Popoloca"
+    "San Felipe Otlaltepec Popoloca",
+    "圣费利佩奥特拉特佩克波波洛卡语"
   ],
   "pox": [
-    "波拉布語"
+    "波拉布語",
+    "波拉布语"
   ],
   "poy": [
     "Pogolo"
@@ -21270,7 +23193,8 @@
   ],
   "poz-cet-pro": [
     "原始中-東部馬來-波利尼西亞語",
-    "Proto-Central-Eastern Malayo-Polynesian"
+    "Proto-Central-Eastern Malayo-Polynesian",
+    "原始中-东部马来-波利尼西亚语"
   ],
   "poz-hce-pro": [
     "Proto-Halmahera-Cenderawasih",
@@ -21278,51 +23202,63 @@
   ],
   "poz-lgx-pro": [
     "原始楠榜語",
-    "Proto-Lampungic"
+    "Proto-Lampungic",
+    "原始楠榜语"
   ],
   "poz-mcm-pro": [
     "原始馬來-占語",
-    "Proto-Malayo-Chamic"
+    "Proto-Malayo-Chamic",
+    "原始马来-占语"
   ],
   "poz-mly-pro": [
     "原始馬來語",
-    "Proto-Malayic"
+    "Proto-Malayic",
+    "原始马来语"
   ],
   "poz-msa-pro": [
     "原始馬來-松巴哇語",
-    "Proto-Malayo-Sumbawan"
+    "Proto-Malayo-Sumbawan",
+    "原始马来-松巴哇语"
   ],
   "poz-oce-pro": [
     "原始大洋洲語",
-    "Proto-Oceanic"
+    "Proto-Oceanic",
+    "原始大洋洲语"
   ],
   "poz-pep-pro": [
-    "原始東部波利尼西亞語"
+    "原始東部波利尼西亞語",
+    "原始东部波利尼西亚语"
   ],
   "poz-pnp-pro": [
     "原始核心波利尼西亞語",
-    "Proto-Nuclear Polynesian"
+    "Proto-Nuclear Polynesian",
+    "原始核心波利尼西亚语"
   ],
   "poz-pol-pro": [
     "原始波利尼西亞語",
-    "Proto-Polynesian"
+    "Proto-Polynesian",
+    "原始波利尼西亚语"
   ],
   "poz-pro": [
     "原始馬來-波利尼西亞語",
     "Proto-Malayo-Polynesian",
-    "Proto-Western Malayo-Polynesian"
+    "Proto-Western Malayo-Polynesian",
+    "原始马来-波利尼西亚语"
   ],
   "poz-ssw-pro": [
     "原始南蘇拉威西語",
-    "Proto-South Sulawesi"
+    "Proto-South Sulawesi",
+    "原始南苏拉威西语"
   ],
   "poz-sus-pro": [
     "原始巽他-蘇拉威西語",
-    "Proto-Sunda-Sulawesi"
+    "Proto-Sunda-Sulawesi",
+    "原始巽他-苏拉威西语"
   ],
   "poz-swa-pro": [
     "原始北沙撈越語",
-    "Proto-North Sarawak"
+    "Proto-North Sarawak",
+    "原始北沙捞越语"
   ],
   "ppa": [
     "Pao"
@@ -21333,12 +23269,14 @@
   "ppi": [
     "帕伊帕伊語",
     "Paipai",
-    "Akwa'ala"
+    "Akwa'ala",
+    "帕伊帕伊语"
   ],
   "ppk": [
     "烏馬語",
     "Uma",
-    "Pipikoro"
+    "Pipikoro",
+    "乌马语"
   ],
   "ppl": [
     "皮皮爾語",
@@ -21346,7 +23284,8 @@
     "Nahuat",
     "Náhuat",
     "Nawat",
-    "Náwat"
+    "Náwat",
+    "皮皮尔语"
   ],
   "ppm": [
     "Papuma"
@@ -21373,7 +23312,8 @@
   ],
   "pps": [
     "聖路易特馬拉卡約卡波波洛卡語",
-    "San Luís Temalacayuca Popoloca"
+    "San Luís Temalacayuca Popoloca",
+    "圣路易特马拉卡约卡波波洛卡语"
   ],
   "ppt": [
     "Pa",
@@ -21394,14 +23334,21 @@
     "干仔轄語",
     "洪雅語",
     "洪安雅語",
-    "和安雅語"
+    "和安雅語",
+    "拍瀑拉语",
+    "巴布拉语",
+    "干仔辖语",
+    "洪雅语",
+    "洪安雅语",
+    "和安雅语"
   ],
   "pqa": [
     "Pa'a"
   ],
   "pqe-pro": [
     "原始東部馬來-波利尼西亞語",
-    "Proto-Eastern Malayo-Polynesian"
+    "Proto-Eastern Malayo-Polynesian",
+    "原始东部马来-波利尼西亚语"
   ],
   "pqm": [
     "Malecite-Passamaquoddy",
@@ -21417,7 +23364,8 @@
   ],
   "pre": [
     "普林西比語",
-    "Principense"
+    "Principense",
+    "普林西比语"
   ],
   "prf": [
     "Paranan"
@@ -21426,7 +23374,9 @@
     "古普魯士語",
     "普魯士語",
     "Old Prussian",
-    "Prussian"
+    "Prussian",
+    "古普鲁士语",
+    "普鲁士语"
   ],
   "prh": [
     "Porohanon"
@@ -21437,7 +23387,9 @@
   "prk": [
     "巴饒克語",
     "Parauk",
-    "巴饒克方言"
+    "巴饒克方言",
+    "巴饶克语",
+    "巴饶克方言"
   ],
   "prl": [
     "秘魯手語",
@@ -21455,11 +23407,13 @@
     "古奧克語",
     "Old Occitan",
     "Old Provençal",
-    "Old Provencal"
+    "Old Provencal",
+    "古奥克语"
   ],
   "prq": [
     "佩勒內阿舍寧卡語",
-    "Ashéninka Perené"
+    "Ashéninka Perené",
+    "佩勒内阿舍宁卡语"
   ],
   "prr": [
     "Puri"
@@ -21482,10 +23436,12 @@
   "prz": [
     "普羅維登西亞手語",
     "Providencia Sign Language",
-    "Providence Island Sign Language"
+    "Providence Island Sign Language",
+    "普罗维登西亚手语"
   ],
   "ps": [
-    "普什圖語"
+    "普什圖語",
+    "普什图语"
   ],
   "psa": [
     "Asue Awyu",
@@ -21493,34 +23449,41 @@
   ],
   "psc": [
     "波斯手語",
-    "Persian Sign Language"
+    "Persian Sign Language",
+    "波斯手语"
   ],
   "psd": [
     "平原印第安手語",
-    "Plains Indian Sign Language"
+    "Plains Indian Sign Language",
+    "平原印第安手语"
   ],
   "pse": [
     "中馬來語",
-    "Central Malay"
+    "Central Malay",
+    "中马来语"
   ],
   "psg": [
     "檳城手語",
-    "Penang Sign Language"
+    "Penang Sign Language",
+    "槟城手语"
   ],
   "psh": [
     "西南帕沙伊語",
-    "Southwest Pashayi"
+    "Southwest Pashayi",
+    "西南帕沙伊语"
   ],
   "psi": [
     "東南帕沙伊語",
     "Southeast Pashayi",
     "Southeastern Pashayi",
     "Southeastern Pashai",
-    "Southeast Pashai"
+    "Southeast Pashai",
+    "东南帕沙伊语"
   ],
   "psl": [
     "波多黎各手語",
-    "Puerto Rican Sign Language"
+    "Puerto Rican Sign Language",
+    "波多黎各手语"
   ],
   "psm": [
     "Pauserna",
@@ -21531,18 +23494,21 @@
   ],
   "pso": [
     "波蘭手語",
-    "Polish Sign Language"
+    "Polish Sign Language",
+    "波兰手语"
   ],
   "psp": [
     "菲律賓手語",
-    "Philippine Sign Language"
+    "Philippine Sign Language",
+    "菲律宾手语"
   ],
   "psq": [
     "Pasi"
   ],
   "psr": [
     "葡萄牙手語",
-    "Portuguese Sign Language"
+    "Portuguese Sign Language",
+    "葡萄牙手语"
   ],
   "pss": [
     "Kaulong"
@@ -21550,7 +23516,8 @@
   "psu": [
     "索拉塞那語",
     "Sauraseni",
-    "Shauraseni"
+    "Shauraseni",
+    "索拉塞那语"
   ],
   "psw": [
     "Port Sandwich"
@@ -21559,7 +23526,8 @@
     "Piscataway"
   ],
   "pt": [
-    "葡萄牙語"
+    "葡萄牙語",
+    "葡萄牙语"
   ],
   "pta": [
     "Pai Tavytera"
@@ -21612,7 +23580,9 @@
     "Phorhépecha",
     "Phorhé",
     "Porhé",
-    "塔拉斯卡語"
+    "塔拉斯卡語",
+    "普雷佩查语",
+    "塔拉斯卡语"
   ],
   "pub": [
     "Purum",
@@ -21702,17 +23672,20 @@
     "Southern Patwin"
   ],
   "pwm": [
-    "莫爾伯語"
+    "莫爾伯語",
+    "莫尔伯语"
   ],
   "pwn": [
     "排灣語",
-    "Paiwan"
+    "Paiwan",
+    "排湾语"
   ],
   "pwo": [
     "西波克倫語",
     "Western Pwo",
     "Delta Pwo",
-    "Pwo Western Karen"
+    "Pwo Western Karen",
+    "西波克伦语"
   ],
   "pwr": [
     "Powari"
@@ -21721,11 +23694,13 @@
     "北波克倫語",
     "Northern Pwo",
     "Phlong",
-    "Pwo Northern Karen"
+    "Pwo Northern Karen",
+    "北波克伦语"
   ],
   "pxm": [
     "科扎爾特佩克米塞語",
-    "Quetzaltepec Mixe"
+    "Quetzaltepec Mixe",
+    "科扎尔特佩克米塞语"
   ],
   "pye": [
     "Pye Krumen"
@@ -21741,16 +23716,19 @@
   ],
   "pys": [
     "巴拉圭手語",
-    "Paraguayan Sign Language"
+    "Paraguayan Sign Language",
+    "巴拉圭手语"
   ],
   "pyu": [
     "卑南語",
     "Puyuma",
-    "Pinuyumayan"
+    "Pinuyumayan",
+    "卑南语"
   ],
   "pyx": [
     "驃語",
-    "Pyu"
+    "Pyu",
+    "骠语"
   ],
   "pyy": [
     "Pyen",
@@ -21759,70 +23737,85 @@
   ],
   "pzh": [
     "巴宰語",
-    "Pazeh"
+    "Pazeh",
+    "巴宰语"
   ],
   "pzn": [
     "Para Naga"
   ],
   "qfa-adm-pro": [
     "原始大安達曼語",
-    "Proto-Great Andamanese"
+    "Proto-Great Andamanese",
+    "原始大安达曼语"
   ],
   "qfa-bet-pro": [
-    "原始貝台語"
+    "原始貝台語",
+    "原始贝台语"
   ],
   "qfa-cka-pro": [
     "原始楚科奇-堪察加語",
-    "Proto-Chukotko-Kamchatkan"
+    "Proto-Chukotko-Kamchatkan",
+    "原始楚科奇-堪察加语"
   ],
   "qfa-hur-pro": [
     "原始胡里安-烏拉爾圖語",
-    "Proto-Hurro-Urartian"
+    "Proto-Hurro-Urartian",
+    "原始胡里安-乌拉尔图语"
   ],
   "qfa-kad-pro": [
     "Proto-Kadu"
   ],
   "qfa-kms-pro": [
     "原始侗水語",
-    "Proto-Kam-Sui"
+    "Proto-Kam-Sui",
+    "原始侗水语"
   ],
   "qfa-kor-pro": [
     "原始朝鮮語",
-    "Proto-Korean"
+    "Proto-Korean",
+    "原始朝鲜语"
   ],
   "qfa-kra-pro": [
     "原始仡佬語",
-    "Proto-Kra"
+    "Proto-Kra",
+    "原始仡佬语"
   ],
   "qfa-lic-pro": [
-    "原始黎語"
+    "原始黎語",
+    "原始黎语"
   ],
   "qfa-onb-pro": [
-    "原始貝語"
+    "原始貝語",
+    "原始贝语"
   ],
   "qfa-ong-pro": [
     "Proto-Ongan"
   ],
   "qfa-tak-pro": [
-    "原始侗台語"
+    "原始侗台語",
+    "原始侗台语"
   ],
   "qfa-yen-pro": [
     "原始葉尼塞語",
-    "Proto-Yeniseian"
+    "Proto-Yeniseian",
+    "原始叶尼塞语"
   ],
   "qfa-yuk-pro": [
     "原始尤卡吉爾語",
-    "Proto-Yukaghir"
+    "Proto-Yukaghir",
+    "原始尤卡吉尔语"
   ],
   "qu": [
-    "克丘亞語"
+    "克丘亞語",
+    "克丘亚语"
   ],
   "qua": [
     "Quapaw",
     "Arkansas"
   ],
   "quc": [
-    "基切語"
+    "基切語",
+    "基切语"
   ],
   "qui": [
     "Quileute"
@@ -21850,7 +23843,8 @@
   ],
   "qwc": [
     "古典克丘亞語",
-    "Classical Quechua"
+    "Classical Quechua",
+    "古典克丘亚语"
   ],
   "qwe-kch": [
     "Kichwa",
@@ -21877,7 +23871,10 @@
     "Mamluk-Kipchak",
     "Cuman",
     "Kuman",
-    "Polovets"
+    "Polovets",
+    "钦察语",
+    "克普恰克语",
+    "奇普恰克语"
   ],
   "qwt": [
     "Kwalhioqua-Tlatskanai",
@@ -21885,7 +23882,8 @@
   ],
   "qxs": [
     "南羌語",
-    "Southern Qiang"
+    "Southern Qiang",
+    "南羌语"
   ],
   "qya": [
     "Quenya"
@@ -21914,11 +23912,13 @@
   "rad": [
     "埃地語",
     "Rade",
-    "Rhade"
+    "Rhade",
+    "埃地语"
   ],
   "raf": [
     "西梅瓦杭語",
-    "Western Meohang"
+    "Western Meohang",
+    "西梅瓦杭语"
   ],
   "rag": [
     "Logooli",
@@ -21930,7 +23930,8 @@
     "Rabha",
     "Maituri",
     "Rongdani",
-    "Rava"
+    "Rava",
+    "拉巴语"
   ],
   "rai": [
     "Ramoaaina",
@@ -21945,7 +23946,8 @@
   ],
   "raj": [
     "拉賈斯坦語",
-    "Rajasthani"
+    "Rajasthani",
+    "拉贾斯坦语"
   ],
   "rak": [
     "Tulu-Bohuai",
@@ -21956,9 +23958,11 @@
     "Ralte"
   ],
   "ram": [
+    "卡內拉語",
     "Canela",
     "Krahô",
-    "Canela-Krahô"
+    "Canela-Krahô",
+    "卡内拉语"
   ],
   "ran": [
     "Riantana",
@@ -21971,7 +23975,8 @@
     "拉帕努伊語",
     "Rapa Nui",
     "Rapanui",
-    "Pascuense"
+    "Pascuense",
+    "拉帕努伊语"
   ],
   "raq": [
     "Saam"
@@ -21980,7 +23985,8 @@
     "拉羅湯加語",
     "Rarotongan",
     "Cook Islands Maori",
-    "Cook Islands Māori"
+    "Cook Islands Māori",
+    "拉罗汤加语"
   ],
   "ras": [
     "Tegali",
@@ -22004,7 +24010,8 @@
   ],
   "raw": [
     "日旺語",
-    "Rawang"
+    "Rawang",
+    "日旺语"
   ],
   "rax": [
     "Rang"
@@ -22021,15 +24028,18 @@
   "rbk": [
     "北邦托克語",
     "Northern Bontoc",
-    "Northern Bontok"
+    "Northern Bontok",
+    "北邦托克语"
   ],
   "rbl": [
     "米拉亞比科爾語",
-    "Miraya Bikol"
+    "Miraya Bikol",
+    "米拉亚比科尔语"
   ],
   "rcf": [
     "留尼旺克里奧爾法語",
-    "Réunion Creole French"
+    "Réunion Creole French",
+    "留尼旺克里奥尔法语"
   ],
   "rdb": [
     "Rudbari"
@@ -22039,7 +24049,8 @@
   ],
   "reb": [
     "勒姆邦語",
-    "Rembong"
+    "Rembong",
+    "勒姆邦语"
   ],
   "ree": [
     "Rejang Kayan",
@@ -22063,7 +24074,8 @@
   "rej": [
     "勒姜語",
     "Rejang",
-    "Rejangese"
+    "Rejangese",
+    "勒姜语"
   ],
   "rel": [
     "Rendille"
@@ -22094,7 +24106,8 @@
     "羅姆希臘語",
     "Romani Greek",
     "Romano-Greek",
-    "Hellenoromani"
+    "Hellenoromani",
+    "罗姆希腊语"
   ],
   "rgk": [
     "Rangkas"
@@ -22102,7 +24115,8 @@
   "rgn": [
     "羅馬涅語",
     "Romagnol",
-    "Romagnolo"
+    "Romagnolo",
+    "罗马涅语"
   ],
   "rgr": [
     "Resígaro"
@@ -22115,7 +24129,8 @@
   ],
   "rhg": [
     "羅興亞語",
-    "Rohingya"
+    "Rohingya",
+    "罗兴亚语"
   ],
   "rhp": [
     "Yahang"
@@ -22129,7 +24144,10 @@
     "Tarifit",
     "Rifain",
     "里菲亞語",
-    "里夫語"
+    "里夫語",
+    "里菲安语",
+    "里菲亚语",
+    "里夫语"
   ],
   "ril": [
     "Riang"
@@ -22179,7 +24197,8 @@
     "Ramree",
     "Yangbye",
     "Thandwe",
-    "Chaungtha"
+    "Chaungtha",
+    "若开语"
   ],
   "rkm": [
     "Marka"
@@ -22190,10 +24209,12 @@
   ],
   "rkw": [
     "阿拉瓜爾語",
-    "Arakwal"
+    "Arakwal",
+    "阿拉瓜尔语"
   ],
   "rm": [
-    "羅曼什語"
+    "羅曼什語",
+    "罗曼什语"
   ],
   "rma": [
     "Rama"
@@ -22203,69 +24224,81 @@
   ],
   "rmc": [
     "喀爾巴阡羅姆語",
-    "Carpathian Romani"
+    "Carpathian Romani",
+    "喀尔巴阡罗姆语"
   ],
   "rmd": [
     "旅行者丹麥語",
-    "Traveller Danish"
+    "Traveller Danish",
+    "旅行者丹麦语"
   ],
   "rme": [
     "盎格魯羅姆語",
-    "Angloromani"
+    "Angloromani",
+    "盎格鲁罗姆语"
   ],
   "rmf": [
     "芬蘭羅姆語",
-    "Kalo Finnish Romani"
+    "Kalo Finnish Romani",
+    "芬兰罗姆语"
   ],
   "rmg": [
     "旅行者挪威語",
-    "Traveller Norwegian"
+    "Traveller Norwegian",
+    "旅行者挪威语"
   ],
   "rmh": [
     "Murkim"
   ],
   "rmi": [
     "洛馬夫倫語",
-    "Lomavren"
+    "Lomavren",
+    "洛马夫伦语"
   ],
   "rmk": [
     "Romkun"
   ],
   "rml": [
     "波羅的羅姆語",
-    "Baltic Romani"
+    "Baltic Romani",
+    "波罗的罗姆语"
   ],
   "rmm": [
     "Roma"
   ],
   "rmn": [
     "巴爾幹羅姆語",
-    "Balkan Romani"
+    "Balkan Romani",
+    "巴尔干罗姆语"
   ],
   "rmo": [
     "辛特羅姆語",
     "Sinte Romani",
     "Sinti Romani",
     "Sinti-Manouche",
-    "Sinti"
+    "Sinti",
+    "辛特罗姆语"
   ],
   "rmp": [
     "Rempi"
   ],
   "rmq": [
     "伊比利吉普賽語",
-    "Caló"
+    "Caló",
+    "伊比利吉普赛语"
   ],
   "rms": [
     "羅馬尼亞手語",
-    "Romanian Sign Language"
+    "Romanian Sign Language",
+    "罗马尼亚手语"
   ],
   "rmt": [
     "Domari"
   ],
   "rmu": [
     "斯堪地羅姆語",
-    "Tavringer Romani"
+    "Tavringer Romani",
+    "斯堪地罗姆语"
   ],
   "rmv": [
     "Romanova"
@@ -22274,21 +24307,25 @@
     "威爾士羅姆語",
     "Welsh Romani",
     "Welsh Romany",
-    "Kååle"
+    "Kååle",
+    "威尔士罗姆语"
   ],
   "rmx": [
     "Romam"
   ],
   "rmy": [
     "弗拉赫羅姆語",
-    "Vlax Romani"
+    "Vlax Romani",
+    "弗拉赫罗姆语"
   ],
   "rmz": [
     "馬爾馬語",
-    "Marma"
+    "Marma",
+    "马尔马语"
   ],
   "rn": [
-    "克倫地語"
+    "克倫地語",
+    "克伦地语"
   ],
   "rnd": [
     "Ruwund"
@@ -22296,7 +24333,8 @@
   "rng": [
     "龍加語",
     "Ronga",
-    "Xironga"
+    "Xironga",
+    "龙加语"
   ],
   "rnl": [
     "Ranglong"
@@ -22309,17 +24347,20 @@
   ],
   "rnw": [
     "龍瓦語",
-    "Rungwa"
+    "Rungwa",
+    "龙瓦语"
   ],
   "ro": [
-    "羅馬尼亞語"
+    "羅馬尼亞語",
+    "罗马尼亚语"
   ],
   "roa-ang": [
     "安茹語",
     "Angevin",
     "Craonnais",
     "Baugeois",
-    "Saumurois"
+    "Saumurois",
+    "安茹语"
   ],
   "roa-bbn": [
     "Bourbonnais-Berrichon",
@@ -22349,7 +24390,8 @@
     "Langrois",
     "Valsaônois",
     "Verduno-Chalonnais",
-    "Sédelocien"
+    "Sédelocien",
+    "勃艮第语"
   ],
   "roa-cha": [
     "香檳語",
@@ -22366,9 +24408,11 @@
     "Argonnais",
     "Porcien",
     "Ardennais",
-    "Sugny"
+    "Sugny",
+    "香槟语"
   ],
   "roa-fcm": [
+    "弗朗什-孔泰語",
     "Franc-Comtois",
     "Frainc-Comtou",
     "Comtois",
@@ -22377,15 +24421,18 @@
     "Vâdais",
     "Taignon",
     "Bisontin",
-    "Bousbot"
+    "Bousbot",
+    "弗朗什-孔泰语"
   ],
   "roa-gal": [
     "加羅語",
-    "Gallo"
+    "Gallo",
+    "加罗语"
   ],
   "roa-leo": [
     "萊昂語",
-    "Leonese"
+    "Leonese",
+    "莱昂语"
   ],
   "roa-lor": [
     "洛林語",
@@ -22398,23 +24445,28 @@
     "Messin",
     "Nancéien",
     "Spinalien",
-    "Déodatien"
+    "Déodatien",
+    "洛林语"
   ],
   "roa-oan": [
     "納瓦拉-阿拉貢語",
     "Navarro-Aragonese",
-    "Old Aragonese"
+    "Old Aragonese",
+    "纳瓦拉-阿拉贡语"
   ],
   "roa-oca": [
     "古加泰羅尼亞語",
-    "Old Catalan"
+    "Old Catalan",
+    "古加泰罗尼亚语"
   ],
   "roa-ole": [
     "古萊昂語",
-    "Old Leonese"
+    "Old Leonese",
+    "古莱昂语"
   ],
   "roa-opt": [
-    "古葡萄牙語"
+    "古葡萄牙語",
+    "古葡萄牙语"
   ],
   "roa-orl": [
     "奧爾良語",
@@ -22423,7 +24475,8 @@
     "Solognot",
     "Gâtinais",
     "Blaisois",
-    "Vendômois"
+    "Vendômois",
+    "奥尔良语"
   ],
   "roa-poi": [
     "Poitevin-Saintongeais",
@@ -22433,15 +24486,18 @@
   ],
   "roa-tar": [
     "塔倫蒂諾語",
-    "Tarantino"
+    "Tarantino",
+    "塔伦蒂诺语"
   ],
   "roa-tou": [
     "圖蘭格語",
-    "Tourangeau"
+    "Tourangeau",
+    "图兰格语"
   ],
   "rob": [
     "塔埃語",
-    "Tae'"
+    "Tae'",
+    "塔埃语"
   ],
   "roc": [
     "Cacgia Roglai"
@@ -22453,28 +24509,33 @@
     "Ronji"
   ],
   "rof": [
-    "蘭博語"
+    "蘭博語",
+    "兰博语"
   ],
   "rog": [
     "Northern Roglai"
   ],
   "rol": [
     "朗布隆語",
-    "Romblomanon"
+    "Romblomanon",
+    "朗布隆语"
   ],
   "rom": [
     "羅姆語",
     "Romani",
-    "Gypsy"
+    "Gypsy",
+    "罗姆语"
   ],
   "roo": [
     "羅托卡特語",
-    "Rotokas"
+    "Rotokas",
+    "罗托卡特语"
   ],
   "rop": [
     "澳洲克里奧爾語",
     "Kriol",
-    "Australian Kriol"
+    "Australian Kriol",
+    "澳洲克里奥尔语"
   ],
   "ror": [
     "Rongga"
@@ -22505,7 +24566,8 @@
   ],
   "rsl": [
     "俄羅斯手語",
-    "Russian Sign Language"
+    "Russian Sign Language",
+    "俄罗斯手语"
   ],
   "rsm": [
     "Miriwoong Sign Language"
@@ -22521,13 +24583,16 @@
   "rtm": [
     "羅圖馬語",
     "Rotuman",
-    "洛圖馬語"
+    "洛圖馬語",
+    "罗图马语",
+    "洛图马语"
   ],
   "rtw": [
     "Rathawi"
   ],
   "ru": [
-    "俄語"
+    "俄語",
+    "俄语"
   ],
   "rub": [
     "Gungu"
@@ -22537,13 +24602,15 @@
   ],
   "rue": [
     "盧森尼亞語",
-    "Rusyn"
+    "Rusyn",
+    "卢森尼亚语"
   ],
   "ruf": [
     "Luguru"
   ],
   "rug": [
-    "羅維阿納語"
+    "羅維阿納語",
+    "罗维阿纳语"
   ],
   "ruh": [
     "Ruga"
@@ -22557,20 +24624,26 @@
   "ruo": [
     "伊斯特羅-羅馬尼亞語",
     "伊斯特拉-羅馬尼亞語",
-    "Istro-Romanian"
+    "Istro-Romanian",
+    "伊斯特罗-罗马尼亚语",
+    "伊斯特拉-罗马尼亚语"
   ],
   "rup": [
     "阿羅馬尼亞語",
-    "Aromanian"
+    "Aromanian",
+    "阿罗马尼亚语"
   ],
   "ruq": [
     "梅戈來諾-羅馬尼亞語",
-    "Megleno-Romanian"
+    "Megleno-Romanian",
+    "梅戈来诺-罗马尼亚语"
   ],
   "rut": [
     "魯圖爾語",
     "Rutul",
-    "塔特語"
+    "塔特語",
+    "鲁图尔语",
+    "塔特语"
   ],
   "ruu": [
     "Lanas Lobu"
@@ -22583,13 +24656,15 @@
     "Ruma"
   ],
   "rw": [
-    "盧旺達語"
+    "盧旺達語",
+    "卢旺达语"
   ],
   "rwa": [
     "Rawo"
   ],
   "rwk": [
-    "羅瓦語"
+    "羅瓦語",
+    "罗瓦语"
   ],
   "rwm": [
     "Amba"
@@ -22605,16 +24680,20 @@
   ],
   "ryn": [
     "北奄美大島語",
-    "Northern Amami-Oshima"
+    "Northern Amami-Oshima",
+    "北奄美大岛语"
   ],
   "rys": [
     "八重山語",
-    "Yaeyama"
+    "Yaeyama",
+    "八重山语"
   ],
   "ryu": [
     "沖繩語",
     "琉球語",
-    "Okinawan"
+    "Okinawan",
+    "冲绳语",
+    "琉球语"
   ],
   "rzh": [
     "Razihi",
@@ -22622,11 +24701,13 @@
     "Jabal Razih"
   ],
   "sa": [
-    "梵語"
+    "梵語",
+    "梵语"
   ],
   "saa": [
     "薩巴語",
-    "Saba"
+    "Saba",
+    "萨巴语"
   ],
   "sab": [
     "Buglere",
@@ -22646,7 +24727,8 @@
     "Meskwaki"
   ],
   "sad": [
-    "桑達韋語"
+    "桑達韋語",
+    "桑达韦语"
   ],
   "sae": [
     "Sabanê"
@@ -22657,7 +24739,8 @@
   "sah": [
     "雅庫特語",
     "Yakut",
-    "Sakha"
+    "Sakha",
+    "雅库特语"
   ],
   "sai-ajg": [
     "Ajagua"
@@ -22725,14 +24808,17 @@
     "Kara"
   ],
   "sai-car-pro": [
-    "原始加勒比語"
+    "原始加勒比語",
+    "原始加勒比语"
   ],
   "sai-cat": [
     "Catacao"
   ],
   "sai-cer-pro": [
+    "原始塞拉多語",
     "Proto-Cerrado",
-    "Proto-Amazonian Jê"
+    "Proto-Amazonian Jê",
+    "原始塞拉多语"
   ],
   "sai-chi": [
     "Chirino"
@@ -22750,8 +24836,10 @@
     "Churuya"
   ],
   "sai-cje-pro": [
+    "原始中熱語",
     "Proto-Central Jê",
-    "Proto-Akuwẽ"
+    "Proto-Akuwẽ",
+    "原始中热语"
   ],
   "sai-cmg": [
     "Comechingon"
@@ -22825,12 +24913,14 @@
     "Proto-Huitoto-Ocaina"
   ],
   "sai-jee-pro": [
+    "原始熱語",
     "Proto-Jê",
     "Proto-Gê",
     "Proto-Jean",
     "Proto-Gean",
     "Proto-Jê-Kaingang",
-    "Proto-Ye"
+    "Proto-Ye",
+    "原始热语"
   ],
   "sai-jko": [
     "Jeikó"
@@ -22848,11 +24938,13 @@
     "Kiriri"
   ],
   "sai-mal": [
-    "馬拉利語"
+    "馬拉利語",
+    "马拉利语"
   ],
   "sai-mar": [
     "馬拉蒂諾語",
-    "Maratino"
+    "Maratino",
+    "马拉蒂诺语"
   ],
   "sai-mat": [
     "馬塔納維語",
@@ -22861,10 +24953,12 @@
     "Matanaui",
     "Matanawü",
     "Mitandua",
-    "Moutoniway"
+    "Moutoniway",
+    "马塔纳维语"
   ],
   "sai-mcn": [
-    "莫卡納語"
+    "莫卡納語",
+    "莫卡纳语"
   ],
   "sai-men": [
     "Menien"
@@ -22908,8 +25002,10 @@
     "Peagaxinan"
   ],
   "sai-nje-pro": [
+    "原始北熱語",
     "Proto-Northern Jê",
-    "Proto-Core Jê"
+    "Proto-Core Jê",
+    "原始北热语"
   ],
   "sai-opo": [
     "Opón",
@@ -22998,7 +25094,9 @@
     "Sutagao"
   ],
   "sai-sje-pro": [
-    "Proto-Southern Jê"
+    "原始南熱語",
+    "Proto-Southern Jê",
+    "原始南热语"
   ],
   "sai-tab": [
     "Tabancale",
@@ -23095,26 +25193,31 @@
   ],
   "saj": [
     "薩胡語",
-    "Sahu"
+    "Sahu",
+    "萨胡语"
   ],
   "sak": [
     "Sake",
     "Shake"
   ],
   "sal-pro": [
-    "原始薩利希語"
+    "原始薩利希語",
+    "原始萨利希语"
   ],
   "sam": [
     "撒馬利亞亞拉姆語",
     "撒馬利亞語",
     "Samaritan Aramaic",
-    "Samaritan"
+    "Samaritan",
+    "撒马利亚亚拉姆语",
+    "撒马利亚语"
   ],
   "sao": [
     "Sause"
   ],
   "saq": [
-    "薩布魯語"
+    "薩布魯語",
+    "萨布鲁语"
   ],
   "sar": [
     "Saraveca",
@@ -23123,18 +25226,21 @@
     "Sarave"
   ],
   "sas": [
-    "薩薩克語"
+    "薩薩克語",
+    "萨萨克语"
   ],
   "sat": [
     "桑塔利語",
-    "Santali"
+    "Santali",
+    "桑塔利语"
   ],
   "sau": [
     "Saleman"
   ],
   "sav": [
     "薩菲薩菲語",
-    "Saafi-Saafi"
+    "Saafi-Saafi",
+    "萨菲萨菲语"
   ],
   "saw": [
     "Sawi"
@@ -23148,10 +25254,12 @@
   ],
   "saz": [
     "索拉什特拉語",
-    "Saurashtra"
+    "Saurashtra",
+    "索拉什特拉语"
   ],
   "sba": [
-    "甘拜語"
+    "甘拜語",
+    "甘拜语"
   ],
   "sbb": [
     "Simbo"
@@ -23182,7 +25290,8 @@
     "索里-哈林甘語",
     "Sori-Harengan",
     "Sori",
-    "Harengan"
+    "Harengan",
+    "索里-哈林甘语"
   ],
   "sbi": [
     "Seti"
@@ -23194,20 +25303,23 @@
     "Safwa"
   ],
   "sbl": [
-    "波多蘭三描語"
+    "波多蘭三描語",
+    "波多兰三描语"
   ],
   "sbm": [
     "Sagala"
   ],
   "sbn": [
     "信德比爾語",
-    "Sindhi Bhil"
+    "Sindhi Bhil",
+    "信德比尔语"
   ],
   "sbo": [
     "Sabüm"
   ],
   "sbp": [
-    "桑古語"
+    "桑古語",
+    "桑古语"
   ],
   "sbq": [
     "Sileibi"
@@ -23226,7 +25338,8 @@
   ],
   "sbv": [
     "薩比尼語",
-    "Sabine"
+    "Sabine",
+    "萨比尼语"
   ],
   "sbw": [
     "Simba"
@@ -23241,7 +25354,8 @@
     "Sara Kaba"
   ],
   "sc": [
-    "撒丁語"
+    "撒丁語",
+    "撒丁语"
   ],
   "scb": [
     "Chut"
@@ -23249,11 +25363,13 @@
   "sce": [
     "東鄉語",
     "Dongxiang",
-    "Santa"
+    "Santa",
+    "东乡语"
   ],
   "scf": [
     "聖米格爾克里奧爾法語",
-    "San Miguel Creole French"
+    "San Miguel Creole French",
+    "圣米格尔克里奥尔法语"
   ],
   "scg": [
     "Sanggau"
@@ -23261,39 +25377,47 @@
   "sch": [
     "薩卡車普語",
     "Sakachep",
-    "Khelma"
+    "Khelma",
+    "萨卡车普语"
   ],
   "sci": [
     "斯里蘭卡克里奧爾馬來語",
-    "Sri Lankan Creole Malay"
+    "Sri Lankan Creole Malay",
+    "斯里兰卡克里奥尔马来语"
   ],
   "sck": [
     "薩達里語",
-    "Sadri"
+    "Sadri",
+    "萨达里语"
   ],
   "scl": [
     "希納語",
     "Shina",
     "Gilgiti",
     "Astori",
-    "Chilasi"
+    "Chilasi",
+    "希纳语"
   ],
   "scn": [
     "西西里語",
-    "Sicilian"
+    "Sicilian",
+    "西西里语"
   ],
   "sco": [
     "低地蘇格蘭語",
     "蘇格蘭語",
     "Scots",
-    "Lowland Scots"
+    "Lowland Scots",
+    "低地苏格兰语",
+    "苏格兰语"
   ],
   "scp": [
     "約爾莫語",
     "Yolmo",
     "Hyolmo",
     "Yohlmo",
-    "Helambu Sherpa"
+    "Helambu Sherpa",
+    "约尔莫语"
   ],
   "scq": [
     "Sa'och",
@@ -23301,7 +25425,8 @@
   ],
   "scs": [
     "北斯拉維語",
-    "North Slavey"
+    "North Slavey",
+    "北斯拉维语"
   ],
   "scu": [
     "Shumcho"
@@ -23316,20 +25441,24 @@
     "Sicel"
   ],
   "sd": [
-    "信德語"
+    "信德語",
+    "信德语"
   ],
   "sda": [
     "托拉查-薩達語",
-    "Toraja-Sa'dan"
+    "Toraja-Sa'dan",
+    "托拉查-萨达语"
   ],
   "sdb": [
     "沙巴克語",
     "Shabak",
-    "Shabaki"
+    "Shabaki",
+    "沙巴克语"
   ],
   "sdc": [
     "薩薩里語",
-    "Sassarese"
+    "Sassarese",
+    "萨萨里语"
   ],
   "sde": [
     "Surubu"
@@ -23337,11 +25466,13 @@
   "sdf": [
     "薩爾里語",
     "Sarli",
-    "Sarliya"
+    "Sarliya",
+    "萨尔里语"
   ],
   "sdg": [
     "沙維語",
-    "Savi"
+    "Savi",
+    "沙维语"
   ],
   "sdh": [
     "南庫爾德語",
@@ -23349,7 +25480,8 @@
     "Kermanshani",
     "Kermanshahi",
     "Kermanshahi Kurdish",
-    "Kermanshani Kurdish"
+    "Kermanshani Kurdish",
+    "南库尔德语"
   ],
   "sdj": [
     "Suundi"
@@ -23359,25 +25491,29 @@
   ],
   "sdl": [
     "沙烏地阿拉伯手語",
-    "Saudi Arabian Sign Language"
+    "Saudi Arabian Sign Language",
+    "沙乌地阿拉伯手语"
   ],
   "sdm": [
     "Semandang"
   ],
   "sdn": [
     "加盧拉語",
-    "Gallurese"
+    "Gallurese",
+    "加卢拉语"
   ],
   "sdo": [
     "Bukar-Sadung Bidayuh"
   ],
   "sdp": [
     "舍朱奔語",
-    "Sherdukpen"
+    "Sherdukpen",
+    "舍朱奔语"
   ],
   "sdr": [
     "奧拉昂薩達里語",
-    "Oraon Sadri"
+    "Oraon Sadri",
+    "奥拉昂萨达里语"
   ],
   "sds": [
     "Sened"
@@ -23404,11 +25540,13 @@
     "Sibu Melanau"
   ],
   "se": [
-    "北薩米語"
+    "北薩米語",
+    "北萨米语"
   ],
   "sea": [
     "塞邁語",
-    "Semai"
+    "Semai",
+    "塞迈语"
   ],
   "sec": [
     "Sechelt"
@@ -23417,7 +25555,8 @@
     "Sedang"
   ],
   "see": [
-    "塞訥卡語"
+    "塞訥卡語",
+    "塞讷卡语"
   ],
   "sef": [
     "Cebaara Senoufo"
@@ -23426,10 +25565,12 @@
     "Segeju"
   ],
   "seh": [
-    "賽納語"
+    "賽納語",
+    "赛纳语"
   ],
   "sei": [
-    "瑟里語"
+    "瑟里語",
+    "瑟里语"
   ],
   "sej": [
     "Sene"
@@ -23444,11 +25585,14 @@
   "sel": [
     "塞爾庫普語",
     "Selkup",
-    "謝爾庫普語"
+    "謝爾庫普語",
+    "塞尔库普语",
+    "谢尔库普语"
   ],
   "sem-amm": [
     "亞捫語",
-    "Ammonite"
+    "Ammonite",
+    "亚扪语"
   ],
   "sem-amo": [
     "Amorite"
@@ -23482,14 +25626,16 @@
   ],
   "sem-pro": [
     "原始閃米特語",
-    "Proto-Semitic"
+    "Proto-Semitic",
+    "原始闪米特语"
   ],
   "sem-saf": [
     "Safaitic"
   ],
   "sem-srb": [
     "古南阿拉伯語",
-    "Old South Arabian"
+    "Old South Arabian",
+    "古南阿拉伯语"
   ],
   "sem-tay": [
     "Taymanitic",
@@ -23501,7 +25647,8 @@
   ],
   "sem-wes-pro": [
     "原始西閃米特語",
-    "Proto-West Semitic"
+    "Proto-West Semitic",
+    "原始西闪米特语"
   ],
   "sen": [
     "Nanerigé Sénoufo"
@@ -23524,7 +25671,8 @@
     "Koyraboro Senni Songhay",
     "Koyraboro Senni Songhai",
     "Koroboro Senni",
-    "Eastern Songhay"
+    "Eastern Songhay",
+    "东桑海语"
   ],
   "set": [
     "Sentani"
@@ -23547,48 +25695,58 @@
   ],
   "sfb": [
     "法國比利時手語",
-    "French Belgian Sign Language"
+    "French Belgian Sign Language",
+    "法国比利时手语"
   ],
   "sfm": [
     "小花苗語",
-    "Small Flowery Miao"
+    "Small Flowery Miao",
+    "小花苗语"
   ],
   "sfs": [
     "南非手語",
-    "South African Sign Language"
+    "South African Sign Language",
+    "南非手语"
   ],
   "sfw": [
     "Sehwi"
   ],
   "sg": [
-    "桑戈語"
+    "桑戈語",
+    "桑戈语"
   ],
   "sga": [
     "古愛爾蘭語",
-    "Old Irish"
+    "Old Irish",
+    "古爱尔兰语"
   ],
   "sgb": [
-    "麥安契埃塔語"
+    "麥安契埃塔語",
+    "麦安契埃塔语"
   ],
   "sgc": [
     "Kipsigis"
   ],
   "sgd": [
     "蘇里高農語",
-    "Surigaonon"
+    "Surigaonon",
+    "苏里高农语"
   ],
   "sge": [
     "色蓋語",
-    "Segai"
+    "Segai",
+    "色盖语"
   ],
   "sgg": [
     "瑞士德語手語",
     "Swiss-German Sign Language",
-    "Swiss German Sign Language"
+    "Swiss German Sign Language",
+    "瑞士德语手语"
   ],
   "sgh": [
     "舒格南語",
-    "Shughni"
+    "Shughni",
+    "舒格南语"
   ],
   "sgi": [
     "Suga"
@@ -23605,11 +25763,13 @@
   "sgr": [
     "桑加薩爾語",
     "Sangisari",
-    "Sangsari"
+    "Sangsari",
+    "桑加萨尔语"
   ],
   "sgs": [
     "薩莫吉提亞語",
-    "Samogitian"
+    "Samogitian",
+    "萨莫吉提亚语"
   ],
   "sgt": [
     "Brokpake",
@@ -23628,13 +25788,15 @@
     "桑格萊奇語",
     "Sanglechi",
     "Sanglich",
-    "Warduji"
+    "Warduji",
+    "桑格莱奇语"
   ],
   "sgz": [
     "Sursurunga"
   ],
   "sh": [
-    "塞爾維亞-克羅地亞語"
+    "塞爾維亞-克羅地亞語",
+    "塞尔维亚-克罗地亚语"
   ],
   "sha": [
     "Shall-Zwall"
@@ -23647,11 +25809,13 @@
   ],
   "shd": [
     "昆達爾-沙希語",
-    "Kundal Shahi"
+    "Kundal Shahi",
+    "昆达尔-沙希语"
   ],
   "she": [
     "謝科語",
-    "Sheko"
+    "Sheko",
+    "谢科语"
   ],
   "shg": [
     "Shua",
@@ -23669,7 +25833,8 @@
     "Western Shoshone",
     "Western Shoshoni",
     "Northern Shoshone",
-    "Northern Shoshoni"
+    "Northern Shoshoni",
+    "休休尼语"
   ],
   "shi": [
     "施盧赫語",
@@ -23680,28 +25845,32 @@
     "Tashlhiyt",
     "Tashelhit Berber",
     "Tachelhit Berber",
-    "Tashlhiyt Berber"
+    "Tashlhiyt Berber",
+    "施卢赫语"
   ],
   "shj": [
     "Shatt"
   ],
   "shk": [
     "什魯克語",
-    "Shilluk"
+    "Shilluk",
+    "什鲁克语"
   ],
   "shl": [
     "Shendu"
   ],
   "shm": [
     "沙赫魯迪語",
-    "Shahrudi"
+    "Shahrudi",
+    "沙赫鲁迪语"
   ],
   "shn": [
     "撣語",
     "Shan",
     "Kwam Tai",
     "Kam Tai",
-    "Tai Yai"
+    "Tai Yai",
+    "掸语"
   ],
   "sho": [
     "Shanga"
@@ -23709,7 +25878,9 @@
   "shp": [
     "希皮博-科尼博語",
     "希皮波-科尼波語",
-    "Shipibo-Conibo"
+    "Shipibo-Conibo",
+    "希皮博-科尼博语",
+    "希皮波-科尼波语"
   ],
   "shq": [
     "Sala"
@@ -23726,10 +25897,13 @@
   "shu": [
     "乍得阿拉伯語",
     "查德阿拉伯語",
-    "Chadian Arabic"
+    "Chadian Arabic",
+    "乍得阿拉伯语",
+    "查德阿拉伯语"
   ],
   "shv": [
-    "山地語"
+    "山地語",
+    "山地语"
   ],
   "shw": [
     "Shwai",
@@ -23739,41 +25913,49 @@
     "畲語",
     "She",
     "Ho Ne",
-    "Ho Nte"
+    "Ho Nte",
+    "畲语"
   ],
   "shy": [
     "塔查維特語",
     "Tachawit",
     "Shawiya Berber",
-    "Chaouïa"
+    "Chaouïa",
+    "塔查维特语"
   ],
   "shz": [
     "Syenara Senoufo"
   ],
   "si": [
-    "僧加羅語"
+    "僧加羅語",
+    "僧加罗语"
   ],
   "sia": [
     "阿卡拉薩米語",
-    "Akkala Sami"
+    "Akkala Sami",
+    "阿卡拉萨米语"
   ],
   "sib": [
     "塞波普語",
-    "Sebop"
+    "Sebop",
+    "塞波普语"
   ],
   "sid": [
-    "希達摩語"
+    "希達摩語",
+    "希达摩语"
   ],
   "sie": [
     "Simaa"
   ],
   "sij": [
     "農巴米語",
-    "Numbami"
+    "Numbami",
+    "农巴米语"
   ],
   "sio-pro": [
     "原始蘇語",
-    "Proto-Siouan"
+    "Proto-Siouan",
+    "原始苏语"
   ],
   "sip": [
     "錫金語",
@@ -23782,7 +25964,8 @@
     "Dranjoke",
     "Denjongka",
     "Denzongpeke",
-    "Denzongke"
+    "Denzongke",
+    "锡金语"
   ],
   "siq": [
     "Sonia"
@@ -23815,7 +25998,8 @@
     "Rgyalrong",
     "Jiarong",
     "Gyarung",
-    "Kuru"
+    "Kuru",
+    "茶堡话"
   ],
   "sit-kha-pro": [
     "Proto-Kham"
@@ -23834,7 +26018,8 @@
   ],
   "sit-pro": [
     "原始漢藏語",
-    "Proto-Sino-Tibetan"
+    "Proto-Sino-Tibetan",
+    "原始汉藏语"
   ],
   "sit-sit": [
     "四土話",
@@ -23852,11 +26037,13 @@
     "Jyarong",
     "Jyarung",
     "Yelong",
-    "Kuru"
+    "Kuru",
+    "四土话"
   ],
   "sit-tan-pro": [
     "原始達尼語",
-    "Proto-Tani"
+    "Proto-Tani",
+    "原始达尼语"
   ],
   "sit-tgm": [
     "Tangam"
@@ -23873,7 +26060,8 @@
     "Rgyalrong",
     "Jiarong",
     "Gyarung",
-    "Kuru"
+    "Kuru",
+    "草登话"
   ],
   "sit-zbu": [
     "Zbu",
@@ -23903,7 +26091,8 @@
   ],
   "siy": [
     "斯凡迪語",
-    "Sivandi"
+    "Sivandi",
+    "斯凡迪语"
   ],
   "siz": [
     "Siwi",
@@ -23917,18 +26106,21 @@
   ],
   "sjd": [
     "基爾丁薩米語",
-    "Kildin Sami"
+    "Kildin Sami",
+    "基尔丁萨米语"
   ],
   "sje": [
     "皮特薩米語",
-    "Pite Sami"
+    "Pite Sami",
+    "皮特萨米语"
   ],
   "sjg": [
     "Assangori"
   ],
   "sjk": [
     "凱米薩米語",
-    "Kemi Sami"
+    "Kemi Sami",
+    "凯米萨米语"
   ],
   "sjl": [
     "Miji",
@@ -23941,18 +26133,21 @@
   ],
   "sjn": [
     "辛達林語",
-    "Sindarin"
+    "Sindarin",
+    "辛达林语"
   ],
   "sjo": [
     "錫伯語",
     "Xibe",
     "Sibo",
     "Sibe",
-    "Xibo"
+    "Xibo",
+    "锡伯语"
   ],
   "sjp": [
     "蘇爾賈普里語",
-    "Surjapuri"
+    "Surjapuri",
+    "苏尔贾普里语"
   ],
   "sjr": [
     "Siar-Lak"
@@ -23962,25 +26157,30 @@
   ],
   "sjt": [
     "特爾薩米語",
-    "Ter Sami"
+    "Ter Sami",
+    "特尔萨米语"
   ],
   "sju": [
     "于默薩米語",
-    "Ume Sami"
+    "Ume Sami",
+    "于默萨米语"
   ],
   "sjw": [
     "肖尼語",
-    "Shawnee"
+    "Shawnee",
+    "肖尼语"
   ],
   "sk": [
-    "斯洛伐克語"
+    "斯洛伐克語",
+    "斯洛伐克语"
   ],
   "ska": [
     "Skagit"
   ],
   "skb": [
     "石語",
-    "Saek"
+    "Saek",
+    "石语"
   ],
   "skc": [
     "Ma Manda",
@@ -24013,7 +26213,8 @@
   "ski": [
     "西卡語",
     "Sika",
-    "Sikanese"
+    "Sikanese",
+    "西卡语"
   ],
   "skj": [
     "Seke"
@@ -24026,7 +26227,8 @@
     "Kutong"
   ],
   "skn": [
-    "哥里布安-蘇巴農語"
+    "哥里布安-蘇巴農語",
+    "哥里布安-苏巴农语"
   ],
   "sko": [
     "Seko Tengah"
@@ -24041,9 +26243,11 @@
     "沙拉基語",
     "Saraiki",
     "Siraiki",
-    "Seraiki"
+    "Seraiki",
+    "沙拉基语"
   ],
   "sks": [
+    "馬伊亞語",
     "Maia",
     "Maya",
     "Banar",
@@ -24051,7 +26255,8 @@
     "Saki",
     "Suaro",
     "Turutap",
-    "Yakiba"
+    "Yakiba",
+    "马伊亚语"
   ],
   "skt": [
     "Sakata",
@@ -24079,10 +26284,12 @@
     "Skou"
   ],
   "skw": [
+    "斯克皮克里奧爾荷蘭語",
     "Skepi Creole Dutch",
     "Skepi Dutch",
     "Skepi Dutch Creole",
-    "Essequibo Dutch"
+    "Essequibo Dutch",
+    "斯克皮克里奥尔荷兰语"
   ],
   "skx": [
     "Seko Padang"
@@ -24093,15 +26300,18 @@
   ],
   "skz": [
     "塞卡爾語",
-    "Sekar"
+    "Sekar",
+    "塞卡尔语"
   ],
   "sl": [
-    "斯洛文尼亞語"
+    "斯洛文尼亞語",
+    "斯洛文尼亚语"
   ],
   "sla-pro": [
     "原始斯拉夫語",
     "Proto-Slavic",
-    "Common Slavic"
+    "Common Slavic",
+    "原始斯拉夫语"
   ],
   "slc": [
     "Saliba (Colombia)",
@@ -24119,14 +26329,16 @@
   "slf": [
     "瑞士意大利語手語",
     "Swiss-Italian Sign Language",
-    "Swiss Italian Sign Language"
+    "Swiss Italian Sign Language",
+    "瑞士意大利语手语"
   ],
   "slg": [
     "Selungai Murut"
   ],
   "slh": [
     "南普吉特海灣薩利希語",
-    "Southern Puget Sound Salish"
+    "Southern Puget Sound Salish",
+    "南普吉特海湾萨利希语"
   ],
   "slj": [
     "Salumá"
@@ -24136,7 +26348,8 @@
   ],
   "slm": [
     "潘古塔蘭巴瑤語",
-    "Pangutaran Sama"
+    "Pangutaran Sama",
+    "潘古塔兰巴瑶语"
   ],
   "sln": [
     "Salinan"
@@ -24151,11 +26364,13 @@
   ],
   "slr": [
     "撒拉語",
-    "Salar"
+    "Salar",
+    "撒拉语"
   ],
   "sls": [
     "新加坡手語",
-    "Singapore Sign Language"
+    "Singapore Sign Language",
+    "新加坡手语"
   ],
   "slt": [
     "Sila"
@@ -24170,18 +26385,21 @@
     "Salampasu"
   ],
   "sly": [
-    "塞拉亞語"
+    "塞拉亞語",
+    "塞拉亚语"
   ],
   "slz": [
     "Ma'ya"
   ],
   "sm": [
-    "薩摩亞語"
+    "薩摩亞語",
+    "萨摩亚语"
   ],
   "sma": [
     "南薩米語",
     "Southern Sami",
-    "Lule Sami"
+    "Lule Sami",
+    "南萨米语"
   ],
   "smb": [
     "Simbari"
@@ -24204,32 +26422,38 @@
   "smi-pro": [
     "原始薩米語",
     "Proto-Samic",
-    "Proto-Sami"
+    "Proto-Sami",
+    "原始萨米语"
   ],
   "smj": [
     "呂勒薩米語",
-    "Lule Sami"
+    "Lule Sami",
+    "吕勒萨米语"
   ],
   "smk": [
     "博利瑙語",
     "Bolinao",
-    "Binubolinao"
+    "Binubolinao",
+    "博利瑙语"
   ],
   "sml": [
     "Central Sama"
   ],
   "smm": [
     "穆薩薩語",
-    "Musasa"
+    "Musasa",
+    "穆萨萨语"
   ],
   "smn": [
     "伊納里薩米語",
-    "Inari Sami"
+    "Inari Sami",
+    "伊纳里萨米语"
   ],
   "smp": [
     "撒馬利亞希伯來語",
     "Samaritan Hebrew",
-    "Samaritan"
+    "Samaritan",
+    "撒马利亚希伯来语"
   ],
   "smq": [
     "Samo"
@@ -24242,11 +26466,13 @@
     "Defayan",
     "Simolol",
     "Simulul",
-    "Simeuloë"
+    "Simeuloë",
+    "锡默卢语"
   ],
   "sms": [
     "斯科爾特薩米語",
-    "Skolt Sami"
+    "Skolt Sami",
+    "斯科尔特萨米语"
   ],
   "smt": [
     "Simte"
@@ -24256,39 +26482,46 @@
   ],
   "smv": [
     "桑維蒂語",
-    "Samvedi"
+    "Samvedi",
+    "桑维蒂语"
   ],
   "smw": [
     "松巴哇語",
-    "Sumbawa"
+    "Sumbawa",
+    "松巴哇语"
   ],
   "smx": [
     "Samba"
   ],
   "smy": [
     "森南尼語",
-    "Semnani"
+    "Semnani",
+    "森南尼语"
   ],
   "smz": [
     "Simeku"
   ],
   "sn": [
-    "修納語"
+    "修納語",
+    "修纳语"
   ],
   "snb": [
     "Sebuyau"
   ],
   "snc": [
     "西瑙高羅語",
-    "Sinaugoro"
+    "Sinaugoro",
+    "西瑙高罗语"
   ],
   "sne": [
     "查格依語",
-    "Bau Bidayuh"
+    "Bau Bidayuh",
+    "查格依语"
   ],
   "snf": [
     "諾恩語",
-    "Noon"
+    "Noon",
+    "诺恩语"
   ],
   "sng": [
     "Sanga (Congo)",
@@ -24304,7 +26537,8 @@
     "Riverain Sango"
   ],
   "snk": [
-    "索尼基語"
+    "索尼基語",
+    "索尼基语"
   ],
   "snl": [
     "Sangil"
@@ -24353,13 +26587,15 @@
     "Asas"
   ],
   "so": [
-    "索馬里語"
+    "索馬里語",
+    "索马里语"
   ],
   "soa": [
     "宋傣語",
     "Thai Song",
     "Lao Song",
-    "Song"
+    "Song",
+    "宋傣语"
   ],
   "sob": [
     "Sobei"
@@ -24376,7 +26612,8 @@
   ],
   "sog": [
     "粟特語",
-    "Sogdian"
+    "Sogdian",
+    "粟特语"
   ],
   "soh": [
     "Aka (Sudan)",
@@ -24392,16 +26629,19 @@
   ],
   "sok": [
     "索科羅語",
-    "Sokoro"
+    "Sokoro",
+    "索科罗语"
   ],
   "sol": [
     "索洛斯語",
-    "Solos"
+    "Solos",
+    "索洛斯语"
   ],
   "son-pro": [
     "原始桑海語",
     "Proto-Songhay",
-    "Proto-Songhai"
+    "Proto-Songhai",
+    "原始桑海语"
   ],
   "soo": [
     "Nsong",
@@ -24424,7 +26664,8 @@
     "Sambla"
   ],
   "sou": [
-    "南部泰語"
+    "南部泰語",
+    "南部泰语"
   ],
   "sov": [
     "Sonsorolese"
@@ -24470,7 +26711,8 @@
   ],
   "spi": [
     "薩波尼語",
-    "Saponi"
+    "Saponi",
+    "萨波尼语"
   ],
   "spk": [
     "Sengo"
@@ -24505,7 +26747,8 @@
   ],
   "sps": [
     "薩波薩語",
-    "Saposa"
+    "Saposa",
+    "萨波萨语"
   ],
   "spt": [
     "Spiti Bhoti"
@@ -24517,7 +26760,8 @@
     "桑巴爾普里語",
     "Sambalpuri",
     "Kosali",
-    "Koshali"
+    "Koshali",
+    "桑巴尔普里语"
   ],
   "spx": [
     "南皮賽恩語",
@@ -24525,13 +26769,15 @@
     "Old Sabellic",
     "Old Sabellian",
     "Middle Adriatic",
-    "Central Adriatic"
+    "Central Adriatic",
+    "南皮赛恩语"
   ],
   "spy": [
     "Sabaot"
   ],
   "sq": [
-    "阿爾巴尼亞語"
+    "阿爾巴尼亞語",
+    "阿尔巴尼亚语"
   ],
   "sqa": [
     "Shama-Sambuga"
@@ -24541,7 +26787,8 @@
   ],
   "sqj-pro": [
     "原始阿爾巴尼亞語",
-    "Proto-Albanian"
+    "Proto-Albanian",
+    "原始阿尔巴尼亚语"
   ],
   "sqk": [
     "Albanian Sign Language"
@@ -24554,27 +26801,32 @@
   ],
   "sqo": [
     "索爾赫伊語",
-    "Sorkhei"
+    "Sorkhei",
+    "索尔赫伊语"
   ],
   "sqq": [
     "Sou"
   ],
   "sqr": [
     "西庫爾阿拉伯語",
-    "Siculo-Arabic"
+    "Siculo-Arabic",
+    "西库尔阿拉伯语"
   ],
   "sqs": [
     "斯里蘭卡手語",
-    "Sri Lankan Sign Language"
+    "Sri Lankan Sign Language",
+    "斯里兰卡手语"
   ],
   "sqt": [
     "索科特拉語",
     "Soqotri",
-    "Socotri"
+    "Socotri",
+    "索科特拉语"
   ],
   "squ": [
     "斯闊米什語",
-    "Squamish"
+    "Squamish",
+    "斯阔米什语"
   ],
   "sra": [
     "Saruga"
@@ -24593,7 +26845,8 @@
   ],
   "srh": [
     "薩里庫爾語",
-    "Sarikoli"
+    "Sarikoli",
+    "萨里库尔语"
   ],
   "sri": [
     "Siriano"
@@ -24606,18 +26859,22 @@
   ],
   "srm": [
     "薩拉馬卡語",
-    "Saramaccan"
+    "Saramaccan",
+    "萨拉马卡语"
   ],
   "srn": [
     "蘇里南湯加語",
     "蘇里南語",
-    "Sranan Tongo"
+    "Sranan Tongo",
+    "苏里南汤加语",
+    "苏里南语"
   ],
   "srq": [
     "Sirionó"
   ],
   "srr": [
-    "塞雷爾語"
+    "塞雷爾語",
+    "塞雷尔语"
   ],
   "srs": [
     "Sarcee",
@@ -24650,10 +26907,12 @@
   ],
   "srz": [
     "沙赫米爾扎迪語",
-    "Shahmirzadi"
+    "Shahmirzadi",
+    "沙赫米尔扎迪语"
   ],
   "ss": [
-    "史瓦濟語"
+    "史瓦濟語",
+    "史瓦济语"
   ],
   "ssa-klk-pro": [
     "Proto-Kuliak"
@@ -24663,7 +26922,8 @@
   ],
   "ssa-pro": [
     "原始尼羅-撒哈拉語",
-    "Proto-Nilo-Saharan"
+    "Proto-Nilo-Saharan",
+    "原始尼罗-撒哈拉语"
   ],
   "ssb": [
     "Southern Sama"
@@ -24679,7 +26939,8 @@
   ],
   "ssf": [
     "邵語",
-    "Sao"
+    "Sao",
+    "邵语"
   ],
   "ssg": [
     "Seimat"
@@ -24690,7 +26951,8 @@
   "ssi": [
     "桑斯語",
     "Sansi",
-    "Bhilki"
+    "Bhilki",
+    "桑斯语"
   ],
   "ssj": [
     "Sausi"
@@ -24712,7 +26974,8 @@
   ],
   "ssp": [
     "西班牙手語",
-    "Spanish Sign Language"
+    "Spanish Sign Language",
+    "西班牙手语"
   ],
   "ssq": [
     "So'a"
@@ -24720,7 +26983,8 @@
   "ssr": [
     "瑞士法國手語",
     "Swiss-French Sign Language",
-    "Swiss French Sign Language"
+    "Swiss French Sign Language",
+    "瑞士法国手语"
   ],
   "sss": [
     "Sô"
@@ -24738,16 +27002,19 @@
     "Samberigi"
   ],
   "ssy": [
-    "薩霍語"
+    "薩霍語",
+    "萨霍语"
   ],
   "ssz": [
     "Sengseng"
   ],
   "st": [
-    "塞索托語"
+    "塞索托語",
+    "塞索托语"
   ],
   "stb": [
-    "北蘇巴農語"
+    "北蘇巴農語",
+    "北苏巴农语"
   ],
   "std": [
     "Sentinelese"
@@ -24764,7 +27031,8 @@
   "sth": [
     "雪爾塔語",
     "Shelta",
-    "Cant"
+    "Cant",
+    "雪尔塔语"
   ],
   "sti": [
     "Bulo Stieng"
@@ -24786,7 +27054,8 @@
   ],
   "stp": [
     "東南特佩瓦語",
-    "Southeastern Tepehuan"
+    "Southeastern Tepehuan",
+    "东南特佩瓦语"
   ],
   "stq": [
     "薩特弗里斯蘭語",
@@ -24795,15 +27064,21 @@
     "東弗里西語",
     "Saterland Frisian",
     "East Frisian",
-    "Eastern Frisian"
+    "Eastern Frisian",
+    "萨特弗里斯兰语",
+    "沙特弗里西语",
+    "东弗里斯兰语",
+    "东弗里西语"
   ],
   "str": [
     "薩尼奇語",
-    "Saanich"
+    "Saanich",
+    "萨尼奇语"
   ],
   "sts": [
     "舒馬斯梯語",
-    "Shumashti"
+    "Shumashti",
+    "舒马斯梯语"
   ],
   "stt": [
     "Budeh Stieng"
@@ -24819,10 +27094,12 @@
   ],
   "sty": [
     "西伯利亞韃靼語",
-    "Siberian Tatar"
+    "Siberian Tatar",
+    "西伯利亚鞑靼语"
   ],
   "su": [
-    "巽他語"
+    "巽他語",
+    "巽他语"
   ],
   "sua": [
     "Sulka"
@@ -24831,26 +27108,31 @@
     "Suku"
   ],
   "suc": [
-    "西蘇巴農語"
+    "西蘇巴農語",
+    "西苏巴农语"
   ],
   "sue": [
     "蘇埃納語",
-    "Suena"
+    "Suena",
+    "苏埃纳语"
   ],
   "sug": [
     "Suganga"
   ],
   "sui": [
     "蘇基語",
-    "Suki"
+    "Suki",
+    "苏基语"
   ],
   "suk": [
     "蘇庫馬語",
-    "Sukuma"
+    "Sukuma",
+    "苏库马语"
   ],
   "suq": [
     "蘇里語",
-    "Suri"
+    "Suri",
+    "苏里语"
   ],
   "sur": [
     "Mwaghavul",
@@ -24858,7 +27140,8 @@
     "Mupun"
   ],
   "sus": [
-    "蘇蘇語"
+    "蘇蘇語",
+    "苏苏语"
   ],
   "sut": [
     "Subtiaba"
@@ -24872,7 +27155,9 @@
   "sux": [
     "蘇美爾語",
     "蘇美語",
-    "Sumerian"
+    "Sumerian",
+    "苏美尔语",
+    "苏美语"
   ],
   "suy": [
     "Suyá"
@@ -24881,11 +27166,13 @@
     "Sunwar"
   ],
   "sv": [
-    "瑞典語"
+    "瑞典語",
+    "瑞典语"
   ],
   "sva": [
     "斯凡語",
-    "Svan"
+    "Svan",
+    "斯凡语"
   ],
   "svb": [
     "Ulau-Suain"
@@ -24897,29 +27184,35 @@
     "Serili"
   ],
   "svk": [
-    "斯洛伐克手語"
+    "斯洛伐克手語",
+    "斯洛伐克手语"
   ],
   "svm": [
-    "斯拉夫莫利塞語"
+    "斯拉夫莫利塞語",
+    "斯拉夫莫利塞语"
   ],
   "svs": [
     "Savosavo"
   ],
   "svx": [
-    "斯卡洛維亞語"
+    "斯卡洛維亞語",
+    "斯卡洛维亚语"
   ],
   "sw": [
-    "斯瓦希里語"
+    "斯瓦希里語",
+    "斯瓦希里语"
   ],
   "swb": [
-    "馬約特科摩羅語"
+    "馬約特科摩羅語",
+    "马约特科摩罗语"
   ],
   "swf": [
     "Sere"
   ],
   "swg": [
     "施瓦本語",
-    "Swabian"
+    "Swabian",
+    "施瓦本语"
   ],
   "swi": [
     "水語",
@@ -24927,7 +27220,8 @@
     "Ai Sui",
     "Shui",
     "Sui Li",
-    "Suipo"
+    "Suipo",
+    "水语"
   ],
   "swj": [
     "Sira"
@@ -24967,7 +27261,8 @@
   ],
   "sww": [
     "索瓦語",
-    "Sowa"
+    "Sowa",
+    "索瓦语"
   ],
   "swx": [
     "Suruahá",
@@ -24993,23 +27288,27 @@
     "史興語",
     "Shixing",
     "Shuhi",
-    "Xumi"
+    "Xumi",
+    "史兴语"
   ],
   "sxk": [
     "南卡拉普亞語",
-    "Southern Kalapuya"
+    "Southern Kalapuya",
+    "南卡拉普亚语"
   ],
   "sxl": [
     "瑟羅尼亞語",
     "Selonian",
-    "Selian"
+    "Selian",
+    "瑟罗尼亚语"
   ],
   "sxm": [
     "Samre"
   ],
   "sxn": [
     "桑格語",
-    "Sangir"
+    "Sangir",
+    "桑格语"
   ],
   "sxo": [
     "Sorothaptic"
@@ -25018,7 +27317,9 @@
     "拉阿魯哇語",
     "Saaroa",
     "Hla'alua",
-    "沙阿魯哇語"
+    "沙阿魯哇語",
+    "拉阿鲁哇语",
+    "沙阿鲁哇语"
   ],
   "sxs": [
     "Sasaru"
@@ -25030,30 +27331,36 @@
     "Siang"
   ],
   "syb": [
-    "中蘇巴農語"
+    "中蘇巴農語",
+    "中苏巴农语"
   ],
   "syc": [
     "古典敘利亞語",
-    "Classical Syriac"
+    "Classical Syriac",
+    "古典叙利亚语"
   ],
   "syd-fne": [
     "森林涅涅茨語",
-    "Forest Nenets"
+    "Forest Nenets",
+    "森林涅涅茨语"
   ],
   "syd-pro": [
     "原始薩莫耶德語",
-    "Proto-Samoyedic"
+    "Proto-Samoyedic",
+    "原始萨莫耶德语"
   ],
   "syi": [
     "Seki"
   ],
   "syk": [
     "蘇庫爾語",
-    "Sukur"
+    "Sukur",
+    "苏库尔语"
   ],
   "syl": [
     "錫爾赫特語",
-    "Sylheti"
+    "Sylheti",
+    "锡尔赫特语"
   ],
   "sym": [
     "Maya Samo"
@@ -25103,7 +27410,8 @@
     "Silesian",
     "Upper Silesian",
     "Silesian Polish",
-    "Upper Silesian Polish"
+    "Upper Silesian Polish",
+    "西里西亚语"
   ],
   "szn": [
     "Sula"
@@ -25130,10 +27438,12 @@
   ],
   "szy": [
     "撒奇萊雅語",
-    "Sakizaya"
+    "Sakizaya",
+    "撒奇莱雅语"
   ],
   "ta": [
-    "泰米爾語"
+    "泰米爾語",
+    "泰米尔语"
   ],
   "taa": [
     "Lower Tanana",
@@ -25143,11 +27453,13 @@
   "tab": [
     "塔巴薩蘭語",
     "Tabasaran",
-    "Tabassaran"
+    "Tabassaran",
+    "塔巴萨兰语"
   ],
   "tac": [
     "低地塔拉烏馬拉語",
-    "Lowland Tarahumara"
+    "Lowland Tarahumara",
+    "低地塔拉乌马拉语"
   ],
   "tad": [
     "Tause"
@@ -25163,11 +27475,13 @@
   ],
   "tai-pro": [
     "原始台語",
-    "Proto-Tai"
+    "Proto-Tai",
+    "原始台语"
   ],
   "tai-swe-pro": [
     "原始西南台語",
-    "Proto-Southwestern Tai"
+    "Proto-Southwestern Tai",
+    "原始西南台语"
   ],
   "taj": [
     "Eastern Tamang"
@@ -25185,17 +27499,22 @@
     "達悟語",
     "Yami",
     "雅美語",
-    "Tao"
+    "Tao",
+    "达悟语",
+    "雅美语"
   ],
   "tap": [
     "Taabwa"
   ],
   "taq": [
-    "Tamasheq"
+    "塔馬舍克語",
+    "Tamasheq",
+    "塔马舍克语"
   ],
   "tar": [
     "中塔拉烏馬拉語",
-    "Central Tarahumara"
+    "Central Tarahumara",
+    "中塔拉乌马拉语"
   ],
   "tas": [
     "Tay Boi",
@@ -25220,7 +27539,9 @@
     "泰雅語",
     "Atayal",
     "泰雅爾語",
-    "Tayal"
+    "Tayal",
+    "泰雅语",
+    "泰雅尔语"
   ],
   "taz": [
     "Tocho"
@@ -25258,11 +27579,13 @@
     "Tiang"
   ],
   "tbk": [
-    "卡拉米-塔格巴努瓦語"
+    "卡拉米-塔格巴努瓦語",
+    "卡拉米-塔格巴努瓦语"
   ],
   "tbl": [
     "特波里語",
-    "Tboli"
+    "Tboli",
+    "特波里语"
   ],
   "tbm": [
     "Tagbu"
@@ -25280,16 +27603,19 @@
   ],
   "tbq-bdg-pro": [
     "原始博多-加羅語",
-    "Proto-Bodo-Garo"
+    "Proto-Bodo-Garo",
+    "原始博多-加罗语"
   ],
   "tbq-kuk-pro": [
     "原始庫基-欽語",
     "Proto-Kuki-Chin",
-    "Proto-Kukish"
+    "Proto-Kukish",
+    "原始库基-钦语"
   ],
   "tbq-lal-pro": [
     "原始臘羅語",
-    "Proto-Lalo"
+    "Proto-Lalo",
+    "原始腊罗语"
   ],
   "tbq-laz": [
     "Laze",
@@ -25298,19 +27624,22 @@
   ],
   "tbq-lob-pro": [
     "原始緬彝語",
-    "Proto-Lolo-Burmese"
+    "Proto-Lolo-Burmese",
+    "原始缅彝语"
   ],
   "tbq-lol-pro": [
     "原始彝語",
     "Proto-Loloish",
-    "Proto-Nisoic"
+    "Proto-Nisoic",
+    "原始彝语"
   ],
   "tbq-plg": [
     "白狼語",
     "Pai-lang",
     "Bai-lang",
     "Pailang",
-    "Bailang"
+    "Bailang",
+    "白狼语"
   ],
   "tbr": [
     "Tumtum"
@@ -25330,7 +27659,8 @@
     "Tobo"
   ],
   "tbw": [
-    "塔格巴努瓦語"
+    "塔格巴努瓦語",
+    "塔格巴努瓦语"
   ],
   "tbx": [
     "Kapin",
@@ -25356,18 +27686,21 @@
     "Tafi"
   ],
   "tce": [
-    "南塔穹語"
+    "南塔穹語",
+    "南塔穹语"
   ],
   "tcf": [
     "馬利納爾特佩克特拉帕克語",
-    "Malinaltepec Tlapanec"
+    "Malinaltepec Tlapanec",
+    "马利纳尔特佩克特拉帕克语"
   ],
   "tcg": [
     "Tamagario"
   ],
   "tch": [
     "特克斯和凱科斯群島克里奧爾英語",
-    "Turks and Caicos Creole English"
+    "Turks and Caicos Creole English",
+    "特克斯和凯科斯群岛克里奥尔英语"
   ],
   "tci": [
     "Wára"
@@ -25407,26 +27740,31 @@
     "Torres Strait Brokan",
     "Torres Strait Broken",
     "Torres Strait Pidgin",
-    "Yumplatok"
+    "Yumplatok",
+    "托雷斯海峡克里奥尔语"
   ],
   "tct": [
     "佯僙語",
-    "T'en"
+    "T'en",
+    "佯僙语"
   ],
   "tcu": [
     "東南塔拉烏馬拉語",
-    "Southeastern Tarahumara"
+    "Southeastern Tarahumara",
+    "东南塔拉乌马拉语"
   ],
   "tcw": [
     "特克帕特蘭托托納克語",
-    "Tecpatlán Totonac"
+    "Tecpatlán Totonac",
+    "特克帕特兰托托纳克语"
   ],
   "tcx": [
     "Toda"
   ],
   "tcy": [
     "圖陸語",
-    "Tulu"
+    "Tulu",
+    "图陆语"
   ],
   "tcz": [
     "Thado Chin",
@@ -25451,7 +27789,10 @@
     "Tai Dehong",
     "Tai Le",
     "Chinese Shan",
-    "Chinese Tai"
+    "Chinese Tai",
+    "傣纳语",
+    "傣那语",
+    "德宏傣语"
   ],
   "tde": [
     "Tiranige Diga Dogon"
@@ -25473,7 +27814,8 @@
   ],
   "tdj": [
     "塔基歐語",
-    "Tajio"
+    "Tajio",
+    "塔基欧语"
   ],
   "tdk": [
     "Tambas"
@@ -25520,7 +27862,8 @@
     "Tadyawan"
   ],
   "te": [
-    "泰盧固語"
+    "泰盧固語",
+    "泰卢固语"
   ],
   "tea": [
     "Temiar"
@@ -25536,7 +27879,8 @@
   ],
   "tee": [
     "韋韋特拉特佩瓦語",
-    "Huehuetla Tepehua"
+    "Huehuetla Tepehua",
+    "韦韦特拉特佩瓦语"
   ],
   "tef": [
     "Teressa"
@@ -25565,24 +27909,28 @@
     "提姆語",
     "Timne",
     "Themne",
-    "KaThemne"
+    "KaThemne",
+    "提姆语"
   ],
   "ten": [
     "Tama (Colombia)",
     "Tama"
   ],
   "teo": [
-    "特索語"
+    "特索語",
+    "特索语"
   ],
   "tep": [
     "特佩卡諾語",
-    "Tepecano"
+    "Tepecano",
+    "特佩卡诺语"
   ],
   "teq": [
     "Temein"
   ],
   "ter": [
-    "泰雷諾語"
+    "泰雷諾語",
+    "泰雷诺语"
   ],
   "tes": [
     "Tengger"
@@ -25590,7 +27938,8 @@
   "tet": [
     "德頓語",
     "Tetum",
-    "Tetun"
+    "Tetun",
+    "德顿语"
   ],
   "teu": [
     "Soo"
@@ -25607,7 +27956,8 @@
     "Tesuque Tewa",
     "Nambe Tewa",
     "Ohkay Owingeh",
-    "Pojoaque"
+    "Pojoaque",
+    "特瓦语"
   ],
   "tex": [
     "Tennet"
@@ -25631,14 +27981,17 @@
   ],
   "tfr": [
     "特里貝語",
-    "Teribe"
+    "Teribe",
+    "特里贝语"
   ],
   "tft": [
     "特爾納特語",
-    "Ternate"
+    "Ternate",
+    "特尔纳特语"
   ],
   "tg": [
-    "塔吉克語"
+    "塔吉克語",
+    "塔吉克语"
   ],
   "tga": [
     "Sagalla"
@@ -25665,19 +28018,23 @@
   "tgh": [
     "多巴哥克里奧爾英語",
     "托貝哥克里奧爾英語",
-    "Tobagonian Creole English"
+    "Tobagonian Creole English",
+    "多巴哥克里奥尔英语",
+    "托贝哥克里奥尔英语"
   ],
   "tgi": [
     "Lawunuia"
   ],
   "tgn": [
     "坦達加農語",
-    "Tandaganon"
+    "Tandaganon",
+    "坦达加农语"
   ],
   "tgo": [
     "塔古拉語",
     "Sudest",
-    "Tagula"
+    "Tagula",
+    "塔古拉语"
   ],
   "tgp": [
     "Tangoa"
@@ -25692,7 +28049,8 @@
     "Nume"
   ],
   "tgt": [
-    "中塔格巴努瓦語"
+    "中塔格巴努瓦語",
+    "中塔格巴努瓦语"
   ],
   "tgu": [
     "Tanggu"
@@ -25705,19 +28063,22 @@
   ],
   "tgx": [
     "塔吉什語",
-    "Tagish"
+    "Tagish",
+    "塔吉什语"
   ],
   "tgy": [
     "Togoyo"
   ],
   "th": [
-    "泰語"
+    "泰語",
+    "泰语"
   ],
   "thc": [
     "傣包語",
     "Tai Hang Tong",
     "Tai Pao",
-    "Tai Muong"
+    "Tai Muong",
+    "傣包语"
   ],
   "thd": [
     "Kuuk Thaayorre",
@@ -25732,7 +28093,8 @@
   ],
   "thh": [
     "北塔拉烏馬拉語",
-    "Northern Tarahumara"
+    "Northern Tarahumara",
+    "北塔拉乌马拉语"
   ],
   "thi": [
     "Tai Long"
@@ -25746,7 +28108,8 @@
   "thm": [
     "他文語",
     "Aheu",
-    "So (Thavung)"
+    "So (Thavung)",
+    "他文语"
   ],
   "thn": [
     "Thachanadan"
@@ -25783,7 +28146,8 @@
     "Air Tamajeq"
   ],
   "ti": [
-    "提格里尼亞語"
+    "提格里尼亞語",
+    "提格里尼亚语"
   ],
   "tia": [
     "Tidikelt Tamazight",
@@ -25797,11 +28161,13 @@
   ],
   "tig": [
     "提格雷語",
-    "Tigre"
+    "Tigre",
+    "提格雷语"
   ],
   "tih": [
     "蒂穆貢穆魯特語",
-    "Timugon Murut"
+    "Timugon Murut",
+    "蒂穆贡穆鲁特语"
   ],
   "tii": [
     "Tiene"
@@ -25820,7 +28186,8 @@
   ],
   "tin": [
     "廷迪語",
-    "Tindi"
+    "Tindi",
+    "廷迪语"
   ],
   "tio": [
     "Teop"
@@ -25842,7 +28209,8 @@
   ],
   "tiv": [
     "泰雷諾語",
-    "Tivi"
+    "Tivi",
+    "泰雷诺语"
   ],
   "tiw": [
     "Tiwi"
@@ -25858,11 +28226,13 @@
   ],
   "tiy": [
     "蒂魯賴語",
-    "Tiruray"
+    "Tiruray",
+    "蒂鲁赖语"
   ],
   "tiz": [
     "紅金傣語",
-    "Tai Hongjin"
+    "Tai Hongjin",
+    "红金傣语"
   ],
   "tja": [
     "Tajuasohn"
@@ -25871,7 +28241,8 @@
     "Tunjung"
   ],
   "tji": [
-    "北部土家語"
+    "北部土家語",
+    "北部土家语"
   ],
   "tjm": [
     "Timucua"
@@ -25884,7 +28255,8 @@
   ],
   "tjs": [
     "南部土家語",
-    "Southern Tujia"
+    "Southern Tujia",
+    "南部土家语"
   ],
   "tju": [
     "Tjurruru"
@@ -25896,7 +28268,8 @@
     "Tjapwurrung"
   ],
   "tk": [
-    "土庫曼語"
+    "土庫曼語",
+    "土库曼语"
   ],
   "tka": [
     "Truká"
@@ -25915,14 +28288,16 @@
   ],
   "tkl": [
     "托克勞語",
-    "Tokelauan"
+    "Tokelauan",
+    "托克劳语"
   ],
   "tkm": [
     "Takelma"
   ],
   "tkn": [
     "德之島語",
-    "Toku-No-Shima"
+    "Toku-No-Shima",
+    "德之岛语"
   ],
   "tkp": [
     "Tikopia"
@@ -25933,7 +28308,8 @@
   "tkr": [
     "查庫爾語",
     "Caxur",
-    "Tsaxur"
+    "Tsaxur",
+    "查库尔语"
   ],
   "tks": [
     "Ramandi",
@@ -25944,7 +28320,8 @@
   ],
   "tku": [
     "上內卡克薩托托納克語",
-    "Upper Necaxa Totonac"
+    "Upper Necaxa Totonac",
+    "上内卡克萨托托纳克语"
   ],
   "tkv": [
     "Mur Pano",
@@ -25960,11 +28337,13 @@
     "Takua"
   ],
   "tl": [
-    "他加祿語"
+    "他加祿語",
+    "他加禄语"
   ],
   "tla": [
     "西南特佩瓦語",
-    "Southwestern Tepehuan"
+    "Southwestern Tepehuan",
+    "西南特佩瓦语"
   ],
   "tlb": [
     "Tobelo"
@@ -25972,7 +28351,8 @@
   "tlc": [
     "耶庫阿特拉托托納克語",
     "Misantla Totonac",
-    "Yecuatla Totonac"
+    "Yecuatla Totonac",
+    "耶库阿特拉托托纳克语"
   ],
   "tld": [
     "Talaud"
@@ -25985,11 +28365,13 @@
   ],
   "tlh": [
     "克林貢語",
-    "Klingon"
+    "Klingon",
+    "克林贡语"
   ],
   "tli": [
     "特林吉特語",
-    "Tlingit"
+    "Tlingit",
+    "特林吉特语"
   ],
   "tlj": [
     "Talinga-Bwisi"
@@ -26011,7 +28393,8 @@
   ],
   "tlp": [
     "菲洛梅納-馬塔-科阿維特蘭托托納克語",
-    "Filomena Mata-Coahuitlán Totonac"
+    "Filomena Mata-Coahuitlán Totonac",
+    "菲洛梅纳-马塔-科阿维特兰托托纳克语"
   ],
   "tlq": [
     "Tai Loi"
@@ -26032,7 +28415,8 @@
   "tlv": [
     "塔利亞布語",
     "Taliabu",
-    "Soboyo"
+    "Soboyo",
+    "塔利亚布语"
   ],
   "tlx": [
     "Khehek"
@@ -26045,7 +28429,8 @@
     "Taleshi",
     "Tolashi",
     "Asalemi",
-    "Anbarani"
+    "Anbarani",
+    "塔利什语"
   ],
   "tma": [
     "Tama (Chad)",
@@ -26075,7 +28460,8 @@
     "Tamashek",
     "Tamahaq",
     "Tamajaq",
-    "Tamasheq"
+    "Tamasheq",
+    "图阿雷格语"
   ],
   "tmi": [
     "Tutuba"
@@ -26091,7 +28477,8 @@
   ],
   "tmm": [
     "傣奈語",
-    "Tai Thanh"
+    "Tai Thanh",
+    "傣奈语"
   ],
   "tmn": [
     "Taman (Indonesia)",
@@ -26127,7 +28514,8 @@
     "Tamanaku"
   ],
   "tn": [
-    "茨瓦納語"
+    "茨瓦納語",
+    "茨瓦纳语"
   ],
   "tna": [
     "Tacana"
@@ -26173,7 +28561,8 @@
   ],
   "tnq": [
     "泰諾語",
-    "Taino"
+    "Taino",
+    "泰诺语"
   ],
   "tnr": [
     "Bedik"
@@ -26183,16 +28572,19 @@
   ],
   "tnt": [
     "通騰博安語",
-    "Tontemboan"
+    "Tontemboan",
+    "通腾博安语"
   ],
   "tnu": [
     "岱康語",
-    "Tay Khang"
+    "Tay Khang",
+    "岱康语"
   ],
   "tnv": [
     "坦昌雅語",
     "Tangchangya",
-    "Tanhangya"
+    "Tanhangya",
+    "坦昌雅语"
   ],
   "tnw": [
     "Tonsawang"
@@ -26208,7 +28600,8 @@
     "Tonga"
   ],
   "to": [
-    "湯加語"
+    "湯加語",
+    "汤加语"
   ],
   "tob": [
     "Toba",
@@ -26219,7 +28612,8 @@
   ],
   "toc": [
     "科尤特拉托托納克語",
-    "Coyutla Totonac"
+    "Coyutla Totonac",
+    "科尤特拉托托纳克语"
   ],
   "tod": [
     "Toma"
@@ -26235,13 +28629,15 @@
     "Siska",
     "Sisya",
     "Tonga",
-    "Western Nyasa"
+    "Western Nyasa",
+    "通加语（马拉维）"
   ],
   "toh": [
     "通加語（莫桑比克）",
     "Tonga (Mozambique)",
     "Gitonga",
-    "Tonga"
+    "Tonga",
+    "通加语（莫桑比克）"
   ],
   "toi": [
     "Tonga (Zambia)",
@@ -26252,11 +28648,13 @@
   ],
   "toj": [
     "托霍拉瓦爾語",
-    "Tojolabal"
+    "Tojolabal",
+    "托霍拉瓦尔语"
   ],
   "tok": [
     "道本語",
-    "Toki Pona"
+    "Toki Pona",
+    "道本语"
   ],
   "tol": [
     "Tolowa",
@@ -26268,11 +28666,13 @@
   ],
   "too": [
     "西科特佩克-德華雷斯托托納克語",
-    "Xicotepec de Juárez Totonac"
+    "Xicotepec de Juárez Totonac",
+    "西科特佩克-德华雷斯托托纳克语"
   ],
   "top": [
     "帕潘特拉托托納克語",
-    "Papantla Totonac"
+    "Papantla Totonac",
+    "帕潘特拉托托纳克语"
   ],
   "toq": [
     "Toposa"
@@ -26282,7 +28682,8 @@
   ],
   "tos": [
     "高地托托納克語",
-    "Highland Totonac"
+    "Highland Totonac",
+    "高地托托纳克语"
   ],
   "tou": [
     "Tho"
@@ -26323,7 +28724,8 @@
     "Tok Pisin",
     "Melanesian Pidgin English",
     "Neo-Melanesian",
-    "New Guinea Pidgin"
+    "New Guinea Pidgin",
+    "托克皮辛语"
   ],
   "tpj": [
     "Tapieté"
@@ -26341,15 +28743,18 @@
   ],
   "tpn": [
     "圖皮南巴語",
-    "Tupinambá"
+    "Tupinambá",
+    "图皮南巴语"
   ],
   "tpo": [
     "行彤傣語",
-    "Tai Pao"
+    "Tai Pao",
+    "行彤傣语"
   ],
   "tpp": [
     "比薩佛洛勒斯特佩瓦語",
-    "Pisaflores Tepehua"
+    "Pisaflores Tepehua",
+    "比萨佛洛勒斯特佩瓦语"
   ],
   "tpq": [
     "Tukpa"
@@ -26359,7 +28764,8 @@
   ],
   "tpt": [
     "特拉奇奇爾科特佩瓦語",
-    "Tlachichilco Tepehua"
+    "Tlachichilco Tepehua",
+    "特拉奇奇尔科特佩瓦语"
   ],
   "tpu": [
     "Tampuan"
@@ -26371,11 +28777,14 @@
     "古圖皮語",
     "古典圖皮語",
     "Old Tupi",
-    "Classical Tupi"
+    "Classical Tupi",
+    "古图皮语",
+    "古典图皮语"
   ],
   "tpx": [
     "阿卡特佩克-梅帕語",
-    "Acatepec Me'phaa"
+    "Acatepec Me'phaa",
+    "阿卡特佩克-梅帕语"
   ],
   "tpy": [
     "Trumai"
@@ -26409,16 +28818,19 @@
   ],
   "tqt": [
     "西托托納克語",
-    "Western Totonac"
+    "Western Totonac",
+    "西托托纳克语"
   ],
   "tqu": [
     "Touo"
   ],
   "tqw": [
-    "通卡瓦語"
+    "通卡瓦語",
+    "通卡瓦语"
   ],
   "tr": [
-    "土耳其語"
+    "土耳其語",
+    "土耳其语"
   ],
   "tra": [
     "Tirahi"
@@ -26437,7 +28849,8 @@
   ],
   "trf": [
     "千里達克里奧爾英語",
-    "Trinidadian Creole English"
+    "Trinidadian Creole English",
+    "千里达克里奥尔英语"
   ],
   "trg": [
     "Lishán Didán"
@@ -26459,15 +28872,18 @@
   ],
   "trk-oat": [
     "古安納托利亞土耳其語",
-    "Old Anatolian Turkish"
+    "Old Anatolian Turkish",
+    "古安纳托利亚土耳其语"
   ],
   "trk-pro": [
     "原始突厥語",
-    "Proto-Turkic"
+    "Proto-Turkic",
+    "原始突厥语"
   ],
   "trl": [
     "旅行者蘇格蘭語",
-    "Traveller Scottish"
+    "Traveller Scottish",
+    "旅行者苏格兰语"
   ],
   "trm": [
     "Tregami"
@@ -26485,13 +28901,17 @@
     "Tarao",
     "Tarao Naga",
     "Taraotrong",
-    "Tarau"
+    "Tarau",
+    "塔劳语"
   ],
   "trp": [
     "博羅克語",
     "Kokborok",
     "廓博羅克語",
-    "特里普拉語"
+    "特里普拉語",
+    "博罗克语",
+    "廓博罗克语",
+    "特里普拉语"
   ],
   "trq": [
     "San Martín Itunyoso Triqui"
@@ -26507,13 +28927,16 @@
   ],
   "tru": [
     "圖羅尤語",
-    "Turoyo"
+    "Turoyo",
+    "图罗尤语"
   ],
   "trv": [
     "賽德克語",
     "Seediq",
     "太魯閣語",
-    "Taroko"
+    "Taroko",
+    "赛德克语",
+    "太鲁阁语"
   ],
   "trw": [
     "Torwali"
@@ -26526,13 +28949,15 @@
   "try": [
     "土隆語",
     "Turung",
-    "Tai Turung"
+    "Tai Turung",
+    "土隆语"
   ],
   "trz": [
     "Torá"
   ],
   "ts": [
-    "聰加語"
+    "聰加語",
+    "聪加语"
   ],
   "tsa": [
     "Tsaangi"
@@ -26544,18 +28969,21 @@
     "Tswa"
   ],
   "tsd": [
-    "特薩克尼恩語"
+    "特薩克尼恩語",
+    "特萨克尼恩语"
   ],
   "tse": [
     "突尼西亞手語",
-    "Tunisian Sign Language"
+    "Tunisian Sign Language",
+    "突尼西亚手语"
   ],
   "tsf": [
     "Southwestern Tamang"
   ],
   "tsg": [
     "陶蘇格語",
-    "Sūg"
+    "Sūg",
+    "陶苏格语"
   ],
   "tsh": [
     "Tsuvan"
@@ -26563,7 +28991,9 @@
   "tsi": [
     "茨姆錫安語",
     "欽西安語",
-    "Tsimshian"
+    "Tsimshian",
+    "茨姆锡安语",
+    "钦西安语"
   ],
   "tsj": [
     "Tshangla",
@@ -26571,30 +29001,35 @@
   ],
   "tsl": [
     "卜老語",
-    "Ts'ün-Lao"
+    "Ts'ün-Lao",
+    "卜老语"
   ],
   "tsm": [
     "土耳其手語",
-    "Turkish Sign Language"
+    "Turkish Sign Language",
+    "土耳其手语"
   ],
   "tsp": [
     "Northern Toussian"
   ],
   "tsq": [
     "泰國手語",
-    "Thai Sign Language"
+    "Thai Sign Language",
+    "泰国手语"
   ],
   "tsr": [
     "Akei"
   ],
   "tss": [
     "臺灣手語",
-    "Taiwan Sign Language"
+    "Taiwan Sign Language",
+    "台湾手语"
   ],
   "tsu": [
     "鄒語",
     "Cou",
-    "Tsou"
+    "Tsou",
+    "邹语"
   ],
   "tsv": [
     "Tsogo"
@@ -26609,7 +29044,8 @@
     "Tebul Sign Language"
   ],
   "tt": [
-    "韃靼語"
+    "韃靼語",
+    "鞑靼语"
   ],
   "tta": [
     "Tutelo"
@@ -26619,7 +29055,8 @@
   ],
   "ttc": [
     "特克提特克語",
-    "Tektiteko"
+    "Tektiteko",
+    "特克提特克语"
   ],
   "ttd": [
     "Tauade"
@@ -26633,7 +29070,8 @@
   ],
   "ttg": [
     "都東語",
-    "Tutong"
+    "Tutong",
+    "都东语"
   ],
   "tth": [
     "Upper Ta'oih"
@@ -26651,7 +29089,8 @@
     "Totela"
   ],
   "ttm": [
-    "北塔穹語"
+    "北塔穹語",
+    "北塔穹语"
   ],
   "ttn": [
     "Towei"
@@ -26669,14 +29108,16 @@
     "Tera"
   ],
   "tts": [
-    "伊桑語"
+    "伊桑語",
+    "伊桑语"
   ],
   "ttt": [
     "塔特語",
     "Tat",
     "Caucasian Tat",
     "Muslim Tat",
-    "Armeno-Tat"
+    "Armeno-Tat",
+    "塔特语"
   ],
   "ttu": [
     "Torau"
@@ -26729,7 +29170,8 @@
   ],
   "tum": [
     "通布卡語",
-    "Tumbuka"
+    "Tumbuka",
+    "通布卡语"
   ],
   "tun": [
     "Tunica"
@@ -26739,14 +29181,16 @@
   ],
   "tup-gua-pro": [
     "原始圖皮-瓜拉尼語",
-    "Proto-Tupi-Guarani"
+    "Proto-Tupi-Guarani",
+    "原始图皮-瓜拉尼语"
   ],
   "tup-kab": [
     "Kabishiana"
   ],
   "tup-pro": [
     "原始圖皮語",
-    "Proto-Tupian"
+    "Proto-Tupian",
+    "原始图皮语"
   ],
   "tuq": [
     "Tedaga",
@@ -26763,15 +29207,18 @@
   ],
   "tuw-kkl": [
     "恰喀拉語",
-    "Kyakala"
+    "Kyakala",
+    "恰喀拉语"
   ],
   "tuw-pro": [
     "原始通古斯語",
-    "Proto-Tungusic"
+    "Proto-Tungusic",
+    "原始通古斯语"
   ],
   "tuw-sol": [
     "索倫語",
-    "Solon"
+    "Solon",
+    "索伦语"
   ],
   "tux": [
     "Tuxináwa"
@@ -26796,7 +29243,8 @@
   ],
   "tvl": [
     "圖瓦盧語",
-    "Tuvaluan"
+    "Tuvaluan",
+    "图瓦卢语"
   ],
   "tvm": [
     "Tela-Masbuar"
@@ -26825,18 +29273,23 @@
     "大滿語",
     "大武壟語",
     "Taivoan",
-    "Taivuan"
+    "Taivuan",
+    "大武垅语",
+    "大满语",
+    "大武垄语"
   ],
   "tvy": [
     "帝汶皮欽語",
     "Timor Pidgin",
-    "Bidau Creole Portuguese"
+    "Bidau Creole Portuguese",
+    "帝汶皮钦语"
   ],
   "twa": [
     "Twana"
   ],
   "twb": [
-    "西塔烏碧語"
+    "西塔烏碧語",
+    "西塔乌碧语"
   ],
   "twc": [
     "Teshenawa"
@@ -26848,7 +29301,8 @@
   "twf": [
     "陶斯語",
     "Taos",
-    "Northern Tiwa"
+    "Northern Tiwa",
+    "陶斯语"
   ],
   "twg": [
     "Tereweng"
@@ -26858,7 +29312,9 @@
     "傣皓語",
     "Tai Dón",
     "Tai Khao",
-    "White Tai"
+    "White Tai",
+    "傣端语",
+    "傣皓语"
   ],
   "twm": [
     "Tawang Monpa"
@@ -26873,11 +29329,13 @@
     "Ere"
   ],
   "twq": [
-    "北桑海語"
+    "北桑海語",
+    "北桑海语"
   ],
   "twr": [
     "西南塔拉烏馬拉語",
-    "Southwestern Tarahumara"
+    "Southwestern Tarahumara",
+    "西南塔拉乌马拉语"
   ],
   "twt": [
     "Turiwára"
@@ -26901,7 +29359,10 @@
     "龜茲語",
     "Tocharian B",
     "West Tocharian",
-    "Kuchean"
+    "Kuchean",
+    "吐火罗语B",
+    "乙种吐火罗语",
+    "龟兹语"
   ],
   "txc": [
     "Tsetsaut"
@@ -26911,11 +29372,13 @@
   ],
   "txg": [
     "西夏語",
-    "Tangut"
+    "Tangut",
+    "西夏语"
   ],
   "txh": [
     "色雷斯語",
-    "Thracian"
+    "Thracian",
+    "色雷斯语"
   ],
   "txi": [
     "Ikpeng"
@@ -26925,7 +29388,8 @@
   ],
   "txm": [
     "托米尼語",
-    "Tomini"
+    "Tomini",
+    "托米尼语"
   ],
   "txn": [
     "West Tarangan"
@@ -26952,11 +29416,13 @@
     "Tatana"
   ],
   "ty": [
-    "大溪地語"
+    "大溪地語",
+    "大溪地语"
   ],
   "tya": [
     "陶亞語",
-    "Tauya"
+    "Tauya",
+    "陶亚语"
   ],
   "tye": [
     "Kyenga"
@@ -26991,18 +29457,21 @@
   ],
   "tyr": [
     "傣亮語",
-    "Tai Daeng"
+    "Tai Daeng",
+    "傣亮语"
   ],
   "tys": [
     "沙爬語",
     "Sapa",
     "Sa Pa",
     "Tày Sa Pa",
-    "Tai Sapa"
+    "Tai Sapa",
+    "沙爬语"
   ],
   "tyt": [
     "德地傣語",
-    "Tày Tac"
+    "Tày Tac",
+    "德地傣语"
   ],
   "tyu": [
     "Kua"
@@ -27010,21 +29479,25 @@
   "tyv": [
     "圖瓦語",
     "Tuvan",
-    "Tyvan"
+    "Tyvan",
+    "图瓦语"
   ],
   "tyx": [
     "Teke-Tyee"
   ],
   "tyz": [
-    "岱依語"
+    "岱依語",
+    "岱依语"
   ],
   "tza": [
     "坦桑尼亞手語",
-    "Tanzanian Sign Language"
+    "Tanzanian Sign Language",
+    "坦桑尼亚手语"
   ],
   "tzh": [
     "策爾塔爾語",
-    "Tzeltal"
+    "Tzeltal",
+    "策尔塔尔语"
   ],
   "tzj": [
     "Tz'utujil",
@@ -27035,14 +29508,16 @@
   ],
   "tzm": [
     "中阿特拉斯柏柏爾語",
-    "Central Atlas Tamazight"
+    "Central Atlas Tamazight",
+    "中阿特拉斯柏柏尔语"
   ],
   "tzn": [
     "Tugun"
   ],
   "tzo": [
     "佐齊爾語",
-    "Tzotzil"
+    "Tzotzil",
+    "佐齐尔语"
   ],
   "tzx": [
     "Tabriak",
@@ -27072,29 +29547,34 @@
   "ubu": [
     "考蓋爾語",
     "Kaugel",
-    "Umbu-Ungu"
+    "Umbu-Ungu",
+    "考盖尔语"
   ],
   "uby": [
     "尤比克語",
-    "Ubykh"
+    "Ubykh",
+    "尤比克语"
   ],
   "uda": [
     "烏達語",
-    "Uda"
+    "Uda",
+    "乌达语"
   ],
   "ude": [
     "烏德蓋語",
     "Udihe",
     "Udege",
     "Udekhe",
-    "Udeghe"
+    "Udeghe",
+    "乌德盖语"
   ],
   "udg": [
     "Muduga"
   ],
   "udi": [
     "烏迪語",
-    "Udi"
+    "Udi",
+    "乌迪语"
   ],
   "udj": [
     "Ujir"
@@ -27104,7 +29584,8 @@
   ],
   "udm": [
     "烏得穆爾特語",
-    "Udmurt"
+    "Udmurt",
+    "乌得穆尔特语"
   ],
   "udu": [
     "Uduk"
@@ -27116,11 +29597,13 @@
     "Ufim"
   ],
   "ug": [
-    "維吾爾語"
+    "維吾爾語",
+    "维吾尔语"
   ],
   "uga": [
     "烏加里特語",
-    "Ugaritic"
+    "Ugaritic",
+    "乌加里特语"
   ],
   "ugb": [
     "Kuku-Ugbanh"
@@ -27134,11 +29617,13 @@
   "ugo": [
     "貢語",
     "Gong",
-    "Ugong"
+    "Ugong",
+    "贡语"
   ],
   "ugy": [
     "烏拉圭手語",
-    "Uruguayan Sign Language"
+    "Uruguayan Sign Language",
+    "乌拉圭手语"
   ],
   "uha": [
     "Uhami"
@@ -27156,7 +29641,8 @@
     "Tanjijili"
   ],
   "uk": [
-    "烏克蘭語"
+    "烏克蘭語",
+    "乌克兰语"
   ],
   "uka": [
     "Kaburi"
@@ -27173,7 +29659,8 @@
   ],
   "ukl": [
     "烏克蘭手語",
-    "Ukrainian Sign Language"
+    "Ukrainian Sign Language",
+    "乌克兰手语"
   ],
   "ukp": [
     "Ukpe-Bayobiri"
@@ -27203,11 +29690,13 @@
   ],
   "ulc": [
     "烏爾奇語",
-    "Ulch"
+    "Ulch",
+    "乌尔奇语"
   ],
   "ule": [
     "盧萊語",
-    "Lule"
+    "Lule",
+    "卢莱语"
   ],
   "ulf": [
     "Afra"
@@ -27217,7 +29706,8 @@
   ],
   "ulk": [
     "梅里阿姆語",
-    "Meriam"
+    "Meriam",
+    "梅里阿姆语"
   ],
   "ull": [
     "Ullatan"
@@ -27228,7 +29718,8 @@
   "uln": [
     "拉包爾克里奧德語",
     "Unserdeutsch",
-    "Rabaul Creole German"
+    "Rabaul Creole German",
+    "拉包尔克里奥德语"
   ],
   "ulu": [
     "Uma' Lung"
@@ -27242,12 +29733,14 @@
   "umb": [
     "姆班杜語",
     "Umbundu",
-    "South Mbundu"
+    "South Mbundu",
+    "姆班杜语"
   ],
   "umc": [
     "馬魯西尼語",
     "Umbundu",
-    "South Mbundu"
+    "South Mbundu",
+    "马鲁西尼语"
   ],
   "umd": [
     "Umbindhamu"
@@ -27278,13 +29771,15 @@
   ],
   "umu": [
     "門西語",
-    "Munsee"
+    "Munsee",
+    "门西语"
   ],
   "una": [
     "North Watut"
   ],
   "und": [
-    "待定語言"
+    "待定語言",
+    "待定语言"
   ],
   "und-isa": [
     "Isaurian"
@@ -27324,7 +29819,8 @@
   ],
   "unm": [
     "烏納米語",
-    "Unami"
+    "Unami",
+    "乌纳米语"
   ],
   "unn": [
     "Kurnai",
@@ -27341,7 +29837,8 @@
   ],
   "unr": [
     "蒙達里語",
-    "Mundari"
+    "Mundari",
+    "蒙达里语"
   ],
   "unu": [
     "Unubahe"
@@ -27362,7 +29859,8 @@
   ],
   "uon": [
     "龜崙語",
-    "Kulon"
+    "Kulon",
+    "龟仑语"
   ],
   "upi": [
     "Umeda"
@@ -27371,7 +29869,8 @@
     "Uripiv-Wala-Rano-Atchin"
   ],
   "ur": [
-    "烏爾都語"
+    "烏爾都語",
+    "乌尔都语"
   ],
   "ura": [
     "Urarina"
@@ -27380,7 +29879,8 @@
     "烏魯布-卡波爾語",
     "Urubú-Kaapor",
     "Ka'apor",
-    "Kaaporté"
+    "Kaaporté",
+    "乌鲁布-卡波尔语"
   ],
   "urc": [
     "Urningangg"
@@ -27396,28 +29896,33 @@
   ],
   "urh": [
     "烏爾霍博語",
-    "Urhobo"
+    "Urhobo",
+    "乌尔霍博语"
   ],
   "uri": [
     "Urim"
   ],
   "urj-mdv-pro": [
     "原始莫爾多瓦語",
-    "Proto-Mordvinic"
+    "Proto-Mordvinic",
+    "原始莫尔多瓦语"
   ],
   "urj-prm-pro": [
     "原始彼爾姆語",
-    "Proto-Permic"
+    "Proto-Permic",
+    "原始彼尔姆语"
   ],
   "urj-pro": [
     "原始烏拉爾語",
     "Proto-Uralic",
     "Proto-Finno-Ugric",
-    "Proto-Finno-Permic"
+    "Proto-Finno-Permic",
+    "原始乌拉尔语"
   ],
   "urj-ugr-pro": [
     "原始烏戈爾語",
-    "Proto-Ugric"
+    "Proto-Ugric",
+    "原始乌戈尔语"
   ],
   "urk": [
     "奧朗勞特語",
@@ -27427,7 +29932,8 @@
     "Lawta",
     "Chao Tha Le",
     "Chao Nam",
-    "Lawoi"
+    "Lawoi",
+    "奥朗劳特语"
   ],
   "url": [
     "Urali"
@@ -27453,7 +29959,8 @@
   ],
   "uru": [
     "烏魯米語",
-    "Urumi"
+    "Urumi",
+    "乌鲁米语"
   ],
   "urv": [
     "Uruava"
@@ -27508,7 +30015,9 @@
     "南派伍特語",
     "Southern Paiute",
     "Colorado River Numic",
-    "Chemehuevi"
+    "Chemehuevi",
+    "尤特语",
+    "南派伍特语"
   ],
   "uth": [
     "Hun",
@@ -27530,7 +30039,8 @@
   ],
   "uum": [
     "烏魯姆語",
-    "Urum"
+    "Urum",
+    "乌鲁姆语"
   ],
   "uun": [
     "龜崙-巴宰語",
@@ -27542,7 +30052,11 @@
     "龜崙語",
     "巴宰語",
     "噶哈巫語",
-    "Kaxabu"
+    "Kaxabu",
+    "龟仑-巴宰语",
+    "龟仑语",
+    "巴宰语",
+    "噶哈巫语"
   ],
   "uur": [
     "Ura (Vanuatu)"
@@ -27556,7 +30070,8 @@
     "West Uvean",
     "Uvean",
     "Faga Ouvéa",
-    "Fagauvea"
+    "Fagauvea",
+    "西乌韦阿语"
   ],
   "uvh": [
     "Uri"
@@ -27571,11 +30086,13 @@
     "Doko-Uyanga"
   ],
   "uz": [
-    "烏茲別克語"
+    "烏茲別克語",
+    "乌兹别克语"
   ],
   "vaa": [
     "瓦加里博里語",
-    "Vaagri Booli"
+    "Vaagri Booli",
+    "瓦加里博里语"
   ],
   "vae": [
     "Vale"
@@ -27587,13 +30104,16 @@
     "瓦爾哈迪語",
     "Varhadi",
     "Varhadi-Nagpuri",
-    "瓦爾哈迪-納格普里語"
+    "瓦爾哈迪-納格普里語",
+    "瓦尔哈迪语",
+    "瓦尔哈迪-纳格普里语"
   ],
   "vai": [
     "瓦伊語",
     "Vai",
     "Gallinas",
-    "Vy"
+    "Vy",
+    "瓦伊语"
   ],
   "vaj": [
     "Sekele",
@@ -27608,7 +30128,8 @@
   ],
   "vam": [
     "瓦尼莫語",
-    "Vanimo"
+    "Vanimo",
+    "瓦尼莫语"
   ],
   "van": [
     "Valman"
@@ -27627,7 +30148,8 @@
   ],
   "vas": [
     "瓦薩維語",
-    "Vasavi"
+    "Vasavi",
+    "瓦萨维语"
   ],
   "vau": [
     "Vanuma"
@@ -27635,7 +30157,8 @@
   "vav": [
     "瓦爾里語",
     "Varli",
-    "Warli"
+    "Warli",
+    "瓦尔里语"
   ],
   "vay": [
     "Vayu"
@@ -27648,13 +30171,16 @@
     "Southwestern Bontok"
   ],
   "ve": [
-    "文達語"
+    "文達語",
+    "文达语"
   ],
   "vec": [
-    "威尼斯語"
+    "威尼斯語",
+    "威尼斯语"
   ],
   "ved": [
-    "維達語"
+    "維達語",
+    "维达语"
   ],
   "vem": [
     "Vemgo-Mabas"
@@ -27664,25 +30190,30 @@
   ],
   "vep": [
     "維普斯語",
-    "Veps"
+    "Veps",
+    "维普斯语"
   ],
   "ver": [
     "Mom Jango"
   ],
   "vgr": [
     "瓦戈里語",
-    "Vaghri"
+    "Vaghri",
+    "瓦戈里语"
   ],
   "vgt": [
     "佛蘭德手語",
-    "Flemish Sign Language"
+    "Flemish Sign Language",
+    "佛兰德手语"
   ],
   "vi": [
-    "越南語"
+    "越南語",
+    "越南语"
   ],
   "vic": [
     "美屬維爾京群島克里奧爾語",
-    "Virgin Islands Creole"
+    "Virgin Islands Creole",
+    "美属维尔京群岛克里奥尔语"
   ],
   "vid": [
     "Vidunda"
@@ -27695,7 +30226,8 @@
   ],
   "vil": [
     "維萊拉語",
-    "Vilela"
+    "Vilela",
+    "维莱拉语"
   ],
   "vis": [
     "Vishavan"
@@ -27708,7 +30240,8 @@
   ],
   "vka": [
     "卡里亞拉語",
-    "Kariyarra"
+    "Kariyarra",
+    "卡里亚拉语"
   ],
   "vki": [
     "Ija-Zuba"
@@ -27742,25 +30275,29 @@
   ],
   "vku": [
     "庫拉馬語",
-    "Kurrama"
+    "Kurrama",
+    "库拉马语"
   ],
   "vlp": [
     "Valpei"
   ],
   "vls": [
     "西佛蘭德語",
-    "West Flemish"
+    "West Flemish",
+    "西佛兰德语"
   ],
   "vma": [
     "馬圖蘇利那語",
-    "Martuthunira"
+    "Martuthunira",
+    "马图苏利那语"
   ],
   "vmb": [
     "Mbabaram"
   ],
   "vmc": [
     "尤克斯特拉瓦卡米斯特克語",
-    "Juxtlahuaca Mixtec"
+    "Juxtlahuaca Mixtec",
+    "尤克斯特拉瓦卡米斯特克语"
   ],
   "vmd": [
     "Mudu Koraga"
@@ -27779,7 +30316,8 @@
     "Nürnbergisch",
     "Oberfränkisch",
     "Upper Franconian",
-    "Vogtländisch"
+    "Vogtländisch",
+    "东法兰克尼亚语"
   ],
   "vmg": [
     "Minigir",
@@ -27787,40 +30325,47 @@
   ],
   "vmh": [
     "馬拉格伊語",
-    "Maraghei"
+    "Maraghei",
+    "马拉格伊语"
   ],
   "vmi": [
     "Miwa"
   ],
   "vmj": [
     "伊斯塔尤特拉米斯特克語",
-    "Ixtayutla Mixtec"
+    "Ixtayutla Mixtec",
+    "伊斯塔尤特拉米斯特克语"
   ],
   "vmk": [
     "Makhuwa-Shirima"
   ],
   "vml": [
     "馬爾加納語",
-    "Malgana"
+    "Malgana",
+    "马尔加纳语"
   ],
   "vmm": [
     "米特拉通戈米斯特克語",
-    "Mitlatongo Mixtec"
+    "Mitlatongo Mixtec",
+    "米特拉通戈米斯特克语"
   ],
   "vmp": [
     "索亞爾特佩克馬薩特克語",
-    "Soyaltepec Mazatec"
+    "Soyaltepec Mazatec",
+    "索亚尔特佩克马萨特克语"
   ],
   "vmq": [
     "索亞爾特佩克米斯特克語",
-    "Soyaltepec Mixtec"
+    "Soyaltepec Mixtec",
+    "索亚尔特佩克米斯特克语"
   ],
   "vmr": [
     "Marenje"
   ],
   "vmu": [
     "穆盧利吉語",
-    "Muluridyi"
+    "Muluridyi",
+    "穆卢利吉语"
   ],
   "vmv": [
     "Valley Maidu"
@@ -27830,15 +30375,18 @@
   ],
   "vmx": [
     "塔馬索拉米斯特克語",
-    "Tamazola Mixtec"
+    "Tamazola Mixtec",
+    "塔马索拉米斯特克语"
   ],
   "vmy": [
     "阿亞烏特拉馬薩特克語",
-    "Ayautla Mazatec"
+    "Ayautla Mazatec",
+    "阿亚乌特拉马萨特克语"
   ],
   "vmz": [
     "馬薩特蘭馬薩特克語",
-    "Mazatlán Mazatec"
+    "Mazatlán Mazatec",
+    "马萨特兰马萨特克语"
   ],
   "vnk": [
     "Lovono"
@@ -27850,21 +30398,24 @@
     "Vunapu"
   ],
   "vo": [
-    "沃拉普克語"
+    "沃拉普克語",
+    "沃拉普克语"
   ],
   "vor": [
     "Voro"
   ],
   "vot": [
     "沃特語",
-    "Votic"
+    "Votic",
+    "沃特语"
   ],
   "vra": [
     "Vera'a"
   ],
   "vro": [
     "佛羅語",
-    "Võro"
+    "Võro",
+    "佛罗语"
   ],
   "vrs": [
     "Varisi"
@@ -27874,15 +30425,18 @@
   ],
   "vsi": [
     "摩爾多瓦手語",
-    "Moldova Sign Language"
+    "Moldova Sign Language",
+    "摩尔多瓦手语"
   ],
   "vsl": [
     "委內瑞拉手語",
-    "Venezuelan Sign Language"
+    "Venezuelan Sign Language",
+    "委内瑞拉手语"
   ],
   "vsv": [
     "瓦倫西亞手語",
-    "Valencian Sign Language"
+    "Valencian Sign Language",
+    "瓦伦西亚手语"
   ],
   "vto": [
     "Vitou"
@@ -27897,7 +30451,8 @@
     "Chaga",
     "KiVunjo Chaga",
     "Central Kilimanjaro",
-    "Central Chaga"
+    "Central Chaga",
+    "温旧语"
   ],
   "vut": [
     "Vute"
@@ -27908,10 +30463,12 @@
     "阿佤方言",
     "Awa",
     "Ava",
-    "Va"
+    "Va",
+    "阿佤语"
   ],
   "wa": [
-    "瓦隆語"
+    "瓦隆語",
+    "瓦隆语"
   ],
   "waa": [
     "Walla Walla"
@@ -27944,12 +30501,14 @@
     "Wolayta",
     "Wolaitta",
     "Wolaita",
-    "Welayta"
+    "Welayta",
+    "瓦拉莫语"
   ],
   "wam": [
     "麻薩諸塞語",
     "Massachusett",
-    "Wampanoag"
+    "Wampanoag",
+    "麻萨诸塞语"
   ],
   "wan": [
     "Wan"
@@ -27965,18 +30524,21 @@
     "Wageman",
     "Wagiman",
     "Wakiman",
-    "Wogeman"
+    "Wogeman",
+    "瓦吉曼语"
   ],
   "war": [
     "瓦瑞瓦瑞語",
     "Waray-Waray",
     "Waray",
     "Winaray",
-    "Samar-Leyte"
+    "Samar-Leyte",
+    "瓦瑞瓦瑞语"
   ],
   "was": [
     "瓦修語",
-    "Washo"
+    "Washo",
+    "瓦修语"
   ],
   "wat": [
     "Kaninuwa"
@@ -27986,7 +30548,8 @@
     "Wauja",
     "Waura",
     "Waurá",
-    "Uaura"
+    "Uaura",
+    "沃雅语"
   ],
   "wav": [
     "Waka"
@@ -28012,7 +30575,8 @@
   ],
   "wba": [
     "瓦勞語",
-    "Warao"
+    "Warao",
+    "瓦劳语"
   ],
   "wbb": [
     "Wabo"
@@ -28035,35 +30599,42 @@
   ],
   "wbk": [
     "維加里語",
-    "Waigali"
+    "Waigali",
+    "维加里语"
   ],
   "wbl": [
     "瓦罕語",
-    "Wakhi"
+    "Wakhi",
+    "瓦罕语"
   ],
   "wbm": [
     "佤語",
     "Wa",
-    "Va"
+    "Va",
+    "佤语"
   ],
   "wbp": [
     "瓦爾皮瑞語",
-    "Warlpiri"
+    "Warlpiri",
+    "瓦尔皮瑞语"
   ],
   "wbq": [
     "Waddar"
   ],
   "wbr": [
     "瓦格迪語",
-    "Wagdi"
+    "Wagdi",
+    "瓦格迪语"
   ],
   "wbt": [
     "萬曼語",
-    "Wanman"
+    "Wanman",
+    "万曼语"
   ],
   "wbv": [
     "瓦賈里語",
-    "Wajarri"
+    "Wajarri",
+    "瓦贾里语"
   ],
   "wbw": [
     "Woi"
@@ -28101,15 +30672,18 @@
     "Waggote",
     "Waggate",
     "Wagatsch",
-    "Waogatsch"
+    "Waogatsch",
+    "瓦吉吉尼语"
   ],
   "wdu": [
     "瓦吉古語",
-    "Wadjigu"
+    "Wadjigu",
+    "瓦吉古语"
   ],
   "wdy": [
     "瓦賈班蓋語",
-    "Wadjabangayi"
+    "Wadjabangayi",
+    "瓦贾班盖语"
   ],
   "wea": [
     "Wewaw"
@@ -28142,7 +30716,8 @@
     "Cameroon Pidgin",
     "Cameroonian Pidgin English",
     "Cameroonian Creole",
-    "Kamtok"
+    "Kamtok",
+    "喀麦隆皮钦语"
   ],
   "wet": [
     "Perai"
@@ -28151,11 +30726,13 @@
     "衛朗語",
     "Welaung",
     "Rawngtu Chin",
-    "Rawngtu"
+    "Rawngtu",
+    "卫朗语"
   ],
   "wew": [
     "韋耶瓦語",
-    "Weyewa"
+    "Weyewa",
+    "韦耶瓦语"
   ],
   "wfg": [
     "Yafi"
@@ -28168,7 +30745,8 @@
   ],
   "wgg": [
     "旺甘古魯語",
-    "Wangganguru"
+    "Wangganguru",
+    "旺甘古鲁语"
   ],
   "wgi": [
     "Wahgi"
@@ -28178,11 +30756,13 @@
   ],
   "wgu": [
     "維蘭古語",
-    "Wirangu"
+    "Wirangu",
+    "维兰古语"
   ],
   "wgy": [
     "瓦爾加馬伊語",
-    "Warrgamay"
+    "Warrgamay",
+    "瓦尔加马伊语"
   ],
   "wha": [
     "Manusela",
@@ -28202,22 +30782,26 @@
   ],
   "wic": [
     "威奇塔語",
-    "Wichita"
+    "Wichita",
+    "威奇塔语"
   ],
   "wie": [
     "維克-埃帕語",
-    "Wik-Epa"
+    "Wik-Epa",
+    "维克-埃帕语"
   ],
   "wif": [
     "Wik-Keyangan"
   ],
   "wig": [
     "維克-雅塔納語",
-    "Wik-Ngathana"
+    "Wik-Ngathana",
+    "维克-雅塔纳语"
   ],
   "wih": [
     "維克-梅安哈語",
-    "Wik-Me'anha"
+    "Wik-Me'anha",
+    "维克-梅安哈语"
   ],
   "wii": [
     "Minidien"
@@ -28227,22 +30811,26 @@
   ],
   "wik": [
     "維卡爾坎語",
-    "Wikalkan"
+    "Wikalkan",
+    "维卡尔坎语"
   ],
   "wil": [
     "維拉維拉語",
-    "Wilawila"
+    "Wilawila",
+    "维拉维拉语"
   ],
   "wim": [
     "維克-蒙坎語",
-    "Wik-Mungkan"
+    "Wik-Mungkan",
+    "维克-蒙坎语"
   ],
   "win": [
     "溫尼貝戈語",
     "Winnebago",
     "Hocak",
     "Hochank",
-    "Hochunk"
+    "Hochunk",
+    "温尼贝戈语"
   ],
   "wir": [
     "Wiraféd"
@@ -28283,7 +30871,8 @@
   ],
   "wkw": [
     "瓦卡瓦卡語",
-    "Wakawaka"
+    "Wakawaka",
+    "瓦卡瓦卡语"
   ],
   "wky": [
     "Wangkayutyuru"
@@ -28299,7 +30888,8 @@
   ],
   "wlg": [
     "昆巴朗語",
-    "Kunbarlang"
+    "Kunbarlang",
+    "昆巴朗语"
   ],
   "wli": [
     "Waioli"
@@ -28313,11 +30903,13 @@
   ],
   "wlm": [
     "中古威爾士語",
-    "Middle Welsh"
+    "Middle Welsh",
+    "中古威尔士语"
   ],
   "wlo": [
     "窩里沃語",
-    "Wolio"
+    "Wolio",
+    "窝里沃语"
   ],
   "wlr": [
     "Wailapa"
@@ -28327,7 +30919,8 @@
     "Wallisian",
     "East Uvean",
     "ʻUvean",
-    "Fakaʻuvea"
+    "Fakaʻuvea",
+    "瓦利斯语"
   ],
   "wlu": [
     "Wuliwuli"
@@ -28349,7 +30942,8 @@
   ],
   "wmb": [
     "萬巴亞語",
-    "Wambaya"
+    "Wambaya",
+    "万巴亚语"
   ],
   "wmc": [
     "Wamas"
@@ -28368,7 +30962,8 @@
   ],
   "wmi": [
     "瓦明語",
-    "Wamin"
+    "Wamin",
+    "瓦明语"
   ],
   "wmm": [
     "Maiwa (Indonesia)",
@@ -28388,12 +30983,14 @@
   ],
   "wmt": [
     "瓦爾馬賈里語",
-    "Walmajarri"
+    "Walmajarri",
+    "瓦尔马贾里语"
   ],
   "wmw": [
     "姆瓦尼語",
     "Mwani",
-    "Kimwani"
+    "Kimwani",
+    "姆瓦尼语"
   ],
   "wmx": [
     "Womo"
@@ -28406,7 +31003,8 @@
   ],
   "wnd": [
     "萬達朗語",
-    "Wandarang"
+    "Wandarang",
+    "万达朗语"
   ],
   "wne": [
     "瓦內茨語",
@@ -28414,21 +31012,24 @@
     "Wanetsi",
     "Wanechi",
     "Chalgari",
-    "Tarino"
+    "Tarino",
+    "瓦内茨语"
   ],
   "wng": [
     "Wanggom"
   ],
   "wni": [
     "昂儒昂科摩羅語",
-    "Ndzwani Comorian"
+    "Ndzwani Comorian",
+    "昂儒昂科摩罗语"
   ],
   "wnk": [
     "Wanukaka"
   ],
   "wnm": [
     "旺加馬拉語",
-    "Wanggamala"
+    "Wanggamala",
+    "旺加马拉语"
   ],
   "wno": [
     "Wano"
@@ -28448,7 +31049,8 @@
     "Waanyi"
   ],
   "wo": [
-    "沃洛夫語"
+    "沃洛夫語",
+    "沃洛夫语"
   ],
   "woa": [
     "Tyaraity"
@@ -28464,7 +31066,8 @@
   ],
   "woe": [
     "沃雷埃語",
-    "Woleaian"
+    "Woleaian",
+    "沃雷埃语"
   ],
   "wog": [
     "Wogamusin"
@@ -28520,15 +31123,18 @@
     "Warrungu",
     "Warrongo",
     "Warrangu",
-    "Warrango"
+    "Warrango",
+    "瓦龙古语"
   ],
   "wrh": [
     "威拉祖利語",
-    "Wiradhuri"
+    "Wiradhuri",
+    "威拉祖利语"
   ],
   "wri": [
     "瓦里揚加語",
-    "Wariyangga"
+    "Wariyangga",
+    "瓦里扬加语"
   ],
   "wrk": [
     "加拉瓦語",
@@ -28536,15 +31142,18 @@
     "Garrwa",
     "Karawa",
     "Karrwa",
-    "Gaarwa"
+    "Gaarwa",
+    "加拉瓦语"
   ],
   "wrl": [
     "瓦爾曼帕語",
-    "Warlmanpa"
+    "Warlmanpa",
+    "瓦尔曼帕语"
   ],
   "wrm": [
     "瓦魯孟古語",
-    "Warumungu"
+    "Warumungu",
+    "瓦鲁孟古语"
   ],
   "wrn": [
     "Warnang"
@@ -28560,19 +31169,23 @@
   ],
   "wrr": [
     "瓦爾達曼語",
-    "Wardaman"
+    "Wardaman",
+    "瓦尔达曼语"
   ],
   "wrs": [
     "瓦里斯語",
-    "Waris"
+    "Waris",
+    "瓦里斯语"
   ],
   "wru": [
     "瓦魯語",
-    "Waru"
+    "Waru",
+    "瓦鲁语"
   ],
   "wrv": [
     "瓦魯納語",
-    "Waruna"
+    "Waruna",
+    "瓦鲁纳语"
   ],
   "wrw": [
     "Gugu Warra"
@@ -28626,14 +31239,16 @@
   ],
   "wtm": [
     "梅瓦蒂語",
-    "Mewati"
+    "Mewati",
+    "梅瓦蒂语"
   ],
   "wtw": [
     "Wotu"
   ],
   "wua": [
     "維克恩根切拉語",
-    "Wikngenchera"
+    "Wikngenchera",
+    "维克恩根切拉语"
   ],
   "wub": [
     "Wunambal"
@@ -28643,7 +31258,8 @@
   ],
   "wuh": [
     "五屯話",
-    "Wutunhua"
+    "Wutunhua",
+    "五屯话"
   ],
   "wul": [
     "Silimo"
@@ -28667,7 +31283,10 @@
     "上海話",
     "Wu",
     "Suzhounese",
-    "Shanghainese"
+    "Shanghainese",
+    "吴语",
+    "苏州话",
+    "上海话"
   ],
   "wuv": [
     "Wuvulu-Aua",
@@ -28675,7 +31294,8 @@
   ],
   "wux": [
     "伍勒納語",
-    "Wulna"
+    "Wulna",
+    "伍勒纳语"
   ],
   "wuy": [
     "Wauyai"
@@ -28688,32 +31308,40 @@
   ],
   "wwr": [
     "瓦爾瓦語",
-    "Warrwa"
+    "Warrwa",
+    "瓦尔瓦语"
   ],
   "www": [
     "瓦瓦語",
-    "Wawa"
+    "Wawa",
+    "瓦瓦语"
   ],
   "wxa": [
     "瓦鄉話",
-    "Waxianghua"
+    "Waxianghua",
+    "瓦乡话"
   ],
   "wxw": [
     "瓦爾丹迪語",
-    "Wardandi"
+    "Wardandi",
+    "瓦尔丹迪语"
   ],
   "wya": [
     "懷安多特語",
     "懷恩多特語",
     "Wyandot",
-    "休倫語"
+    "休倫語",
+    "怀安多特语",
+    "怀恩多特语",
+    "休伦语"
   ],
   "wyb": [
     "恩吉亞姆巴語",
     "Ngiyambaa",
     "Wangaaybuwan-Ngiyambaa",
     "Wangaaybuwan",
-    "Wayilwan"
+    "Wayilwan",
+    "恩吉亚姆巴语"
   ],
   "wyi": [
     "沃伊伍龍語",
@@ -28753,14 +31381,16 @@
     "Bunurowrung",
     "Boonoorong",
     "Boonerwrung",
-    "Bururong"
+    "Bururong",
+    "沃伊伍龙语"
   ],
   "wym": [
     "維拉莫維安語",
     "Vilamovian",
     "Wilamowicean",
     "Vilamovicean",
-    "Wymysorys"
+    "Wymysorys",
+    "维拉莫维安语"
   ],
   "wyr": [
     "Wayoró",
@@ -28772,14 +31402,16 @@
   ],
   "wyy": [
     "西斐濟語",
-    "Western Fijian"
+    "Western Fijian",
+    "西斐济语"
   ],
   "xaa": [
     "安達盧斯阿拉伯語",
     "Andalusian Arabic",
     "Andalusi Arabic",
     "Moorish Arabic",
-    "Spanish Arabic"
+    "Spanish Arabic",
+    "安达卢斯阿拉伯语"
   ],
   "xab": [
     "Sambe"
@@ -28792,13 +31424,15 @@
   ],
   "xae": [
     "埃桂語",
-    "Aequian"
+    "Aequian",
+    "埃桂语"
   ],
   "xag": [
     "高加索阿爾巴尼亞語",
     "Aghwan",
     "Caucasian Albanian",
-    "Old Udi"
+    "Old Udi",
+    "高加索阿尔巴尼亚语"
   ],
   "xai": [
     "Kaimbé"
@@ -28820,12 +31454,14 @@
     "卡爾梅克衛拉特語",
     "Kalmyk",
     "Oirat",
-    "Modern Oirat"
+    "Modern Oirat",
+    "卡尔梅克卫拉特语"
   ],
   "xam": [
     "卡姆語",
     "ǀXam",
-    "ǀKham"
+    "ǀKham",
+    "卡姆语"
   ],
   "xan": [
     "Xamtanga"
@@ -28844,7 +31480,8 @@
   ],
   "xas": [
     "卡馬斯語",
-    "Kamassian"
+    "Kamassian",
+    "卡马斯语"
   ],
   "xat": [
     "Katawixi"
@@ -28869,19 +31506,23 @@
     "Bactrian",
     "Greco-Bactrian",
     "Kushan",
-    "Kushano-Bactrian"
+    "Kushano-Bactrian",
+    "巴克特里亚语"
   ],
   "xbd": [
     "賓達爾語",
-    "Bindal"
+    "Bindal",
+    "宾达尔语"
   ],
   "xbe": [
     "比加姆巴爾語",
-    "Bigambal"
+    "Bigambal",
+    "比加姆巴尔语"
   ],
   "xbg": [
     "本甘迪茲語",
-    "Bunganditj"
+    "Bunganditj",
+    "本甘迪兹语"
   ],
   "xbi": [
     "Kombio"
@@ -28891,7 +31532,8 @@
   ],
   "xbm": [
     "中古布列塔尼語",
-    "Middle Breton"
+    "Middle Breton",
+    "中古布列塔尼语"
   ],
   "xbn": [
     "Kenaboi"
@@ -28903,17 +31545,20 @@
     "Bulghar",
     "Bolghar",
     "Bolgarian",
-    "Bolgar"
+    "Bolgar",
+    "保加尔语"
   ],
   "xbp": [
     "比布爾曼語",
-    "Bibbulman"
+    "Bibbulman",
+    "比布尔曼语"
   ],
   "xbr": [
     "坎貝拉語",
     "Kambera",
     "East Sumbanese",
-    "Sumbanese"
+    "Sumbanese",
+    "坎贝拉语"
   ],
   "xbw": [
     "Kambiwá"
@@ -28924,15 +31569,18 @@
   ],
   "xcb": [
     "坎伯蘭語",
-    "Cumbric"
+    "Cumbric",
+    "坎伯兰语"
   ],
   "xcc": [
     "卡莫尼語",
-    "Camunic"
+    "Camunic",
+    "卡莫尼语"
   ],
   "xce": [
     "凱爾特伊比利亞語",
-    "Celtiberian"
+    "Celtiberian",
+    "凯尔特伊比利亚语"
   ],
   "xch": [
     "Chemakum"
@@ -28942,7 +31590,8 @@
     "Old Armenian",
     "Classical Armenian",
     "Liturgical Armenian",
-    "Grabar"
+    "Grabar",
+    "古典亚美尼亚语"
   ],
   "xcm": [
     "Comecrudo"
@@ -28955,24 +31604,28 @@
     "Khwarezmian",
     "Chorasmian",
     "Khwarazmian",
-    "Khorezmian"
+    "Khorezmian",
+    "花剌子模语"
   ],
   "xcr": [
     "Carian"
   ],
   "xct": [
     "古典藏語",
-    "Classical Tibetan"
+    "Classical Tibetan",
+    "古典藏语"
   ],
   "xcu": [
     "庫爾蘭語",
-    "Curonian"
+    "Curonian",
+    "库尔兰语"
   ],
   "xcv": [
     "楚凡語",
     "Chuvan",
     "Chuvantsy",
-    "Chuvansky"
+    "Chuvansky",
+    "楚凡语"
   ],
   "xcw": [
     "Coahuilteco"
@@ -28982,11 +31635,13 @@
   ],
   "xda": [
     "達金容語",
-    "Darkinjung"
+    "Darkinjung",
+    "达金容语"
   ],
   "xdc": [
     "達契亞語",
-    "Dacian"
+    "Dacian",
+    "达契亚语"
   ],
   "xdk": [
     "達拉格語",
@@ -28997,19 +31652,23 @@
     "Eora",
     "Iora",
     "Iyora",
-    "Sydney"
+    "Sydney",
+    "达拉格语"
   ],
   "xdm": [
     "以東語",
-    "Edomite"
+    "Edomite",
+    "以东语"
   ],
   "xdy": [
     "馬來達雅語",
-    "Malayic Dayak"
+    "Malayic Dayak",
+    "马来达雅语"
   ],
   "xeb": [
     "埃勃拉語",
-    "Eblaite"
+    "Eblaite",
+    "埃勃拉语"
   ],
   "xed": [
     "Hdi"
@@ -29044,18 +31703,21 @@
   ],
   "xfa": [
     "法利斯克語",
-    "Faliscan"
+    "Faliscan",
+    "法利斯克语"
   ],
   "xga": [
     "加拉提亞語",
-    "Galatian"
+    "Galatian",
+    "加拉提亚语"
   ],
   "xgb": [
     "Gbin"
   ],
   "xgd": [
     "古當語",
-    "Gudang"
+    "Gudang",
+    "古当语"
   ],
   "xgf": [
     "通瓦語",
@@ -29063,15 +31725,18 @@
     "Tongva",
     "Gabrielino",
     "Gabrieleño",
-    "Fernandeño"
+    "Fernandeño",
+    "通瓦语"
   ],
   "xgg": [
     "戈倫語",
-    "Goreng"
+    "Goreng",
+    "戈伦语"
   ],
   "xgi": [
     "加林巴爾語",
-    "Garingbal"
+    "Garingbal",
+    "加林巴尔语"
   ],
   "xgl": [
     "Galindan"
@@ -29086,13 +31751,15 @@
     "Kuinmabara",
     "Karunbara",
     "Rakiwara",
-    "Wapabara"
+    "Wapabara",
+    "达龙巴尔语"
   ],
   "xgn-kha": [
     "哈木尼干蒙古語",
     "Khamnigan Mongol",
     "Khamnigan",
-    "Khamnigan Buryat"
+    "Khamnigan Buryat",
+    "哈木尼干蒙古语"
   ],
   "xgn-mgl": [
     "Mongghul"
@@ -29102,7 +31769,8 @@
   ],
   "xgn-pro": [
     "原始蒙古語",
-    "Proto-Mongolic"
+    "Proto-Mongolic",
+    "原始蒙古语"
   ],
   "xgr": [
     "Garza"
@@ -29112,10 +31780,12 @@
   ],
   "xgw": [
     "古瓦語",
-    "Guwa"
+    "Guwa",
+    "古瓦语"
   ],
   "xh": [
-    "科薩語"
+    "科薩語",
+    "科萨语"
   ],
   "xha": [
     "Harami"
@@ -29123,7 +31793,8 @@
   "xhc": [
     "匈人語",
     "Hunnic",
-    "Hunnish"
+    "Hunnish",
+    "匈人语"
   ],
   "xhd": [
     "Hadrami"
@@ -29131,36 +31802,43 @@
   "xhe": [
     "克特拉尼語",
     "Khetrani",
-    "Khetranki"
+    "Khetranki",
+    "克特拉尼语"
   ],
   "xhm": [
-    "中古高棉語"
+    "中古高棉語",
+    "中古高棉语"
   ],
   "xhr": [
     "赫爾尼基語",
-    "Hernican"
+    "Hernican",
+    "赫尔尼基语"
   ],
   "xht": [
     "哈梯語",
-    "Hattic"
+    "Hattic",
+    "哈梯语"
   ],
   "xhu": [
     "胡里安語",
-    "Hurrian"
+    "Hurrian",
+    "胡里安语"
   ],
   "xhv": [
     "Khua"
   ],
   "xib": [
     "伊比利亞語",
-    "Iberian"
+    "Iberian",
+    "伊比利亚语"
   ],
   "xii": [
     "Xiri"
   ],
   "xil": [
     "伊利里亞語",
-    "Illyrian"
+    "Illyrian",
+    "伊利里亚语"
   ],
   "xin": [
     "Xinca"
@@ -29181,11 +31859,13 @@
   ],
   "xjb": [
     "明瓊巴爾語",
-    "Minjungbal"
+    "Minjungbal",
+    "明琼巴尔语"
   ],
   "xka": [
     "卡爾科提語",
-    "Kalkoti"
+    "Kalkoti",
+    "卡尔科提语"
   ],
   "xkb": [
     "Manigri-Kambolé Ede Nago"
@@ -29194,7 +31874,8 @@
     "科伊因語",
     "Khoini",
     "Xoini",
-    " Kho'ini"
+    " Kho'ini",
+    "科伊因语"
   ],
   "xkd": [
     "Mendalam Kayan"
@@ -29216,11 +31897,14 @@
   "xki": [
     "肯尼亞手語",
     "肯亞手語",
-    "Kenyan Sign Language"
+    "Kenyan Sign Language",
+    "肯尼亚手语",
+    "肯亚手语"
   ],
   "xkj": [
     "卡賈里語",
-    "Kajali"
+    "Kajali",
+    "卡贾里语"
   ],
   "xkk": [
     "Kaco'",
@@ -29230,7 +31914,8 @@
     "巴庫語",
     "Bakung",
     "Mainstream Kenyah",
-    "Kenyah"
+    "Kenyah",
+    "巴库语"
   ],
   "xkn": [
     "Kayan River Kayan"
@@ -29240,7 +31925,8 @@
   ],
   "xkp": [
     "卡巴特伊語",
-    "Kabatei"
+    "Kabatei",
+    "卡巴特伊语"
   ],
   "xkq": [
     "Koroni"
@@ -29288,7 +31974,8 @@
     "Kurtop",
     "Kurtöp",
     "Kurtopkha",
-    "Kurtokha"
+    "Kurtokha",
+    "库尔托普语"
   ],
   "xla": [
     "Kamula"
@@ -29298,19 +31985,23 @@
   ],
   "xlc": [
     "呂基亞語",
-    "Lycian"
+    "Lycian",
+    "吕基亚语"
   ],
   "xld": [
     "呂底亞語",
-    "Lydian"
+    "Lydian",
+    "吕底亚语"
   ],
   "xle": [
     "利姆尼亞語",
-    "Lemnian"
+    "Lemnian",
+    "利姆尼亚语"
   ],
   "xlg": [
     "古利古里亞語",
-    "Ancient Ligurian"
+    "Ancient Ligurian",
+    "古利古里亚语"
   ],
   "xli": [
     "Liburnian"
@@ -29320,21 +32011,25 @@
   ],
   "xlp": [
     "南阿爾卑斯高盧語",
-    "Lepontic"
+    "Lepontic",
+    "南阿尔卑斯高卢语"
   ],
   "xls": [
     "盧西坦尼亞語",
-    "Lusitanian"
+    "Lusitanian",
+    "卢西坦尼亚语"
   ],
   "xlu": [
     "盧維語",
     "Luwian",
     "Cuneiform Luwian",
-    "Hieroglyphic Luwian"
+    "Hieroglyphic Luwian",
+    "卢维语"
   ],
   "xly": [
     "伊利米語",
-    "Elymian"
+    "Elymian",
+    "伊利米语"
   ],
   "xmb": [
     "Mbonga",
@@ -29393,7 +32088,8 @@
     "Naraqi",
     "Qalhari",
     "Varani",
-    "Zori"
+    "Zori",
+    "克尔曼语"
   ],
   "xme-kls": [
     "Kalasuri"
@@ -29403,11 +32099,13 @@
   ],
   "xme-mid": [
     "中古米底語",
-    "Middle Median"
+    "Middle Median",
+    "中古米底语"
   ],
   "xme-old": [
     "上古米底語",
-    "Old Median"
+    "Old Median",
+    "上古米底语"
   ],
   "xme-ott": [
     "Old Tati",
@@ -29430,7 +32128,8 @@
     "Mingrelian",
     "Megrelian",
     "Mingrel",
-    "Megrel"
+    "Megrel",
+    "明格列尔语"
   ],
   "xmg": [
     "Mengaka"
@@ -29442,45 +32141,53 @@
     "Wik-Muminh",
     "Kugu-Nganhcara",
     "Wik-Nganhcara",
-    "Wikngenchera"
+    "Wikngenchera",
+    "库库-穆敏赫语"
   ],
   "xmj": [
     "Majera"
   ],
   "xmk": [
     "古馬其頓語",
-    "Ancient Macedonian"
+    "Ancient Macedonian",
+    "古马其顿语"
   ],
   "xml": [
     "馬來西亞手語",
-    "Malaysian Sign Language"
+    "Malaysian Sign Language",
+    "马来西亚手语"
   ],
   "xmm": [
     "萬鴉老馬來語",
-    "Manado Malay"
+    "Manado Malay",
+    "万鸦老马来语"
   ],
   "xmo": [
     "Morerebi"
   ],
   "xmp": [
     "庫庫-穆因語",
-    "Kuku-Mu'inh"
+    "Kuku-Mu'inh",
+    "库库-穆因语"
   ],
   "xmq": [
     "庫庫-芒克語",
-    "Kuku-Mangk"
+    "Kuku-Mangk",
+    "库库-芒克语"
   ],
   "xmr": [
     "麥羅埃語",
     "Meroitic",
-    "Kushite"
+    "Kushite",
+    "麦罗埃语"
   ],
   "xms": [
     "Moroccan Sign Language"
   ],
   "xmt": [
     "馬特巴特語",
-    "Matbat"
+    "Matbat",
+    "马特巴特语"
   ],
   "xmu": [
     "Kamu"
@@ -29490,29 +32197,34 @@
   ],
   "xmy": [
     "馬雅古杜納語",
-    "Mayaguduna"
+    "Mayaguduna",
+    "马雅古杜纳语"
   ],
   "xmz": [
     "Mori Bawah"
   ],
   "xna": [
     "古北阿拉伯語",
-    "Ancient North Arabian"
+    "Ancient North Arabian",
+    "古北阿拉伯语"
   ],
   "xnb": [
     "卡那卡那富語",
     "Kanakanabu",
-    "Kanakanavu"
+    "Kanakanavu",
+    "卡那卡那富语"
   ],
   "xnd-pro": [
     "原始納-德內語",
     "Proto-Na-Dene",
     "Proto-Na-Dené",
-    "Proto-Athabaskan-Eyak-Tlingit"
+    "Proto-Athabaskan-Eyak-Tlingit",
+    "原始纳-德内语"
   ],
   "xng": [
     "中古蒙古語",
-    "Middle Mongolian"
+    "Middle Mongolian",
+    "中古蒙古语"
   ],
   "xnh": [
     "Kuanhua"
@@ -29522,21 +32234,24 @@
   ],
   "xnk": [
     "恩加納卡爾蒂語",
-    "Nganakarti"
+    "Nganakarti",
+    "恩加纳卡尔蒂语"
   ],
   "xnn": [
     "Northern Kankanay"
   ],
   "xnr": [
     "康格里語",
-    "Kangri"
+    "Kangri",
+    "康格里语"
   ],
   "xns": [
     "Kanashi"
   ],
   "xnt": [
     "納拉甘塞特語",
-    "Narragansett"
+    "Narragansett",
+    "纳拉甘塞特语"
   ],
   "xnu": [
     "Nukunul"
@@ -29546,7 +32261,8 @@
     "Nyiyaparli",
     "Nyiyabali",
     "Njijabali",
-    "Nijadali"
+    "Nijadali",
+    "尼亚帕里语"
   ],
   "xoc": [
     "O'chi'chi'"
@@ -29556,7 +32272,8 @@
   ],
   "xog": [
     "索加語",
-    "Lusoga"
+    "Lusoga",
+    "索加语"
   ],
   "xoi": [
     "Kominimung"
@@ -29596,7 +32313,8 @@
   ],
   "xpa": [
     "皮里亞語",
-    "Pirriya"
+    "Pirriya",
+    "皮里亚语"
   ],
   "xpb": [
     "Pyemmairre",
@@ -29624,18 +32342,21 @@
   ],
   "xpe": [
     "利比里亞克佩列語",
-    "Liberia Kpelle"
+    "Liberia Kpelle",
+    "利比里亚克佩列语"
   ],
   "xpf": [
     "東南塔斯馬尼亞語",
     "Southeast Tasmanian",
     "Mainland Southeast Tasmanian",
     "Nuenonne",
-    "Nyunoni"
+    "Nyunoni",
+    "东南塔斯马尼亚语"
   ],
   "xpg": [
     "弗里吉亞語",
-    "Phrygian"
+    "Phrygian",
+    "弗里吉亚语"
   ],
   "xph": [
     "Tyerrernotepanner",
@@ -29645,30 +32366,35 @@
   ],
   "xpi": [
     "皮克特語",
-    "Pictish"
+    "Pictish",
+    "皮克特语"
   ],
   "xpj": [
     "姆帕利詹語",
     "Mpalitjanh",
-    "Luthigh"
+    "Luthigh",
+    "姆帕利詹语"
   ],
   "xpk": [
     "Kulina",
     "Kulina Pano"
   ],
   "xpl": [
-    "索雷爾港語"
+    "索雷爾港語",
+    "索雷尔港语"
   ],
   "xpm": [
     "旁普科爾語",
-    "Pumpokol"
+    "Pumpokol",
+    "旁普科尔语"
   ],
   "xpn": [
     "Kapinawá"
   ],
   "xpo": [
     "波丘特克語",
-    "Pochutec"
+    "Pochutec",
+    "波丘特克语"
   ],
   "xpp": [
     "Puyo-Paekche"
@@ -29678,14 +32404,16 @@
   ],
   "xpr": [
     "安息語",
-    "Parthian"
+    "Parthian",
+    "安息语"
   ],
   "xps": [
     "Pisidian"
   ],
   "xpu": [
     "布匿語",
-    "Punic"
+    "Punic",
+    "布匿语"
   ],
   "xpv": [
     "Tommeginne",
@@ -29703,7 +32431,8 @@
   ],
   "xpy": [
     "扶餘語",
-    "Buyeo"
+    "Buyeo",
+    "扶余语"
   ],
   "xpz": [
     "Bruny Island",
@@ -29713,7 +32442,8 @@
   ],
   "xqa": [
     "喀喇汗語",
-    "Karakhanid"
+    "Karakhanid",
+    "喀喇汗语"
   ],
   "xqt": [
     "Qatabanian"
@@ -29732,7 +32462,8 @@
   ],
   "xrg": [
     "米南語",
-    "Minang"
+    "Minang",
+    "米南语"
   ],
   "xri": [
     "Krikati-Timbira"
@@ -29746,44 +32477,52 @@
   "xrq": [
     "卡蘭加語",
     "Karranga",
-    "Karrangpurru"
+    "Karrangpurru",
+    "卡兰加语"
   ],
   "xrr": [
     "雷蒂亞語",
     "Raetic",
     "Rhaetic",
-    "Rhaetian"
+    "Rhaetian",
+    "雷蒂亚语"
   ],
   "xrt": [
     "Aranama-Tamique"
   ],
   "xru": [
     "馬利亞穆語",
-    "Marriammu"
+    "Marriammu",
+    "马利亚穆语"
   ],
   "xrw": [
     "Karawa"
   ],
   "xsa": [
     "賽伯伊語",
-    "Sabaean"
+    "Sabaean",
+    "赛伯伊语"
   ],
   "xsb": [
     "三描語",
     "Sambali",
     "Sambal",
     "Tina Sambal",
-    "Tina"
+    "Tina",
+    "三描语"
   ],
   "xsc-pro": [
     "原始斯基泰語",
-    "Proto-Scythian"
+    "Proto-Scythian",
+    "原始斯基泰语"
   ],
   "xsc-sak-pro": [
-    "原始塞語"
+    "原始塞語",
+    "原始塞语"
   ],
   "xsc-skw-pro": [
-    "原始塞-瓦罕語"
+    "原始塞-瓦罕語",
+    "原始塞-瓦罕语"
   ],
   "xsd": [
     "Sidetic"
@@ -29802,7 +32541,8 @@
   ],
   "xsl": [
     "南斯拉維語",
-    "South Slavey"
+    "South Slavey",
+    "南斯拉维语"
   ],
   "xsm": [
     "Kasem",
@@ -29823,7 +32563,8 @@
   ],
   "xsr": [
     "夏爾巴語",
-    "Sherpa"
+    "Sherpa",
+    "夏尔巴语"
   ],
   "xss": [
     "Assan"
@@ -29834,20 +32575,24 @@
   "xsv": [
     "蘇多維亞語",
     "Sudovian",
-    "Jatvingian"
+    "Jatvingian",
+    "苏多维亚语"
   ],
   "xsy": [
     "賽夏語",
     "Saysiyat",
-    "SaySiyat"
+    "SaySiyat",
+    "赛夏语"
   ],
   "xta": [
     "阿爾科紹卡米斯特克語",
-    "Alcozauca Mixtec"
+    "Alcozauca Mixtec",
+    "阿尔科绍卡米斯特克语"
   ],
   "xtb": [
     "查蘇姆巴米斯特克語",
-    "Chazumba Mixtec"
+    "Chazumba Mixtec",
+    "查苏姆巴米斯特克语"
   ],
   "xtc": [
     "Kadugli",
@@ -29855,7 +32600,8 @@
   ],
   "xtd": [
     "迪烏斯-蒂蘭通戈米斯特克語",
-    "Diuxi-Tilantongo Mixtec"
+    "Diuxi-Tilantongo Mixtec",
+    "迪乌斯-蒂兰通戈米斯特克语"
   ],
   "xte": [
     "Ketengban"
@@ -29865,23 +32611,28 @@
   ],
   "xti": [
     "西尼卡瓦米斯特克語",
-    "Sinicahua Mixtec"
+    "Sinicahua Mixtec",
+    "西尼卡瓦米斯特克语"
   ],
   "xtj": [
     "聖胡安泰塔米斯特克語",
-    "San Juan Teita Mixtec"
+    "San Juan Teita Mixtec",
+    "圣胡安泰塔米斯特克语"
   ],
   "xtl": [
     "蒂哈爾特佩克米斯特克語",
-    "Tijaltepec Mixtec"
+    "Tijaltepec Mixtec",
+    "蒂哈尔特佩克米斯特克语"
   ],
   "xtm": [
     "馬格達萊納佩尼亞斯科米斯特克語",
-    "Magdalena Peñasco Mixtec"
+    "Magdalena Peñasco Mixtec",
+    "马格达莱纳佩尼亚斯科米斯特克语"
   ],
   "xtn": [
     "北特拉夏科米斯特克語",
-    "Northern Tlaxiaco Mixtec"
+    "Northern Tlaxiaco Mixtec",
+    "北特拉夏科米斯特克语"
   ],
   "xto": [
     "吐火羅語A",
@@ -29889,11 +32640,15 @@
     "甲種吐火羅語",
     "Tocharian A",
     "East Tocharian",
-    "Agnean"
+    "Agnean",
+    "吐火罗语A",
+    "焉耆语",
+    "甲种吐火罗语"
   ],
   "xtp": [
     "聖米格爾彼德拉斯-米斯特克語",
-    "San Miguel Piedras Mixtec"
+    "San Miguel Piedras Mixtec",
+    "圣米格尔彼德拉斯-米斯特克语"
   ],
   "xtq": [
     "Tumshuqese"
@@ -29903,15 +32658,18 @@
   ],
   "xts": [
     "辛迪維米斯特克語",
-    "Sindihui Mixtec"
+    "Sindihui Mixtec",
+    "辛迪维米斯特克语"
   ],
   "xtt": [
     "塔卡瓦米斯特克語",
-    "Tacahua Mixtec"
+    "Tacahua Mixtec",
+    "塔卡瓦米斯特克语"
   ],
   "xtu": [
     "庫亞梅卡爾科米斯特克語",
-    "Cuyamecalco Mixtec"
+    "Cuyamecalco Mixtec",
+    "库亚梅卡尔科米斯特克语"
   ],
   "xtv": [
     "Thawa"
@@ -29921,11 +32679,13 @@
   ],
   "xty": [
     "約洛索奇特爾米斯特克語",
-    "Yoloxochitl Mixtec"
+    "Yoloxochitl Mixtec",
+    "约洛索奇特尔米斯特克语"
   ],
   "xtz": [
     "塔斯馬尼亞語",
-    "Tasmanian"
+    "Tasmanian",
+    "塔斯马尼亚语"
   ],
   "xua": [
     "Alu Kurumba"
@@ -29938,7 +32698,8 @@
   ],
   "xug": [
     "國頭語",
-    "Kunigami"
+    "Kunigami",
+    "国头语"
   ],
   "xuj": [
     "Jennu Kurumba"
@@ -29948,7 +32709,8 @@
   ],
   "xum": [
     "翁布里亞語",
-    "Umbrian"
+    "Umbrian",
+    "翁布里亚语"
   ],
   "xun": [
     "Unggaranggu"
@@ -29962,11 +32724,13 @@
   "xur": [
     "烏拉爾圖語",
     "Urartian",
-    "Urartean"
+    "Urartean",
+    "乌拉尔图语"
   ],
   "xut": [
     "庫坦特語",
-    "Kuthant"
+    "Kuthant",
+    "库坦特语"
   ],
   "xuu": [
     "Khwe",
@@ -29974,15 +32738,18 @@
   ],
   "xve": [
     "威尼托語",
-    "Venetic"
+    "Venetic",
+    "威尼托语"
   ],
   "xvn": [
     "汪達爾語",
-    "Vandalic"
+    "Vandalic",
+    "汪达尔语"
   ],
   "xvo": [
     "沃爾西語",
-    "Volscian"
+    "Volscian",
+    "沃尔西语"
   ],
   "xvs": [
     "Vestinian"
@@ -29995,7 +32762,8 @@
   ],
   "xwd": [
     "瓦迪瓦迪語",
-    "Wadi Wadi"
+    "Wadi Wadi",
+    "瓦迪瓦迪语"
   ],
   "xwe": [
     "Xwela Gbe"
@@ -30005,7 +32773,8 @@
   ],
   "xwj": [
     "瓦朱克語",
-    "Wajuk"
+    "Wajuk",
+    "瓦朱克语"
   ],
   "xwk": [
     "Wangkumara",
@@ -30018,7 +32787,8 @@
   ],
   "xwo": [
     "書面衛拉特語",
-    "Written Oirat"
+    "Written Oirat",
+    "书面卫拉特语"
   ],
   "xwr": [
     "Kwerba Mamberamo"
@@ -30034,7 +32804,8 @@
     "Barababaraba",
     "Nari-Nari",
     "Wergaia",
-    "Wotjobaluk"
+    "Wotjobaluk",
+    "温巴温巴语"
   ],
   "xxb": [
     "Boro",
@@ -30054,18 +32825,21 @@
   ],
   "xya": [
     "雅伊吉爾語",
-    "Yaygir"
+    "Yaygir",
+    "雅伊吉尔语"
   ],
   "xyb": [
     "揚吉巴拉語",
-    "Yandjibara"
+    "Yandjibara",
+    "扬吉巴拉语"
   ],
   "xyl": [
     "Yalakalore"
   ],
   "xyt": [
     "馬伊-他庫爾蒂語",
-    "Mayi-Thakurti"
+    "Mayi-Thakurti",
+    "马伊-他库尔蒂语"
   ],
   "xyy": [
     "Yorta Yorta",
@@ -30080,7 +32854,8 @@
   ],
   "xzh": [
     "象雄語",
-    "Zhang-Zhung"
+    "Zhang-Zhung",
+    "象雄语"
   ],
   "xzm": [
     "Zemgalian",
@@ -30089,19 +32864,22 @@
   ],
   "xzp": [
     "古薩波特克語",
-    "Ancient Zapotec"
+    "Ancient Zapotec",
+    "古萨波特克语"
   ],
   "yaa": [
     "亞米納瓦語",
     "Yaminahua",
-    "Yaminawa"
+    "Yaminawa",
+    "亚米纳瓦语"
   ],
   "yab": [
     "Yuhup"
   ],
   "yac": [
     "帕斯谷亞利語",
-    "Pass Valley Yali"
+    "Pass Valley Yali",
+    "帕斯谷亚利语"
   ],
   "yad": [
     "Yagua"
@@ -30125,15 +32903,20 @@
     "Yámana",
     "Yagán",
     "Yahgan",
-    "Yaghan"
+    "Yaghan",
+    "雅加语",
+    "雅马纳语",
+    "雅甘语"
   ],
   "yah": [
     "雅茲古拉米語",
     "Yazghulami",
-    "Yazgulyam"
+    "Yazgulyam",
+    "雅兹古拉米语"
   ],
   "yai": [
-    "雅格諾比語"
+    "雅格諾比語",
+    "雅格诺比语"
   ],
   "yaj": [
     "Banda-Yangere"
@@ -30154,17 +32937,20 @@
   ],
   "yao": [
     "瑤語",
-    "Yao (Africa)"
+    "Yao (Africa)",
+    "瑶语"
   ],
   "yap": [
     "雅浦語",
-    "Yapese"
+    "Yapese",
+    "雅浦语"
   ],
   "yaq": [
     "亞基語",
     "Yaqui",
     "Hiaki",
-    "Yoeme"
+    "Yoeme",
+    "亚基语"
   ],
   "yar": [
     "Yabarana"
@@ -30180,7 +32966,8 @@
     "Yuwana"
   ],
   "yav": [
-    "洋卞語"
+    "洋卞語",
+    "洋卞语"
   ],
   "yaw": [
     "Yawalapití"
@@ -30195,15 +32982,18 @@
     "Yala"
   ],
   "ybb": [
-    "耶姆巴語"
+    "耶姆巴語",
+    "耶姆巴语"
   ],
   "ybe": [
     "西部裕固語",
-    "Western Yugur"
+    "Western Yugur",
+    "西部裕固语"
   ],
   "ybh": [
     "雅卡語",
-    "Yakkha"
+    "Yakkha",
+    "雅卡语"
   ],
   "ybi": [
     "Yamphu"
@@ -30213,7 +33003,8 @@
   ],
   "ybk": [
     "黑木吉語",
-    "Bokha"
+    "Bokha",
+    "黑木吉语"
   ],
   "ybl": [
     "Yukuben"
@@ -30238,7 +33029,8 @@
   ],
   "ycl": [
     "倮倮潑語",
-    "Lolopo"
+    "Lolopo",
+    "倮倮泼语"
   ],
   "ycn": [
     "Yucuna",
@@ -30253,14 +33045,16 @@
   ],
   "yda": [
     "揚達語",
-    "Yanda"
+    "Yanda",
+    "扬达语"
   ],
   "yde": [
     "Yangum Dey"
   ],
   "ydg": [
     "伊特格哈語",
-    "Yidgha"
+    "Yidgha",
+    "伊特格哈语"
   ],
   "ydk": [
     "Yoidik"
@@ -30270,7 +33064,8 @@
   ],
   "yec": [
     "葉尼什語",
-    "Yeniche"
+    "Yeniche",
+    "叶尼什语"
   ],
   "yee": [
     "Yimas"
@@ -30281,7 +33076,8 @@
   "yej": [
     "猶太-希臘語",
     "Yevanic",
-    "Judeo-Greek"
+    "Judeo-Greek",
+    "犹太-希腊语"
   ],
   "yen": [
     "Yendang",
@@ -30310,7 +33106,8 @@
   ],
   "ygi": [
     "伊寧蓋語",
-    "Yiningayi"
+    "Yiningayi",
+    "伊宁盖语"
   ],
   "ygl": [
     "Yangum Gel"
@@ -30327,11 +33124,13 @@
   ],
   "ygs": [
     "雍古手語",
-    "Yolngu Sign Language"
+    "Yolngu Sign Language",
+    "雍古手语"
   ],
   "ygu": [
     "尤古爾語",
-    "Yugul"
+    "Yugul",
+    "尤古尔语"
   ],
   "ygw": [
     "Yagwoia"
@@ -30340,42 +33139,51 @@
     "巴哈語",
     "Baha",
     "Baha Buyang",
-    "Paha"
+    "Paha",
+    "巴哈语"
   ],
   "yhd": [
     "猶太伊拉克阿拉伯語",
-    "Judeo-Iraqi Arabic"
+    "Judeo-Iraqi Arabic",
+    "犹太伊拉克阿拉伯语"
   ],
   "yhl": [
     "圪勒頗普佤語",
-    "Hlepho Phowa"
+    "Hlepho Phowa",
+    "圪勒颇普佤语"
   ],
   "yi": [
-    "意第緒語"
+    "意第緒語",
+    "意第绪语"
   ],
   "yia": [
     "英加爾達語",
-    "Yinggarda"
+    "Yinggarda",
+    "英加尔达语"
   ],
   "yif": [
     "阿車語",
     "Ache",
-    "Azhe"
+    "Azhe",
+    "阿车语"
   ],
   "yig": [
     "烏撒納蘇語",
-    "Wusa Nasu"
+    "Wusa Nasu",
+    "乌撒纳苏语"
   ],
   "yii": [
     "Yidiny"
   ],
   "yij": [
     "因吉班迪語",
-    "Yindjibarndi"
+    "Yindjibarndi",
+    "因吉班迪语"
   ],
   "yik": [
     "東山壩臘羅語",
-    "Dongshanba Lalo"
+    "Dongshanba Lalo",
+    "东山坝腊罗语"
   ],
   "yil": [
     "Yindjilandji"
@@ -30401,7 +33209,8 @@
   ],
   "yit": [
     "東臘魯語",
-    "Eastern Lalu"
+    "Eastern Lalu",
+    "东腊鲁语"
   ],
   "yiu": [
     "Awu",
@@ -30422,7 +33231,8 @@
     "Yirrk-Mel",
     "Yirrk-Thangalkl",
     "Yir Thangedl",
-    "Yirr-Thangell"
+    "Yirr-Thangell",
+    "伊尔-约龙特语"
   ],
   "yiz": [
     "Azhe"
@@ -30430,13 +33240,17 @@
   "yka": [
     "亞坎語",
     "Yakan",
-    "雅坎語"
+    "雅坎語",
+    "亚坎语",
+    "雅坎语"
   ],
   "ykg": [
     "北尤卡吉爾語",
     "凍原尤卡吉爾語",
     "Northern Yukaghir",
-    "Tundra Yukaghir"
+    "Tundra Yukaghir",
+    "北尤卡吉尔语",
+    "冻原尤卡吉尔语"
   ],
   "yki": [
     "Yoke"
@@ -30455,7 +33269,9 @@
   "ykn": [
     "河東彝語",
     "跨恩斯話",
-    "Kua-nsi"
+    "Kua-nsi",
+    "河东彝语",
+    "跨恩斯话"
   ],
   "yko": [
     "Yasa"
@@ -30468,7 +33284,9 @@
   ],
   "yku": [
     "跨瑪斯話",
-    "松坪彝語"
+    "松坪彝語",
+    "跨玛斯话",
+    "松坪彝语"
   ],
   "yky": [
     "Yakoma",
@@ -30483,7 +33301,9 @@
   ],
   "yle": [
     "耶里多涅語",
-    "耶勒語"
+    "耶勒語",
+    "耶里多涅语",
+    "耶勒语"
   ],
   "ylg": [
     "Yelogu"
@@ -30491,7 +33311,8 @@
   "yli": [
     "昂古魯克亞利語",
     "Angguruk Yali",
-    "Northern Yali"
+    "Northern Yali",
+    "昂古鲁克亚利语"
   ],
   "yll": [
     "Yil"
@@ -30501,14 +33322,16 @@
   ],
   "yln": [
     "郎念布央語",
-    "Langnian Buyang"
+    "Langnian Buyang",
+    "郎念布央语"
   ],
   "ylo": [
     "Naluo Yi"
   ],
   "ylr": [
     "亞蘭加語",
-    "Yalarnnga"
+    "Yalarnnga",
+    "亚兰加语"
   ],
   "ylu": [
     "Aribwaung",
@@ -30524,7 +33347,8 @@
   ],
   "ymc": [
     "南木吉語",
-    "Southern Muji"
+    "Southern Muji",
+    "南木吉语"
   ],
   "ymd": [
     "Muda"
@@ -30562,18 +33386,21 @@
   ],
   "ymq": [
     "期臘木吉語",
-    "Qila Muji"
+    "Qila Muji",
+    "期腊木吉语"
   ],
   "ymr": [
     "Malasar"
   ],
   "yms": [
     "密細亞語",
-    "Mysian"
+    "Mysian",
+    "密细亚语"
   ],
   "ymx": [
     "北木吉語",
-    "Northern Muji"
+    "Northern Muji",
+    "北木吉语"
   ],
   "ymz": [
     "Muzi"
@@ -30583,7 +33410,8 @@
   ],
   "ynd": [
     "揚德魯萬塔語",
-    "Yandruwandha"
+    "Yandruwandha",
+    "扬德鲁万塔语"
   ],
   "yne": [
     "Lang'e"
@@ -30605,7 +33433,8 @@
   ],
   "yno": [
     "傣允語",
-    "Yong"
+    "Yong",
+    "傣允语"
   ],
   "yns": [
     "Yansi"
@@ -30616,22 +33445,26 @@
     "Yajuna"
   ],
   "yo": [
-    "約魯巴語"
+    "約魯巴語",
+    "约鲁巴语"
   ],
   "yob": [
     "Yoba"
   ],
   "yog": [
     "尤加德語",
-    "Yogad"
+    "Yogad",
+    "尤加德语"
   ],
   "yoi": [
     "與那國語",
-    "Yonaguni"
+    "Yonaguni",
+    "与那国语"
   ],
   "yol": [
     "約拉語",
-    "Yola"
+    "Yola",
+    "约拉语"
   ],
   "yom": [
     "Yombe"
@@ -30641,51 +33474,63 @@
   ],
   "yox": [
     "與論語",
-    "Yoron"
+    "Yoron",
+    "与论语"
   ],
   "yoy": [
     "堯依語",
-    "Yoy"
+    "Yoy",
+    "尧依语"
   ],
   "ypa": [
     "帕拉語",
-    "Phala"
+    "Phala",
+    "帕拉语"
   ],
   "ypb": [
     "拉波普佤語",
-    "Labo Phowa"
+    "Labo Phowa",
+    "拉波普佤语"
   ],
   "ypg": [
     "普拉語",
-    "Phola"
+    "Phola",
+    "普拉语"
   ],
   "yph": [
     "富帕語",
-    "Phupha"
+    "Phupha",
+    "富帕语"
   ],
   "ypk-pro": [
     "原始尤皮克語",
-    "Proto-Yupik"
+    "Proto-Yupik",
+    "原始尤皮克语"
   ],
   "ypm": [
     "富馬語",
-    "Phuma"
+    "Phuma",
+    "富马语"
   ],
   "ypn": [
     "阿尼普佤語",
-    "Ani Phowa"
+    "Ani Phowa",
+    "阿尼普佤语"
   ],
   "ypo": [
     "阿洛普拉語",
-    "Alo Phola"
+    "Alo Phola",
+    "阿洛普拉语"
   ],
   "ypp": [
     "富巴語",
-    "Phupa"
+    "Phupa",
+    "富巴语"
   ],
   "ypz": [
     "富匝語",
-    "Phuza"
+    "Phuza",
+    "富匝语"
   ],
   "yra": [
     "Yerakai"
@@ -30698,13 +33543,15 @@
   ],
   "yri": [
     "亞里語",
-    "Yarí"
+    "Yarí",
+    "亚里语"
   ],
   "yrk": [
     "凍原涅涅茨語",
     "Tundra Nenets",
     "Nenets",
-    "Yurak"
+    "Yurak",
+    "冻原涅涅茨语"
   ],
   "yrl": [
     "奈恩加圖語",
@@ -30712,11 +33559,13 @@
     "Nyengatú",
     "Língua Geral",
     "Geral",
-    "Yeral"
+    "Yeral",
+    "奈恩加图语"
   ],
   "yrn": [
     "耶容語",
-    "Yerong"
+    "Yerong",
+    "耶容语"
   ],
   "yro": [
     "Yaroamë",
@@ -30732,39 +33581,48 @@
   "yry": [
     "雅爾魯延迪語",
     "Yarluyandi",
-    "Yassic"
+    "Yassic",
+    "雅尔鲁延迪语"
   ],
   "ysc": [
     "雅西克語",
     "Jassic",
-    "Yassic"
+    "Yassic",
+    "雅西克语"
   ],
   "ysd": [
     "撒慕語",
     "撒馬多語",
     "Samatao",
     "Samu",
-    "Eastern Samadu"
+    "Eastern Samadu",
+    "撒慕语",
+    "撒马多语"
   ],
   "ysg": [
     "鎖內嘎話",
     "新峰彝語",
-    "Sonaga"
+    "Sonaga",
+    "锁内嘎话",
+    "新峰彝语"
   ],
   "ysl": [
     "南斯拉夫手語",
-    "Yugoslavian Sign Language"
+    "Yugoslavian Sign Language",
+    "南斯拉夫手语"
   ],
   "ysn": [
     "撒尼語",
-    "Sani"
+    "Sani",
+    "撒尼语"
   ],
   "yso": [
     "Nisi"
   ],
   "ysp": [
     "南倮倮潑語",
-    "Southern Lolopo"
+    "Southern Lolopo",
+    "南倮倮泼语"
   ],
   "ysr": [
     "Sirenik"
@@ -30776,16 +33634,19 @@
   ],
   "ysy": [
     "撒涅語",
-    "Sanie"
+    "Sanie",
+    "撒涅语"
   ],
   "yta": [
     "他留語",
-    "Talu"
+    "Talu",
+    "他留语"
   ],
   "ytl": [
     "堂郎語",
     "Tanglang",
-    "Tholo"
+    "Tholo",
+    "堂郎语"
   ],
   "ytp": [
     "Thopho"
@@ -30795,30 +33656,37 @@
   ],
   "yty": [
     "亞泰語",
-    "Yatay"
+    "Yatay",
+    "亚泰语"
   ],
   "yua": [
     "尤卡坦瑪雅語",
     "猶加敦馬雅語",
-    "Yucatec Maya"
+    "Yucatec Maya",
+    "尤卡坦玛雅语",
+    "犹加敦马雅语"
   ],
   "yub": [
     "尤甘巴爾語",
-    "Yugambal"
+    "Yugambal",
+    "尤甘巴尔语"
   ],
   "yuc": [
     "Yuchi"
   ],
   "yud": [
     "猶太的黎波里塔尼亞阿拉伯語",
-    "Judeo-Tripolitanian Arabic"
+    "Judeo-Tripolitanian Arabic",
+    "犹太的黎波里塔尼亚阿拉伯语"
   ],
   "yue": [
     "粵語",
     "Cantonese",
     "廣東話",
     "Yue",
-    "Yüeh"
+    "Yüeh",
+    "粤语",
+    "广东话"
   ],
   "yuf": [
     "Havasupai-Walapai-Yavapai"
@@ -30826,7 +33694,8 @@
   "yug": [
     "尤格語",
     "Yug",
-    "Yugh"
+    "Yugh",
+    "尤格语"
   ],
   "yui": [
     "Yurutí"
@@ -30870,7 +33739,8 @@
   ],
   "yur": [
     "尤羅克語",
-    "Yurok"
+    "Yurok",
+    "尤罗克语"
   ],
   "yut": [
     "Yopno"
@@ -30885,13 +33755,17 @@
     "森林尤卡吉爾語",
     "Southern Yukaghir",
     "Forest Yukaghir",
-    "Kolyma Yukaghir"
+    "Kolyma Yukaghir",
+    "南尤卡吉尔语",
+    "科雷马尤卡吉尔语",
+    "森林尤卡吉尔语"
   ],
   "yuy": [
     "東部裕固語",
     "East Yugur",
     "Eastern Yugur",
-    "Shera Yugur"
+    "Shera Yugur",
+    "东部裕固语"
   ],
   "yuz": [
     "Yuracare"
@@ -30910,11 +33784,13 @@
   ],
   "ywg": [
     "因哈旺卡語",
-    "Yinhawangka"
+    "Yinhawangka",
+    "因哈旺卡语"
   ],
   "ywl": [
     "西臘魯語",
-    "Western Lalu"
+    "Western Lalu",
+    "西腊鲁语"
   ],
   "ywn": [
     "Yawanawa"
@@ -30922,32 +33798,38 @@
   "ywq": [
     "納蘇語",
     "Nasu",
-    "Wuding-Luquan Yi"
+    "Wuding-Luquan Yi",
+    "纳苏语"
   ],
   "ywr": [
     "雅烏魯語",
-    "Yawuru"
+    "Yawuru",
+    "雅乌鲁语"
   ],
   "ywt": [
     "中臘羅語",
-    "Xishanba Lalo"
+    "Xishanba Lalo",
+    "中腊罗语"
   ],
   "ywu": [
     "烏蒙彝語",
     "Wumeng Nasu",
     "Wumeng Yi",
-    "Wusa Yi"
+    "Wusa Yi",
+    "乌蒙彝语"
   ],
   "yww": [
     "Yawarawarga"
   ],
   "yxa": [
     "馬亞瓦利語",
-    "Mayawali"
+    "Mayawali",
+    "马亚瓦利语"
   ],
   "yxg": [
     "亞加拉語",
-    "Yagara"
+    "Yagara",
+    "亚加拉语"
   ],
   "yxl": [
     "亞爾利語",
@@ -30955,49 +33837,62 @@
     "Yarli",
     "Yardliyawarra",
     "Wadikali",
-    "Malyangapa"
+    "Malyangapa",
+    "亚尔利语",
+    "亚尔德利亚瓦拉语"
   ],
   "yxm": [
     "因溫語",
-    "Yinwum"
+    "Yinwum",
+    "因温语"
   ],
   "yxu": [
     "尤尤語",
-    "Yuyu"
+    "Yuyu",
+    "尤尤语"
   ],
   "yxy": [
     "亞布拉亞布拉語",
     "Yabula Yabula",
     "Yabula-Yabula",
-    "Jabulajabula"
+    "Jabulajabula",
+    "亚布拉亚布拉语"
   ],
   "yyu": [
     "托里切利堯語",
     "堯語",
     "Torricelli Yau",
-    "Yau"
+    "Yau",
+    "托里切利尧语",
+    "尧语"
   ],
   "yyz": [
     "阿彝子語",
     "阿彝子話",
-    "Ayizi"
+    "Ayizi",
+    "阿彝子语",
+    "阿彝子话"
   ],
   "yzg": [
     "峨馬布央語",
-    "E'ma Buyang"
+    "E'ma Buyang",
+    "峨马布央语"
   ],
   "yzk": [
     "綽闊語",
-    "Zokhuo"
+    "Zokhuo",
+    "绰阔语"
   ],
   "za": [
-    "壯語"
+    "壯語",
+    "壮语"
   ],
   "zaa": [
     "胡亞雷斯山薩波特克語",
     "Sierra de Juárez Zapotec",
     "Ixtlán Zapotec",
-    "Atepec"
+    "Atepec",
+    "胡亚雷斯山萨波特克语"
   ],
   "zab": [
     "聖胡安格拉維亞薩波特克語",
@@ -31014,10 +33909,12 @@
     "Tlacolula de Matamoros Zapotec",
     "San Jerónimo Tlacochahuaya Zapotec",
     "Jalieza Zapotec",
-    "San Martín Tilcajete Zapotec"
+    "San Martín Tilcajete Zapotec",
+    "圣胡安格拉维亚萨波特克语"
   ],
   "zac": [
-    "奧科特蘭薩波特克語"
+    "奧科特蘭薩波特克語",
+    "奥科特兰萨波特克语"
   ],
   "zad": [
     "卡霍諾斯薩波特克語",
@@ -31025,25 +33922,30 @@
     "Southern Villa Alta Zapotec",
     "Yaganiza Zapotec",
     "Yaganiza-Xagacía Zapotec",
-    "San Mateo Zapotec"
+    "San Mateo Zapotec",
+    "卡霍诺斯萨波特克语"
   ],
   "zae": [
     "亞雷尼薩波特克語",
     "Yareni Zapotec",
     "Western Ixtlán Zapotec",
-    "Etla Zapotec"
+    "Etla Zapotec",
+    "亚雷尼萨波特克语"
   ],
   "zaf": [
-    "阿約克斯科薩波特克語"
+    "阿約克斯科薩波特克語",
+    "阿约克斯科萨波特克语"
   ],
   "zag": [
-    "札加瓦語"
+    "札加瓦語",
+    "札加瓦语"
   ],
   "zah": [
     "Zangwal"
   ],
   "zai": [
-    "地峽薩波特克語"
+    "地峽薩波特克語",
+    "地峡萨波特克语"
   ],
   "zaj": [
     "Zaramo"
@@ -31052,40 +33954,52 @@
     "Zanaki"
   ],
   "zal": [
-    "柔若語"
+    "柔若語",
+    "柔若语"
   ],
   "zam": [
-    "米亞瓦特蘭薩波特克語"
+    "米亞瓦特蘭薩波特克語",
+    "米亚瓦特兰萨波特克语"
   ],
   "zao": [
-    "奧索洛特佩克薩波特克語"
+    "奧索洛特佩克薩波特克語",
+    "奥索洛特佩克萨波特克语"
   ],
   "zap": [
-    "薩波特克語"
+    "薩波特克語",
+    "萨波特克语"
   ],
   "zaq": [
-    "阿洛阿帕姆薩波特克語"
+    "阿洛阿帕姆薩波特克語",
+    "阿洛阿帕姆萨波特克语"
   ],
   "zar": [
-    "林松薩波特克語"
+    "林松薩波特克語",
+    "林松萨波特克语"
   ],
   "zas": [
-    "聖多明各阿爾巴拉達斯薩波特克語"
+    "聖多明各阿爾巴拉達斯薩波特克語",
+    "圣多明各阿尔巴拉达斯萨波特克语"
   ],
   "zat": [
-    "塔巴薩波特克語"
+    "塔巴薩波特克語",
+    "塔巴萨波特克语"
   ],
   "zau": [
-    "藏斯卡語"
+    "藏斯卡語",
+    "藏斯卡语"
   ],
   "zav": [
-    "亞查奇薩波特克語"
+    "亞查奇薩波特克語",
+    "亚查奇萨波特克语"
   ],
   "zaw": [
-    "米特拉薩波特克語"
+    "米特拉薩波特克語",
+    "米特拉萨波特克语"
   ],
   "zax": [
-    "薩達尼薩波特克語"
+    "薩達尼薩波特克語",
+    "萨达尼萨波特克语"
   ],
   "zay": [
     "Zayse-Zergulla"
@@ -31094,26 +34008,32 @@
     "Zari"
   ],
   "zbt": [
-    "巴圖伊語"
+    "巴圖伊語",
+    "巴图伊语"
   ],
   "zca": [
-    "科亞特卡斯阿特拉斯薩波特克語"
+    "科亞特卡斯阿特拉斯薩波特克語",
+    "科亚特卡斯阿特拉斯萨波特克语"
   ],
   "zdj": [
-    "大科摩羅語"
+    "大科摩羅語",
+    "大科摩罗语"
   ],
   "zea": [
     "澤蘭語",
-    "Zealandic"
+    "Zealandic",
+    "泽兰语"
   ],
   "zeg": [
     "Zenag"
   ],
   "zeh": [
-    "東紅水河壯語"
+    "東紅水河壯語",
+    "东红水河壮语"
   ],
   "zen": [
-    "澤納加語"
+    "澤納加語",
+    "泽纳加语"
   ],
   "zga": [
     "Kinga"
@@ -31125,12 +34045,14 @@
     "Standard Moroccan Amazigh",
     "Standard Moroccan Berber",
     "Amazigh",
-    "Tamazight"
+    "Tamazight",
+    "标准摩洛哥柏柏尔语"
   ],
   "zgm": [
     "民講",
     "Min Zhuang",
-    "Minz Zhuang"
+    "Minz Zhuang",
+    "民讲"
   ],
   "zgr": [
     "Magori"
@@ -31139,7 +34061,10 @@
     "漢語",
     "Chinese",
     "現代漢語",
-    "現代標準漢語"
+    "現代標準漢語",
+    "汉语",
+    "现代汉语",
+    "现代标准汉语"
   ],
   "zhb": [
     "Zhaba"
@@ -31148,14 +34073,16 @@
     "Zhire"
   ],
   "zhn": [
-    "儂壯語"
+    "儂壯語",
+    "侬壮语"
   ],
   "zhw": [
     "Zhoa"
   ],
   "zhx-min-pro": [
     "原始閩語",
-    "Proto-Min"
+    "Proto-Min",
+    "原始闽语"
   ],
   "zhx-sht": [
     "韶州土話",
@@ -31163,23 +34090,29 @@
     "Xiangnan Tuhua",
     "Yuebei Tuhua",
     "Shipo",
-    "Shina"
+    "Shina",
+    "韶州土话"
   ],
   "zhx-sjc": [
     "邵將語",
     "邵將話",
     "邵將閩語",
-    "Shao-Jiang Min"
+    "Shao-Jiang Min",
+    "邵将语",
+    "邵将话",
+    "邵将闽语"
   ],
   "zhx-tai": [
     "台山話",
     "Taishanese",
-    "Toishanese"
+    "Toishanese",
+    "台山话"
   ],
   "zhx-teo": [
     "潮州話",
     "Teochew",
-    "Chiuchow"
+    "Chiuchow",
+    "潮州话"
   ],
   "zia": [
     "Zia"
@@ -31187,7 +34120,9 @@
   "zib": [
     "津巴布韋手語",
     "辛巴威手語",
-    "Zimbabwe Sign Language"
+    "Zimbabwe Sign Language",
+    "津巴布韦手语",
+    "辛巴威手语"
   ],
   "zik": [
     "Zimakani"
@@ -31215,24 +34150,28 @@
   ],
   "zkb": [
     "科伊巴爾語",
-    "Koibal"
+    "Koibal",
+    "科伊巴尔语"
   ],
   "zkg": [
     "高句麗語",
-    "Goguryeo"
+    "Goguryeo",
+    "高句丽语"
   ],
   "zkh": [
     "花剌子模突厥語",
     "Khorezmian Turkic",
     "Khorezmian",
-    "Khorezmian-Turkic"
+    "Khorezmian-Turkic",
+    "花剌子模突厥语"
   ],
   "zkk": [
     "Karankawa"
   ],
   "zko": [
     "科特語",
-    "Kott"
+    "Kott",
+    "科特语"
   ],
   "zkp": [
     "São Paulo Kaingáng"
@@ -31242,65 +34181,82 @@
   ],
   "zkt": [
     "契丹語",
-    "Khitan"
+    "Khitan",
+    "契丹语"
   ],
   "zku": [
     "考爾納語",
     "加雲拿語",
-    "Kaurna"
+    "Kaurna",
+    "考尔纳语",
+    "加云拿语"
   ],
   "zkv": [
     "Krevinian"
   ],
   "zkz": [
     "可薩語",
-    "Khazar"
+    "Khazar",
+    "可萨语"
   ],
   "zle-ono": [
     "古諾夫哥羅德語",
-    "Old Novgorodian"
+    "Old Novgorodian",
+    "古诺夫哥罗德语"
   ],
   "zle-ort": [
     "古盧森尼亞語",
     "羅塞尼亞語",
     "魯塞尼亞語",
-    "Old Ruthenian"
+    "Old Ruthenian",
+    "古卢森尼亚语",
+    "罗塞尼亚语",
+    "鲁塞尼亚语"
   ],
   "zlw-ocs": [
     "古捷克語",
-    "Old Czech"
+    "Old Czech",
+    "古捷克语"
   ],
   "zlw-opl": [
     "古波蘭語",
-    "Old Polish"
+    "Old Polish",
+    "古波兰语"
   ],
   "zlw-pom": [
     "波美拉尼亞語",
-    "Pomeranian"
+    "Pomeranian",
+    "波美拉尼亚语"
   ],
   "zlw-slv": [
     "斯洛溫語",
-    "Slovincian"
+    "Slovincian",
+    "斯洛温语"
   ],
   "zma": [
     "曼達語（澳洲）",
-    "Manda (Australia)"
+    "Manda (Australia)",
+    "曼达语（澳洲）"
   ],
   "zmb": [
     "津巴語",
-    "Zimba"
+    "Zimba",
+    "津巴语"
   ],
   "zmc": [
     "馬爾加尼語",
-    "Margany"
+    "Margany",
+    "马尔加尼语"
   ],
   "zmd": [
     "馬里丹語",
-    "Maridan"
+    "Maridan",
+    "马里丹语"
   ],
   "zme": [
     "曼格爾語",
-    "Mangerr"
+    "Mangerr",
+    "曼格尔语"
   ],
   "zmf": [
     "Mfinu"
@@ -31313,22 +34269,26 @@
   ],
   "zmi": [
     "森美蘭馬來語",
-    "Negeri Sembilan Malay"
+    "Negeri Sembilan Malay",
+    "森美兰马来语"
   ],
   "zmj": [
     "馬里提亞賓語",
-    "Maridjabin"
+    "Maridjabin",
+    "马里提亚宾语"
   ],
   "zmk": [
     "曼丹達尼語",
-    "Mandandanyi"
+    "Mandandanyi",
+    "曼丹达尼语"
   ],
   "zml": [
     "Madngele"
   ],
   "zmm": [
     "馬里馬寧迪語",
-    "Marimanindji"
+    "Marimanindji",
+    "马里马宁迪语"
   ],
   "zmn": [
     "Mbangwe"
@@ -31343,21 +34303,25 @@
     "Mituku"
   ],
   "zmr": [
-    "馬拉農庫語"
+    "馬拉農庫語",
+    "马拉农库语"
   ],
   "zms": [
     "Mbesa"
   ],
   "zmt": [
     "馬林加爾語",
-    "Maringarr"
+    "Maringarr",
+    "马林加尔语"
   ],
   "zmu": [
     "穆魯瓦里語",
-    "Muruwari"
+    "Muruwari",
+    "穆鲁瓦里语"
   ],
   "zmv": [
-    "姆巴里曼-古丁馬語"
+    "姆巴里曼-古丁馬語",
+    "姆巴里曼-古丁马语"
   ],
   "zmw": [
     "Mbo (Congo)"
@@ -31367,7 +34331,8 @@
   ],
   "zmy": [
     "馬里耶迪語",
-    "Mariyedi"
+    "Mariyedi",
+    "马里耶迪语"
   ],
   "zmz": [
     "Mbandja"
@@ -31382,115 +34347,151 @@
     "Mang"
   ],
   "znk": [
-    "馬南卡利語"
+    "馬南卡利語",
+    "马南卡利语"
   ],
   "zns": [
     "Mangas"
   ],
   "zoc": [
-    "克派納拉索克語"
+    "克派納拉索克語",
+    "克派纳拉索克语"
   ],
   "zoh": [
-    "奇馬拉帕索克語"
+    "奇馬拉帕索克語",
+    "奇马拉帕索克语"
   ],
   "zom": [
-    "卓米語"
+    "卓米語",
+    "卓米语"
   ],
   "zoo": [
-    "亞松森-米斯特佩克薩波特克語"
+    "亞松森-米斯特佩克薩波特克語",
+    "亚松森-米斯特佩克萨波特克语"
   ],
   "zoq": [
-    "塔巴斯科索克語"
+    "塔巴斯科索克語",
+    "塔巴斯科索克语"
   ],
   "zor": [
-    "拉永索克語"
+    "拉永索克語",
+    "拉永索克语"
   ],
   "zos": [
-    "弗朗西斯科里昂索克語"
+    "弗朗西斯科里昂索克語",
+    "弗朗西斯科里昂索克语"
   ],
   "zpa": [
-    "拉奇吉里薩波特克語"
+    "拉奇吉里薩波特克語",
+    "拉奇吉里萨波特克语"
   ],
   "zpb": [
-    "亞烏特佩克薩波特克語"
+    "亞烏特佩克薩波特克語",
+    "亚乌特佩克萨波特克语"
   ],
   "zpc": [
-    "喬亞潘薩波特克語"
+    "喬亞潘薩波特克語",
+    "乔亚潘萨波特克语"
   ],
   "zpd": [
-    "東南伊斯特蘭薩波特克語"
+    "東南伊斯特蘭薩波特克語",
+    "东南伊斯特兰萨波特克语"
   ],
   "zpe": [
-    "佩塔帕薩波特克語"
+    "佩塔帕薩波特克語",
+    "佩塔帕萨波特克语"
   ],
   "zpf": [
-    "聖佩德羅基亞托尼薩波特克語"
+    "聖佩德羅基亞托尼薩波特克語",
+    "圣佩德罗基亚托尼萨波特克语"
   ],
   "zpg": [
-    "格韋亞德洪堡薩波特克語"
+    "格韋亞德洪堡薩波特克語",
+    "格韦亚德洪堡萨波特克语"
   ],
   "zph": [
-    "托托馬查潘薩波特克語"
+    "托托馬查潘薩波特克語",
+    "托托马查潘萨波特克语"
   ],
   "zpi": [
-    "聖瑪利亞基耶戈拉尼薩波特克語"
+    "聖瑪利亞基耶戈拉尼薩波特克語",
+    "圣玛利亚基耶戈拉尼萨波特克语"
   ],
   "zpj": [
-    "基亞維庫薩斯薩波特克語"
+    "基亞維庫薩斯薩波特克語",
+    "基亚维库萨斯萨波特克语"
   ],
   "zpk": [
-    "特拉科盧利塔薩波特克語"
+    "特拉科盧利塔薩波特克語",
+    "特拉科卢利塔萨波特克语"
   ],
   "zpl": [
-    "拉奇西奧薩波特克語"
+    "拉奇西奧薩波特克語",
+    "拉奇西奥萨波特克语"
   ],
   "zpm": [
-    "米斯特佩克薩波特克語"
+    "米斯特佩克薩波特克語",
+    "米斯特佩克萨波特克语"
   ],
   "zpn": [
-    "聖伊內斯亞切奇薩波特克語"
+    "聖伊內斯亞切奇薩波特克語",
+    "圣伊内斯亚切奇萨波特克语"
   ],
   "zpo": [
-    "阿馬特蘭薩波特克語"
+    "阿馬特蘭薩波特克語",
+    "阿马特兰萨波特克语"
   ],
   "zpp": [
-    "阿爾托薩波特克語"
+    "阿爾托薩波特克語",
+    "阿尔托萨波特克语"
   ],
   "zpq": [
-    "蘇戈喬薩波特克語"
+    "蘇戈喬薩波特克語",
+    "苏戈乔萨波特克语"
   ],
   "zpr": [
-    "聖地亞哥薩尼卡薩波特克語"
+    "聖地亞哥薩尼卡薩波特克語",
+    "圣地亚哥萨尼卡萨波特克语"
   ],
   "zps": [
-    "科亞特蘭薩波特克語"
+    "科亞特蘭薩波特克語",
+    "科亚特兰萨波特克语"
   ],
   "zpt": [
-    "聖比森特科亞特蘭薩波特克語"
+    "聖比森特科亞特蘭薩波特克語",
+    "圣比森特科亚特兰萨波特克语"
   ],
   "zpu": [
-    "亞拉拉格薩波特克語"
+    "亞拉拉格薩波特克語",
+    "亚拉拉格萨波特克语"
   ],
   "zpv": [
-    "奇奇卡潘薩波特克語"
+    "奇奇卡潘薩波特克語",
+    "奇奇卡潘萨波特克语"
   ],
   "zpw": [
-    "薩尼薩薩波特克語"
+    "薩尼薩薩波特克語",
+    "萨尼萨萨波特克语"
   ],
   "zpx": [
-    "聖巴爾塔扎洛希查薩波特克語"
+    "聖巴爾塔扎洛希查薩波特克語",
+    "圣巴尔塔扎洛希查萨波特克语"
   ],
   "zpy": [
-    "馬薩爾特佩克薩波特克語"
+    "馬薩爾特佩克薩波特克語",
+    "马萨尔特佩克萨波特克语"
   ],
   "zpz": [
-    "特斯梅盧坎薩波特克語"
+    "特斯梅盧坎薩波特克語",
+    "特斯梅卢坎萨波特克语"
   ],
   "zra": [
-    "伽耶語"
+    "伽耶語",
+    "伽耶语"
   ],
   "zrg": [
-    "米爾甘語"
+    "米爾甘語",
+    "米尔甘语"
   ],
   "zrn": [
     "Zirenkel"
@@ -31511,49 +34512,63 @@
     "Zambian Sign Language"
   ],
   "zsr": [
-    "南林松薩波特克語"
+    "南林松薩波特克語",
+    "南林松萨波特克语"
   ],
   "zsu": [
     "Sukurum"
   ],
   "zte": [
-    "埃洛特佩克薩波特克語"
+    "埃洛特佩克薩波特克語",
+    "埃洛特佩克萨波特克语"
   ],
   "ztg": [
-    "薩那吉亞薩波特克語"
+    "薩那吉亞薩波特克語",
+    "萨那吉亚萨波特克语"
   ],
   "ztl": [
-    "聖地亞哥拉帕吉亞薩波特克語"
+    "聖地亞哥拉帕吉亞薩波特克語",
+    "圣地亚哥拉帕吉亚萨波特克语"
   ],
   "ztm": [
-    "聖阿古斯丁米斯特佩克薩波特克語"
+    "聖阿古斯丁米斯特佩克薩波特克語",
+    "圣阿古斯丁米斯特佩克萨波特克语"
   ],
   "ztn": [
-    "聖卡塔里納阿爾巴拉達斯薩波特克語"
+    "聖卡塔里納阿爾巴拉達斯薩波特克語",
+    "圣卡塔里纳阿尔巴拉达斯萨波特克语"
   ],
   "ztp": [
-    "洛希查薩波特克語"
+    "洛希查薩波特克語",
+    "洛希查萨波特克语"
   ],
   "ztq": [
-    "基奧基塔尼-基耶里薩波特克語"
+    "基奧基塔尼-基耶里薩波特克語",
+    "基奥基塔尼-基耶里萨波特克语"
   ],
   "zts": [
-    "蒂爾基亞潘薩波特克語"
+    "蒂爾基亞潘薩波特克語",
+    "蒂尔基亚潘萨波特克语"
   ],
   "ztt": [
-    "特哈拉潘薩波特克語"
+    "特哈拉潘薩波特克語",
+    "特哈拉潘萨波特克语"
   ],
   "ztu": [
-    "古伊拉薩波特克語"
+    "古伊拉薩波特克語",
+    "古伊拉萨波特克语"
   ],
   "ztx": [
-    "薩奇拉薩波特克語"
+    "薩奇拉薩波特克語",
+    "萨奇拉萨波特克语"
   ],
   "zty": [
-    "亞蒂薩波特克語"
+    "亞蒂薩波特克語",
+    "亚蒂萨波特克语"
   ],
   "zu": [
-    "祖魯語"
+    "祖魯語",
+    "祖鲁语"
   ],
   "zua": [
     "Zeem"
@@ -31562,24 +34577,29 @@
     "Tokano"
   ],
   "zum": [
-    "孔扎里語"
+    "孔扎里語",
+    "孔扎里语"
   ],
   "zun": [
-    "祖尼語"
+    "祖尼語",
+    "祖尼语"
   ],
   "zuy": [
     "Zumaya"
   ],
   "zwa": [
-    "扎伊語"
+    "扎伊語",
+    "扎伊语"
   ],
   "zyp": [
     "Zyphe"
   ],
   "zza": [
-    "扎扎其語"
+    "扎扎其語",
+    "扎扎其语"
   ],
   "zzj": [
-    "左江壯語"
+    "左江壯語",
+    "左江壮语"
   ]
 }

--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -2766,9 +2766,9 @@ def fix_subtitle_hierarchy(ctx: Wtp, config: WiktionaryConfig, text: str) -> str
             level = 5
         elif lc in config.LINKAGE_SUBTITLES or lc == config.OTHER_SUBTITLES["compounds"]:
             level = 5
-        elif title in config.OTHER_SUBTITLES["inflection_sections"]:
+        elif lc in config.OTHER_SUBTITLES["inflection_sections"]:
             level = 5
-        elif title in config.OTHER_SUBTITLES["ignored_sections"]:
+        elif lc in config.OTHER_SUBTITLES["ignored_sections"]:
             level = 5
         else:
             level = 6


### PR DESCRIPTION
All titles are changed to lower case in the `other_subtitles.json` file in the previous commit.

I also add simplified language names for the Chinese Wiktionary.