### PR TITLE
Add Windows VS Code instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ pages
 .coverage*
 kj-wiktwords.sh
 tmp/
+.venv/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -357,6 +357,21 @@ updated regularly with the latest Wiktionary dump.  Using the
 pre-extracted data may be the easiest option unless you have special
 needs or want to modify the code.
 
+### Installing and running tests on Windows with VS Code
+
+1. Create [a Python virtual environment](https://code.visualstudio.com/docs/python/environments#_creating-environments)
+(venv) in the VS Code workspace with the cloned repo.
+
+2. Open a PowerShell teminal. You may need to [fix terminal permissions](https://stackoverflow.com/questions/56199111/visual-studio-code-cmd-error-cannot-be-loaded-because-running-scripts-is-disabl/67420296#67420296) 
+in order for it to pick up the virtual environment correclty.
+
+3. In the terminal run these commands:
+
+```
+pip install -r requirements.txt
+py -m nose
+```
+
 ## Using the command-line tool
 
 The ``wiktwords`` script is the easiest way to extract data from

--- a/README.md
+++ b/README.md
@@ -323,12 +323,12 @@ This software requires Python 3.
 ### Running tests
 
 This package includes tests written using the ``unittest`` framework.
-They can be run using, for example, ``nose``, which can be installed
-using ``pip3 install nose``.
+They can be run using, for example, ``nose2``, which can be installed
+using ``pip3 install nose2``.
 
 To run the tests, just use the following command in the top-level directory:
 ```
-nosetests
+nose2
 ```
 
 (Unfortunately the test suite for ``wiktextract`` is not yet very
@@ -359,7 +359,7 @@ needs or want to modify the code.
 
 ### Installing and running tests on Windows with VS Code
 
-Tried with Python 3.9.4, newer versions of Python break `nose` tests.
+Tested with Python 3.9.4.
 
 1. Edit `requirements.txt`, replace `wikitextprocessor` line with
 `git+https://github.com/tatuylonen/wikitextprocessor.git`. This is in order to
@@ -372,10 +372,10 @@ install the packages based on `requirements.txt`.
 3. Open a new terminal. It should be PowerShell. You may need to [fix terminal permissions](https://stackoverflow.com/questions/56199111/visual-studio-code-cmd-error-cannot-be-loaded-because-running-scripts-is-disabl/67420296#67420296) 
 in order for it to pick up the virtual environment correclty.
 
-4. In the terminal run these commands:
+4. In the terminal run this command:
 
 ```
-py -m nose
+py -m nose2 -B
 ```
 
 ## Using the command-line tool

--- a/README.md
+++ b/README.md
@@ -359,16 +359,22 @@ needs or want to modify the code.
 
 ### Installing and running tests on Windows with VS Code
 
-1. Create [a Python virtual environment](https://code.visualstudio.com/docs/python/environments#_creating-environments)
-(venv) in the VS Code workspace with the cloned repo.
+Tried with Python 3.9.4, newer versions of Python break `nose` tests.
 
-2. Open a PowerShell teminal. You may need to [fix terminal permissions](https://stackoverflow.com/questions/56199111/visual-studio-code-cmd-error-cannot-be-loaded-because-running-scripts-is-disabl/67420296#67420296) 
+1. Edit `requirements.txt`, replace `wikitextprocessor` line with
+`git+https://github.com/tatuylonen/wikitextprocessor.git`. This is in order to
+depend on the latest `wikitextprocessor` code from GitHub.
+
+2. Create [a Python virtual environment](https://code.visualstudio.com/docs/python/environments#_creating-environments)
+(venv) in the VS Code workspace with the cloned repo. It should automatically
+install the packages based on `requirements.txt`.
+
+3. Open a new terminal. It should be PowerShell. You may need to [fix terminal permissions](https://stackoverflow.com/questions/56199111/visual-studio-code-cmd-error-cannot-be-loaded-because-running-scripts-is-disabl/67420296#67420296) 
 in order for it to pick up the virtual environment correclty.
 
-3. In the terminal run these commands:
+4. In the terminal run these commands:
 
 ```
-pip install -r requirements.txt
 py -m nose
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-nose
+nose2
 python-Levenshtein
-wikitextprocessor
 nltk
+
+wikitextprocessor
+# For development replace the above line with the direct git dependecy below.
+# These packages are being developed in parallel.
+# git+https://github.com/tatuylonen/wikitextprocessor.git


### PR DESCRIPTION
I was able to run tests via VS Code on Windows following these instructions. 

There is only one error, related to bz2 decompression, no `/bin/sh`, but that's a known problem on Windows, I'll try to fix it next, so that all tests can pass.