### PR TITLE
Top-level template name parsing as usable data

### DIFF
--- a/wiktextract/inflection.py
+++ b/wiktextract/inflection.py
@@ -2366,9 +2366,11 @@ class TableContext(object):
     """Saved context used when parsing a table and its subtables."""
     __slot__ = (
         "stored_hdrspans",
+        "template_name",
         )
-    def __init__(self):
+    def __init__(self, template_name=None):
         self.stored_hdrspans = []
+        self.template_name = template_name
 
 def handle_wikitext_table(config, ctx, word, lang, pos,
                           data, tree, titles, source, after):

--- a/wiktextract/inflectiondata.py
+++ b/wiktextract/inflectiondata.py
@@ -6157,6 +6157,11 @@ def check_v(k, v):
                 if not isinstance(v[kk], (int, list, tuple)):
                     print("infl_map[{!r}] contains invalid depth-value "
                                 "{!r}".format(k, v[kk]))
+            elif kk == "inflection-template":
+                if not isinstance(v[kk], (str, list, tuple)):
+                    print("infl_map[{!r}] contains invalid"
+                          "inflection-template value "
+                                "{!r}".format(k, v[kk]))
             else:
                 print("infl_map[{!r}] contains invalid key {!r}"
                       .format(k, kk))

--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -21,7 +21,7 @@ from .tags import valid_tags
 from wiktextract.form_descriptions import (
     decode_tags, parse_word_head, parse_sense_qualifier,
     distw, parse_alt_or_inflection_of, classify_desc)
-from wiktextract.inflection import parse_inflection_section
+from wiktextract.inflection import parse_inflection_section, TableContext
 
 # NodeKind values for subtitles
 LEVEL_KINDS = (NodeKind.LEVEL2, NodeKind.LEVEL3, NodeKind.LEVEL4,
@@ -1833,8 +1833,13 @@ def parse_language(ctx, config, langnode, language, lang_code):
             # Parse inflection tables from the section.  The data is stored
             # under "forms".
             if config.capture_inflections:
-                parse_inflection_section(config, ctx, pos_data, word, language,
-                                         pos, section, tree)
+                template_name = re.search("{{([^}{\|]+)\|", text).group(1)
+                tblctx = TableContext(template_name)
+                    
+                parse_inflection_section(config, ctx, pos_data,
+                                         word, language,
+                                         pos, section, tree,
+                                         tblctx=tblctx)
 
     def get_subpage_section(title, subtitle, seq):
         """Loads a subpage of the given page, and finds the section

--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -1776,14 +1776,65 @@ def parse_language(ctx, config, langnode, language, lang_code):
         # Convert the subtree back to Wikitext, then expand all and parse,
         # capturing templates in the process
         text = ctx.node_to_wikitext(node.children)
-        tree = ctx.parse(text, expand_all=True,
-                         template_fn=inflection_template_fn)
 
-        # Parse inflection tables from the section.  The data is stored
-        # under "forms".
-        if config.capture_inflections:
-            parse_inflection_section(config, ctx, pos_data, word, language,
-                                     pos, section, tree)
+        # Split text into separate sections for each to-level template
+        brace_matches = re.split("({{|}})", text) # ["{{", "template", "}}"]
+
+        template_sections = []
+        
+        if len(brace_matches) > 1:
+            tsection = []
+            after_templates = False  # kludge to keep any text
+                                     # before first template
+                                     # with the first template;
+                                     # otherwise, text
+                                     # goes with preceding template
+            template_nesting = 0  # depth of {{ {{ nesting }} }}
+            for m in brace_matches:
+                if m == "{{":
+                    if (template_nesting == 0 and
+                        after_templates):
+                        template_sections.append(tsection)
+                        tsection = []
+                        # start new section
+                    after_templates = True
+                    template_nesting += 1
+                    tsection.append(m)
+                elif m == "}}":
+                    template_nesting -= 1
+                    if template_nesting < 0:
+                        ctx.error("Couldn't split inflection templates,"
+                                  "{}/{} section {}"
+                                  .format(word, language, section))
+                        template_sections = [] # use whole text
+                        break
+                    tsection.append(m)
+                else:
+                    tsection.append(m)
+            if tsection:  # dangling tsection
+                template_sections.append(tsection)
+                # Why do it this way around? The parser has a preference
+                # to associate bits outside of tables with the preceding
+                # table (`after`-variable), so a new tsection begins
+                # at {{ and everything before it belongs to the previous
+                # template.
+        
+        texts = []
+        if not template_sections:
+            texts = [text]
+        else:
+            for tsection in template_sections:
+                texts.append("".join(tsection))
+
+        for text in texts:
+            tree = ctx.parse(text, expand_all=True,
+                             template_fn=inflection_template_fn)
+    
+            # Parse inflection tables from the section.  The data is stored
+            # under "forms".
+            if config.capture_inflections:
+                parse_inflection_section(config, ctx, pos_data, word, language,
+                                         pos, section, tree)
 
     def get_subpage_section(title, subtitle, seq):
         """Loads a subpage of the given page, and finds the section

--- a/wiktextract/tags.py
+++ b/wiktextract/tags.py
@@ -5839,6 +5839,7 @@ valid_tags = {
     "synonym": "misc",
     "synonym-of": "misc",
     "table-tags": "detail",  # Tags from inflection table, for all entries
+    "inflection-template": "detail",  # Name of top-level template
     "taboo": "misc",
     "tafa-form": "misc",  # Malagasy verbs
     "temporal": "misc",  # relating to time/tense, e.g., talamaq; Finnish adverbials


### PR DESCRIPTION
Implemented here:

* page/parse_inflection now splits the to-be-parsed text into sections with one top-level template each
  * including text after the template (and for the first template, text before it)
* this enables us to pass down the name of those templates (if any) using a TableContext object to the parsing routines
  * added new field into output-json alongside the `table-tags`-tagged form field called `inflection-template` with the name
  * added a new infl_map condition called `inflection-template` which evaluates as true when TableContext.template_name is in or equal to its value

This allows us to more easily debug issues with templates (less hunting down) and to finally have infl_map rules that handle single top-level templates without disturbing anything else. This is a weapon of last resort, when there are just too many contradicting possibilities.