### PR TITLE
Pre-expand Chinese Wiktionary POS template and add more POS heading text

### DIFF
--- a/wiktextract/data/zh/linkage_subtitles.json
+++ b/wiktextract/data/zh/linkage_subtitles.json
@@ -1,6 +1,8 @@
 {
   "近義詞": "synonyms",
   "近义词": "synonyms",
+  "反義詞": "antonyms",
+  "反义词": "antonyms",
   "同義詞": "synonyms",
   "同义词": "synonyms",
   "派生詞彙": "derived",

--- a/wiktextract/data/zh/pos_subtitles.json
+++ b/wiktextract/data/zh/pos_subtitles.json
@@ -6,6 +6,31 @@
       "abbreviation"
     ]
   },
+  "縮寫": {
+    "pos": "abbrev",
+    "tags": [
+      "abbreviation"
+    ]
+  },
+  "首字母縮略字": {
+    "pos": "abbrev",
+    "debug": "part-of-speech Initialism is proscribed",
+    "tags": [
+      "abbreviation"
+    ]
+  },
+  "首字母缩略词": {
+    "pos": "abbrev",
+    "tags": [
+      "abbreviation"
+    ]
+  },
+  "缩约形": {
+    "pos": "abbrev",
+    "tags": [
+      "abbreviation"
+    ]
+  },
   "形容詞": {
     "pos": "adj"
   },
@@ -80,14 +105,10 @@
       "morpheme"
     ]
   },
-  "首字母縮略字": {
-    "pos": "abbrev",
-    "debug": "part-of-speech Initialism is proscribed",
-    "tags": [
-      "abbreviation"
-    ]
-  },
   "感嘆詞": {
+    "pos": "intj"
+  },
+  "叹词": {
     "pos": "intj"
   },
   "不及物動詞": {
@@ -162,6 +183,12 @@
   "介詞": {
     "pos": "prep"
   },
+  "介词": {
+    "pos": "prep"
+  },
+  "介系詞": {
+    "pos": "prep"
+  },
   "代詞": {
     "pos": "pron"
   },
@@ -169,6 +196,9 @@
     "pos": "pron"
   },
   "專有名詞": {
+    "pos": "name"
+  },
+  "专有名词": {
     "pos": "name"
   },
   "成語": {
@@ -214,7 +244,16 @@
   "符號": {
     "pos": "symbol"
   },
+  "符号": {
+    "pos": "symbol"
+  },
   "及物动词": {
+    "pos": "verb",
+    "tags": [
+      "transitive"
+    ]
+  },
+  "及物動詞": {
     "pos": "verb",
     "tags": [
       "transitive"

--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -3013,7 +3013,9 @@ def parse_page(ctx: Wtp, word: str, text: str, config: WiktionaryConfig) -> list
     text = re.sub(r"(?si)<\s*(/\s*)?includeonly\s*>", "", text)
 
     # Expand Chinese Wiktionary language and POS heading templates
-    if config.dump_file_lang_code == "zh" and "{{-" in text:
+    # Language templates: https://zh.wiktionary.org/wiki/Category:语言模板
+    # POS templates: https://zh.wiktionary.org/wiki/Category:詞類模板
+    if config.dump_file_lang_code == "zh" and ("{{-" in text or "{{=" in text):
         text = ctx.expand(text, pre_expand=True)
 
     # Fix up the subtitle hierarchy.  There are hundreds if not thousands of

--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -2874,7 +2874,7 @@ def parse_top_template(config, ctx, node, data):
             return ""
         if name in ("reconstruction",):
             return ""
-        if name == "also":
+        if name.lower() == "also":
             # XXX shows related words that might really have been the intended
             # word, capture them
             return ""


### PR DESCRIPTION
This pull request adds some missing POS and linkage heading texts for Chinese Wiktionary and pre-expands POS heading templates whose names start with "=" like [=n=](https://zh.wiktionary.org/wiki/Template:=n=).