### PR TITLE
Add languages.json for Czech and Slovak

### DIFF
--- a/wiktextract/data/cs/languages.json
+++ b/wiktextract/data/cs/languages.json
@@ -1,0 +1,1019 @@
+{
+  "aa": [
+    "afarština"
+  ],
+  "aau": [
+    "abauština"
+  ],
+  "ab": [
+    "abcházština"
+  ],
+  "abe": [
+    "abenakština"
+  ],
+  "ady": [
+    "adygejština"
+  ],
+  "af": [
+    "afrikánština"
+  ],
+  "ain": [
+    "ainština"
+  ],
+  "ak": [
+    "akanština"
+  ],
+  "ale": [
+    "aleutština"
+  ],
+  "als": [
+    "alsaština"
+  ],
+  "alt": [
+    "jižní altajština"
+  ],
+  "am": [
+    "amharština"
+  ],
+  "an": [
+    "aragonština"
+  ],
+  "ang": [
+    "staroangličtina"
+  ],
+  "ar": [
+    "arabština"
+  ],
+  "arc": [
+    "aramejština"
+  ],
+  "arn": [
+    "araukánština"
+  ],
+  "arz": [
+    "egyptská arabština"
+  ],
+  "as": [
+    "asámština"
+  ],
+  "ast": [
+    "asturština"
+  ],
+  "atv": [
+    "severní altajština"
+  ],
+  "av": [
+    "avarština"
+  ],
+  "avk": [
+    "kotava"
+  ],
+  "ay": [
+    "ajmarština"
+  ],
+  "az": [
+    "ázerbájdžánština"
+  ],
+  "azb": [
+    "jižní ázerbájdžánština"
+  ],
+  "ba": [
+    "baškirština"
+  ],
+  "bal": [
+    "balúčština"
+  ],
+  "bar": [
+    "bavorština"
+  ],
+  "bcl": [
+    "bikolanština"
+  ],
+  "be": [
+    "běloruština"
+  ],
+  "bem": [
+    "bembština"
+  ],
+  "bg": [
+    "bulharština"
+  ],
+  "bi": [
+    "bislamština"
+  ],
+  "bjn": [
+    "bandžárština"
+  ],
+  "bm": [
+    "bambarština"
+  ],
+  "bn": [
+    "bengálština"
+  ],
+  "bo": [
+    "tibetština"
+  ],
+  "bpy": [
+    "bišnuprijskomanipurština"
+  ],
+  "br": [
+    "bretonština"
+  ],
+  "bs": [
+    "bosenština"
+  ],
+  "bxr": [
+    "burjatština"
+  ],
+  "ca": [
+    "katalánština"
+  ],
+  "cab": [
+    "garífuna"
+  ],
+  "ce": [
+    "čečenština"
+  ],
+  "ceb": [
+    "cebuánština"
+  ],
+  "ch": [
+    "čamorština"
+  ],
+  "chg": [
+    "čagatajština"
+  ],
+  "chk": [
+    "čukština"
+  ],
+  "chp": [
+    "čipevajština"
+  ],
+  "chr": [
+    "čerokézština"
+  ],
+  "cim": [
+    "cimbriština"
+  ],
+  "cjs": [
+    "šorština"
+  ],
+  "ckb": [
+    "středokurdština"
+  ],
+  "ckt": [
+    "čukština"
+  ],
+  "co": [
+    "korsičtina"
+  ],
+  "cps": [
+    "kapiznonština"
+  ],
+  "crh": [
+    "krymská tatarština"
+  ],
+  "cs": [
+    "čeština"
+  ],
+  "csb": [
+    "kašubština"
+  ],
+  "cu": [
+    "staroslověnština"
+  ],
+  "cv": [
+    "čuvaština"
+  ],
+  "cy": [
+    "velština"
+  ],
+  "da": [
+    "dánština"
+  ],
+  "de": [
+    "němčina"
+  ],
+  "dgd": [
+    "dagaari dioulou"
+  ],
+  "dje": [
+    "zarmština"
+  ],
+  "dlm": [
+    "dalmatština"
+  ],
+  "dsb": [
+    "dolnolužická srbština"
+  ],
+  "dv": [
+    "divehi (maledivština)"
+  ],
+  "dz": [
+    "dzongkä"
+  ],
+  "ee": [
+    "eveština"
+  ],
+  "egy": [
+    "starověká egyptština"
+  ],
+  "el": [
+    "řečtina"
+  ],
+  "en": [
+    "angličtina"
+  ],
+  "eo": [
+    "esperanto"
+  ],
+  "es": [
+    "španělština"
+  ],
+  "et": [
+    "estonština"
+  ],
+  "eu": [
+    "baskičtina"
+  ],
+  "ext": [
+    "extremadurština"
+  ],
+  "fa": [
+    "perština"
+  ],
+  "fi": [
+    "finština"
+  ],
+  "fil": [
+    "filipínština"
+  ],
+  "fit": [
+    "meänkieli"
+  ],
+  "fj": [
+    "fidžijština"
+  ],
+  "fkv": [
+    "kvenština"
+  ],
+  "fo": [
+    "faerština"
+  ],
+  "fr": [
+    "francouzština"
+  ],
+  "frp": [
+    "franko-provensálština"
+  ],
+  "frr": [
+    "severofríština"
+  ],
+  "fur": [
+    "furlanština"
+  ],
+  "fy": [
+    "fríština"
+  ],
+  "ga": [
+    "irština"
+  ],
+  "gad": [
+    "gaddang"
+  ],
+  "gag": [
+    "gagauzština"
+  ],
+  "gd": [
+    "skotská gaelština"
+  ],
+  "gil": [
+    "kiribatština"
+  ],
+  "gl": [
+    "galicijština"
+  ],
+  "gmh": [
+    "střední horní němčina"
+  ],
+  "gml": [
+    "střední dolní němčina"
+  ],
+  "gn": [
+    "guaranština"
+  ],
+  "goh": [
+    "stará horní němčina"
+  ],
+  "got": [
+    "gótština"
+  ],
+  "grc": [
+    "starořečtina"
+  ],
+  "gsw": [
+    "švýcarská němčina"
+  ],
+  "gu": [
+    "gudžarátština"
+  ],
+  "guz": [
+    "gusiština"
+  ],
+  "gv": [
+    "manština"
+  ],
+  "ha": [
+    "hauština"
+  ],
+  "hak": [
+    "hakka"
+  ],
+  "haw": [
+    "havajština"
+  ],
+  "hbs": [
+    "srbochorvatština"
+  ],
+  "hch": [
+    "víčol"
+  ],
+  "he": [
+    "hebrejština"
+  ],
+  "hi": [
+    "hindština"
+  ],
+  "hil": [
+    "hiligajnonština"
+  ],
+  "hit": [
+    "chetitština"
+  ],
+  "hnd": [
+    "hindko"
+  ],
+  "hr": [
+    "chorvatština"
+  ],
+  "hsb": [
+    "hornolužická srbština"
+  ],
+  "ht": [
+    "haitština"
+  ],
+  "hu": [
+    "maďarština"
+  ],
+  "hy": [
+    "arménština"
+  ],
+  "ia": [
+    "interlingua"
+  ],
+  "id": [
+    "indonéština"
+  ],
+  "ie": [
+    "interlingue"
+  ],
+  "ig": [
+    "igboština"
+  ],
+  "ilo": [
+    "ilokánština"
+  ],
+  "inh": [
+    "inguština"
+  ],
+  "io": [
+    "ido"
+  ],
+  "is": [
+    "islandština"
+  ],
+  "ist": [
+    "istrijština"
+  ],
+  "it": [
+    "italština"
+  ],
+  "iu": [
+    "inuktitutština"
+  ],
+  "izh": [
+    "ingrijština"
+  ],
+  "ja": [
+    "japonština"
+  ],
+  "jbo": [
+    "lojban"
+  ],
+  "jiv": [
+    "šuárština"
+  ],
+  "jpa": [
+    "židovská palestinská aramejština"
+  ],
+  "jv": [
+    "javánština"
+  ],
+  "ka": [
+    "gruzínština"
+  ],
+  "kaa": [
+    "karakalpačtina"
+  ],
+  "kab": [
+    "kabylština"
+  ],
+  "kdn": [
+    "kunda"
+  ],
+  "kea": [
+    "kapverdská kreolština"
+  ],
+  "kho": [
+    "chótanština"
+  ],
+  "kim": [
+    "tofalarština"
+  ],
+  "kjh": [
+    "chakaština"
+  ],
+  "kk": [
+    "kazaština"
+  ],
+  "kl": [
+    "grónština"
+  ],
+  "kld": [
+    "gamilarajština"
+  ],
+  "km": [
+    "khmerština"
+  ],
+  "kn": [
+    "kannadština"
+  ],
+  "ko": [
+    "korejština"
+  ],
+  "kok": [
+    "konkánština"
+  ],
+  "kos": [
+    "kosrajština"
+  ],
+  "krl": [
+    "karelština"
+  ],
+  "ku": [
+    "kurdština"
+  ],
+  "kv": [
+    "komijština"
+  ],
+  "kw": [
+    "kornština"
+  ],
+  "ky": [
+    "kyrgyzština"
+  ],
+  "la": [
+    "latina"
+  ],
+  "lad": [
+    "ladino"
+  ],
+  "lb": [
+    "lucemburština"
+  ],
+  "lbe": [
+    "lakština"
+  ],
+  "lg": [
+    "lugandština"
+  ],
+  "li": [
+    "limburština"
+  ],
+  "lij": [
+    "ligurština"
+  ],
+  "liv": [
+    "livonština"
+  ],
+  "lkt": [
+    "lakotština"
+  ],
+  "lld": [
+    "ladinština"
+  ],
+  "lmo": [
+    "lombardština"
+  ],
+  "ln": [
+    "lingalština"
+  ],
+  "lo": [
+    "laoština"
+  ],
+  "lou": [
+    "louisianská kreolština"
+  ],
+  "lt": [
+    "litevština"
+  ],
+  "ltg": [
+    "latgalština"
+  ],
+  "lv": [
+    "lotyština"
+  ],
+  "mas": [
+    "masajština"
+  ],
+  "mdf": [
+    "mokša"
+  ],
+  "mg": [
+    "malgaština"
+  ],
+  "mh": [
+    "maršálština"
+  ],
+  "mi": [
+    "maorština"
+  ],
+  "mk": [
+    "makedonština"
+  ],
+  "ml": [
+    "malajálamština"
+  ],
+  "mn": [
+    "mongolština"
+  ],
+  "mnc": [
+    "mandžuština"
+  ],
+  "mr": [
+    "maráthština"
+  ],
+  "mrh": [
+    "mara"
+  ],
+  "ms": [
+    "malajština"
+  ],
+  "mt": [
+    "maltština"
+  ],
+  "mwl": [
+    "mirandština"
+  ],
+  "mww": [
+    "bíla hmongština"
+  ],
+  "my": [
+    "barmština"
+  ],
+  "myv": [
+    "erzja"
+  ],
+  "na": [
+    "naurština"
+  ],
+  "nah": [
+    "aztéčtina"
+  ],
+  "nan": [
+    "jižní min"
+  ],
+  "nap": [
+    "neapolština"
+  ],
+  "nb": [
+    "norština (bokmål)"
+  ],
+  "nci": [
+    "klasický nahuatl"
+  ],
+  "nds": [
+    "dolnoněmčina"
+  ],
+  "ne": [
+    "nepálština"
+  ],
+  "new": [
+    "névárština"
+  ],
+  "ng": [
+    "ndondština"
+  ],
+  "nij": [
+    "ngadžuština"
+  ],
+  "niu": [
+    "niueština"
+  ],
+  "nl": [
+    "nizozemština"
+  ],
+  "nn": [
+    "norština (nynorsk)"
+  ],
+  "no": [
+    "norština"
+  ],
+  "nog": [
+    "nogajština"
+  ],
+  "non": [
+    "staronorština"
+  ],
+  "nov": [
+    "novial"
+  ],
+  "nrf": [
+    "guernseyština"
+  ],
+  "nso": [
+    "severní sotština"
+  ],
+  "nv": [
+    "navažština"
+  ],
+  "ny": [
+    "čičevština"
+  ],
+  "oc": [
+    "okcitánština"
+  ],
+  "oj": [
+    "odžibvejština"
+  ],
+  "olo": [
+    "livvština"
+  ],
+  "om": [
+    "oromo"
+  ],
+  "or": [
+    "urijština"
+  ],
+  "orv": [
+    "východní slovanština"
+  ],
+  "os": [
+    "osetština"
+  ],
+  "osa": [
+    "osadžtina"
+  ],
+  "pa": [
+    "pandžábština"
+  ],
+  "pam": [
+    "pampangau"
+  ],
+  "pap": [
+    "papiamentština"
+  ],
+  "pau": [
+    "palauština"
+  ],
+  "pl": [
+    "polština"
+  ],
+  "pms": [
+    "piemontština"
+  ],
+  "pnb": [
+    "paňdžábština (shahmukhi)"
+  ],
+  "pon": [
+    "pohnpeiština"
+  ],
+  "pox": [
+    "polabština"
+  ],
+  "prg": [
+    "pruština"
+  ],
+  "ps": [
+    "paštunština"
+  ],
+  "pt": [
+    "portugalština"
+  ],
+  "qu": [
+    "kečuánština"
+  ],
+  "qua": [
+    "quapawština"
+  ],
+  "raj": [
+    "rádžasthánština"
+  ],
+  "rap": [
+    "rapanuiština"
+  ],
+  "rar": [
+    "rarotongština"
+  ],
+  "rgn": [
+    "romaňolština"
+  ],
+  "rm": [
+    "rétorománština"
+  ],
+  "rmc": [
+    "karpatská romština"
+  ],
+  "rmy": [
+    "vlašská romština"
+  ],
+  "rn": [
+    "kirundi"
+  ],
+  "ro": [
+    "rumunština"
+  ],
+  "rom": [
+    "romština"
+  ],
+  "rtm": [
+    "rotumanština"
+  ],
+  "ru": [
+    "ruština"
+  ],
+  "rue": [
+    "rusínština"
+  ],
+  "rup": [
+    "arumunština"
+  ],
+  "rw": [
+    "rwandština"
+  ],
+  "ryu": [
+    "okinawština"
+  ],
+  "sa": [
+    "sanskrt"
+  ],
+  "sah": [
+    "jakutština"
+  ],
+  "sc": [
+    "sardinština"
+  ],
+  "scn": [
+    "sicilština"
+  ],
+  "sco": [
+    "skotština"
+  ],
+  "sd": [
+    "sindhština"
+  ],
+  "se": [
+    "severní sámština"
+  ],
+  "sgd": [
+    "surigaononština"
+  ],
+  "sgs": [
+    "žemaitština"
+  ],
+  "si": [
+    "sinhálština"
+  ],
+  "sip": [
+    "sikkimština"
+  ],
+  "sk": [
+    "slovenština"
+  ],
+  "sl": [
+    "slovinština"
+  ],
+  "sli": [
+    "slezská němčina"
+  ],
+  "slr": [
+    "salarština"
+  ],
+  "sm": [
+    "samojština"
+  ],
+  "sn": [
+    "šonština"
+  ],
+  "so": [
+    "somálština"
+  ],
+  "sq": [
+    "albánština"
+  ],
+  "sr": [
+    "srbština"
+  ],
+  "src": [
+    "lugudorská sardinština"
+  ],
+  "srn": [
+    "surinamština"
+  ],
+  "sro": [
+    "sardinština"
+  ],
+  "ss": [
+    "siswatština"
+  ],
+  "su": [
+    "sundánština"
+  ],
+  "sux": [
+    "sumerština"
+  ],
+  "sv": [
+    "švédština"
+  ],
+  "sw": [
+    "svahilština"
+  ],
+  "syr": [
+    "syrština"
+  ],
+  "szl": [
+    "slezština"
+  ],
+  "ta": [
+    "tamilština"
+  ],
+  "te": [
+    "telugština"
+  ],
+  "tg": [
+    "tádžičtina"
+  ],
+  "th": [
+    "thajština"
+  ],
+  "ti": [
+    "tigrajština"
+  ],
+  "tk": [
+    "turkmenština"
+  ],
+  "tkl": [
+    "tokelauština"
+  ],
+  "tl": [
+    "tagalština"
+  ],
+  "tlh": [
+    "klingonština"
+  ],
+  "tmr": [
+    "židovská babylonská aramejština"
+  ],
+  "tn": [
+    "setswanština"
+  ],
+  "to": [
+    "tongánština"
+  ],
+  "tog": [
+    "malavská tongština"
+  ],
+  "tpi": [
+    "tok pisin"
+  ],
+  "tr": [
+    "turečtina"
+  ],
+  "ts": [
+    "tsonga"
+  ],
+  "tt": [
+    "tatarština"
+  ],
+  "tum": [
+    "tumbučtina"
+  ],
+  "tvl": [
+    "tuvalština"
+  ],
+  "tw": [
+    "ťwiština"
+  ],
+  "ty": [
+    "tahitština"
+  ],
+  "tyv": [
+    "tuvinština"
+  ],
+  "tzm": [
+    "tamazight"
+  ],
+  "udm": [
+    "udmurtština"
+  ],
+  "ug": [
+    "ujgurština"
+  ],
+  "uk": [
+    "ukrajinština"
+  ],
+  "unm": [
+    "unami"
+  ],
+  "ur": [
+    "urdština"
+  ],
+  "uz": [
+    "uzbečtina"
+  ],
+  "vec": [
+    "benátština"
+  ],
+  "vep": [
+    "vepština"
+  ],
+  "vi": [
+    "vietnamština"
+  ],
+  "vo": [
+    "volapük"
+  ],
+  "vot": [
+    "votština"
+  ],
+  "vro": [
+    "võruština"
+  ],
+  "wa": [
+    "valonština"
+  ],
+  "wah": [
+    "watubela"
+  ],
+  "war": [
+    "warajština"
+  ],
+  "wo": [
+    "wolofština"
+  ],
+  "wym": [
+    "vilamovština"
+  ],
+  "xal": [
+    "kalmyčtina"
+  ],
+  "xcu": [
+    "kurština"
+  ],
+  "xh": [
+    "xhoština"
+  ],
+  "xmf": [
+    "mingrelština"
+  ],
+  "xsv": [
+    "jotvingština"
+  ],
+  "yi": [
+    "jidiš"
+  ],
+  "yo": [
+    "jorubština"
+  ],
+  "yue": [
+    "kantonština"
+  ],
+  "za": [
+    "čuangština"
+  ],
+  "zgh": [
+    "marocký tamazight"
+  ],
+  "zh": [
+    "čínština"
+  ],
+  "zlw-slv": [
+    "severní slovinština"
+  ],
+  "zu": [
+    "zuluština"
+  ],
+  "zza": [
+    "zazaki"
+  ]
+}

--- a/wiktextract/data/sk/languages.json
+++ b/wiktextract/data/sk/languages.json
@@ -1,0 +1,719 @@
+{
+  "aa": [
+    "afarčina"
+  ],
+  "ab": [
+    "abcházština"
+  ],
+  "ace": [
+    "acehčina"
+  ],
+  "ady": [
+    "adygejčina"
+  ],
+  "af": [
+    "afrikánčina"
+  ],
+  "ain": [
+    "ainčina"
+  ],
+  "ak": [
+    "akančina"
+  ],
+  "ale": [
+    "aleutčina"
+  ],
+  "als": [
+    "alsaština"
+  ],
+  "alt": [
+    "južná altajčina"
+  ],
+  "am": [
+    "amharčina"
+  ],
+  "an": [
+    "aragónčina"
+  ],
+  "ar": [
+    "arabčina"
+  ],
+  "arc": [
+    "aramejčina"
+  ],
+  "arn": [
+    "araukánčina"
+  ],
+  "as": [
+    "ásamčina"
+  ],
+  "ast": [
+    "astúrčina"
+  ],
+  "av": [
+    "avarčina"
+  ],
+  "ay": [
+    "aymarčina"
+  ],
+  "az": [
+    "azerbajdžančina"
+  ],
+  "ba": [
+    "baškirčina"
+  ],
+  "bal": [
+    "balúčtina"
+  ],
+  "be": [
+    "bieloruština"
+  ],
+  "bem": [
+    "bembčina"
+  ],
+  "bg": [
+    "bulharčina"
+  ],
+  "bh": [
+    "bihárčina"
+  ],
+  "bho": [
+    "bhódžpurčina"
+  ],
+  "bm": [
+    "bambarčina"
+  ],
+  "bn": [
+    "bengálčina"
+  ],
+  "bo": [
+    "tibetčina"
+  ],
+  "br": [
+    "bretónčina"
+  ],
+  "bs": [
+    "bosniačtina"
+  ],
+  "bxr": [
+    "buriatčina"
+  ],
+  "ca": [
+    "katalánčina"
+  ],
+  "ce": [
+    "čečenčina"
+  ],
+  "ceb": [
+    "cebuánčina"
+  ],
+  "ch": [
+    "čamorčina"
+  ],
+  "cmn": [
+    "mandarínčina"
+  ],
+  "cnr": [
+    "čiernohorčina"
+  ],
+  "co": [
+    "korzičtina"
+  ],
+  "cs": [
+    "čeština"
+  ],
+  "csb": [
+    "kašubčina"
+  ],
+  "cu": [
+    "staroslovienčina"
+  ],
+  "cuk": [
+    "kuna"
+  ],
+  "cv": [
+    "čuvaština"
+  ],
+  "cy": [
+    "waleština"
+  ],
+  "da": [
+    "dánčina"
+  ],
+  "de": [
+    "nemčina"
+  ],
+  "dlm": [
+    "dalmatínčina"
+  ],
+  "dv": [
+    "divehi (maldivčina)"
+  ],
+  "dz": [
+    "dzongkha"
+  ],
+  "ee": [
+    "eweština"
+  ],
+  "el": [
+    "gréčtina"
+  ],
+  "en": [
+    "angličtina"
+  ],
+  "eo": [
+    "esperanto"
+  ],
+  "es": [
+    "španielčina"
+  ],
+  "et": [
+    "estónčina"
+  ],
+  "eu": [
+    "baskičtina"
+  ],
+  "fa": [
+    "perzština"
+  ],
+  "fi": [
+    "fínčina"
+  ],
+  "fil": [
+    "filipínčina"
+  ],
+  "fj": [
+    "fidžijčina"
+  ],
+  "fo": [
+    "faerčina"
+  ],
+  "fr": [
+    "francúzština"
+  ],
+  "fur": [
+    "friulčina"
+  ],
+  "fy": [
+    "frízština"
+  ],
+  "ga": [
+    "írčina"
+  ],
+  "gag": [
+    "gagauzština"
+  ],
+  "gil": [
+    "kiribatčina"
+  ],
+  "gl": [
+    "galícijčina"
+  ],
+  "goh": [
+    "stará horná nemčina"
+  ],
+  "got": [
+    "gótčina"
+  ],
+  "grc": [
+    "starogréčtina"
+  ],
+  "gu": [
+    "gudžarátčina"
+  ],
+  "gv": [
+    "mančina"
+  ],
+  "ha": [
+    "hauština"
+  ],
+  "hak": [
+    "hakka"
+  ],
+  "haw": [
+    "havajčina"
+  ],
+  "hbs": [
+    "srbochorvátčina"
+  ],
+  "he": [
+    "hebrejčina"
+  ],
+  "hi": [
+    "hindčina"
+  ],
+  "hil": [
+    "hiligaynončina"
+  ],
+  "hit": [
+    "chetitčina"
+  ],
+  "hr": [
+    "chorvátčina"
+  ],
+  "hsb": [
+    "hornolužická srbčina"
+  ],
+  "hu": [
+    "maďarčina"
+  ],
+  "hy": [
+    "arménčina"
+  ],
+  "ia": [
+    "interlingua"
+  ],
+  "id": [
+    "indonézština"
+  ],
+  "ie": [
+    "interlingue"
+  ],
+  "ig": [
+    "igboština"
+  ],
+  "ilo": [
+    "ilokánčina"
+  ],
+  "inh": [
+    "inguština"
+  ],
+  "io": [
+    "ido"
+  ],
+  "is": [
+    "islandčina"
+  ],
+  "ist": [
+    "istrijčina"
+  ],
+  "it": [
+    "taliančina"
+  ],
+  "ja": [
+    "japončina"
+  ],
+  "jbo": [
+    "lojban"
+  ],
+  "jiv": [
+    "šuarčina"
+  ],
+  "jv": [
+    "jávčina"
+  ],
+  "ka": [
+    "gruzínčina"
+  ],
+  "kaa": [
+    "karakalpačtina"
+  ],
+  "kab": [
+    "kabylčina"
+  ],
+  "kk": [
+    "kazaština"
+  ],
+  "kl": [
+    "grónčina"
+  ],
+  "kn": [
+    "kannadčina"
+  ],
+  "ko": [
+    "kórejčina"
+  ],
+  "krl": [
+    "karelčina"
+  ],
+  "ku": [
+    "kurdčina"
+  ],
+  "kv": [
+    "komijčina"
+  ],
+  "kw": [
+    "kornčina"
+  ],
+  "ky": [
+    "kirgizština"
+  ],
+  "la": [
+    "latinčina"
+  ],
+  "lad": [
+    "ladino"
+  ],
+  "lb": [
+    "luxemburčina"
+  ],
+  "lg": [
+    "gandčina"
+  ],
+  "li": [
+    "limburčina"
+  ],
+  "lld": [
+    "ladinčina"
+  ],
+  "ln": [
+    "lingalčina"
+  ],
+  "lo": [
+    "laoština"
+  ],
+  "lt": [
+    "litovčina"
+  ],
+  "lv": [
+    "lotyština"
+  ],
+  "mas": [
+    "masajčina"
+  ],
+  "mg": [
+    "malgaština"
+  ],
+  "mi": [
+    "maorijčina"
+  ],
+  "mk": [
+    "macedónčina"
+  ],
+  "ml": [
+    "malajálamčina"
+  ],
+  "mn": [
+    "mongolčina"
+  ],
+  "mnc": [
+    "mandžuština"
+  ],
+  "mr": [
+    "maráthčina"
+  ],
+  "ms": [
+    "malajčina"
+  ],
+  "mt": [
+    "maltčina"
+  ],
+  "mwl": [
+    "mirandčina"
+  ],
+  "my": [
+    "barmčina"
+  ],
+  "na": [
+    "nauruština"
+  ],
+  "nah": [
+    "aztéčtina"
+  ],
+  "nap": [
+    "neapolčina"
+  ],
+  "nb": [
+    "nórčina (bokmål)"
+  ],
+  "ne": [
+    "nepálčina"
+  ],
+  "ng": [
+    "ndonga"
+  ],
+  "niu": [
+    "niueština"
+  ],
+  "nl": [
+    "holandčina"
+  ],
+  "nn": [
+    "nórčina (nynorsk)"
+  ],
+  "no": [
+    "nórčina"
+  ],
+  "nov": [
+    "novial"
+  ],
+  "nv": [
+    "navaho"
+  ],
+  "ny": [
+    "čeva"
+  ],
+  "oc": [
+    "okcitánčina"
+  ],
+  "om": [
+    "oromčina"
+  ],
+  "or": [
+    "uríjčina"
+  ],
+  "os": [
+    "osetčina"
+  ],
+  "pa": [
+    "pandžábčina"
+  ],
+  "pam": [
+    "pampangančina"
+  ],
+  "pap": [
+    "papiamento"
+  ],
+  "pau": [
+    "palajčina"
+  ],
+  "pjt": [
+    "pitjantjatjara"
+  ],
+  "pl": [
+    "poľština"
+  ],
+  "pnb": [
+    "pandžábčina"
+  ],
+  "pon": [
+    "pohnpeičina"
+  ],
+  "pox": [
+    "polabčina"
+  ],
+  "prg": [
+    "pruština"
+  ],
+  "ps": [
+    "paštčina"
+  ],
+  "pt": [
+    "portugalčina"
+  ],
+  "qu": [
+    "kečuánčina"
+  ],
+  "raj": [
+    "radžastančina"
+  ],
+  "rap": [
+    "rapanujčina"
+  ],
+  "rm": [
+    "rétorománčina"
+  ],
+  "rmc": [
+    "karpatská rómčina"
+  ],
+  "rmy": [
+    "vlašská rómčina"
+  ],
+  "ro": [
+    "rumunčina"
+  ],
+  "rom": [
+    "rómčina"
+  ],
+  "ru": [
+    "ruština"
+  ],
+  "rue": [
+    "rusínčina"
+  ],
+  "rup": [
+    "arumunčina"
+  ],
+  "rw": [
+    "rwandčina"
+  ],
+  "sa": [
+    "sanskrit"
+  ],
+  "sah": [
+    "jakutčina"
+  ],
+  "sc": [
+    "sardínčina"
+  ],
+  "scn": [
+    "sicílčina"
+  ],
+  "sco": [
+    "škótčina"
+  ],
+  "sd": [
+    "sindhčina"
+  ],
+  "se": [
+    "severná sámčina"
+  ],
+  "sgs": [
+    "žemajtské nárečie"
+  ],
+  "sh": [
+    "srbochorvátčina"
+  ],
+  "si": [
+    "sinhalčina"
+  ],
+  "sk": [
+    "slovenčina"
+  ],
+  "sl": [
+    "slovinčina"
+  ],
+  "sla-pro": [
+    "praslovančina"
+  ],
+  "sm": [
+    "samojčina"
+  ],
+  "sn": [
+    "šončina"
+  ],
+  "so": [
+    "somálčina"
+  ],
+  "sq": [
+    "albánčina"
+  ],
+  "sr": [
+    "srbčina"
+  ],
+  "sro": [
+    "sardínčina"
+  ],
+  "su": [
+    "sundčina"
+  ],
+  "sux": [
+    "sumerčina"
+  ],
+  "sv": [
+    "švédčina"
+  ],
+  "sw": [
+    "swahilčina"
+  ],
+  "syr": [
+    "sýrčina"
+  ],
+  "ta": [
+    "tamilčina"
+  ],
+  "tah": [
+    "tahitčina"
+  ],
+  "te": [
+    "telugčina"
+  ],
+  "tg": [
+    "tadžičtina"
+  ],
+  "th": [
+    "thajčina"
+  ],
+  "ti": [
+    "tigrejčina"
+  ],
+  "tk": [
+    "turkménčina"
+  ],
+  "tkl": [
+    "tokelaučina"
+  ],
+  "tl": [
+    "tagalčina"
+  ],
+  "tlh": [
+    "klingónčina"
+  ],
+  "to": [
+    "tongčina"
+  ],
+  "tog": [
+    "tongčina (Malawi)"
+  ],
+  "tpi": [
+    "tok pisin"
+  ],
+  "tr": [
+    "turečtina"
+  ],
+  "ts": [
+    "tsonga"
+  ],
+  "tt": [
+    "tatárčina"
+  ],
+  "tum": [
+    "tumbuka"
+  ],
+  "tvl": [
+    "tuvalčina"
+  ],
+  "tw": [
+    "twi"
+  ],
+  "ty": [
+    "tahitčina"
+  ],
+  "tyv": [
+    "tuviančina"
+  ],
+  "tzm": [
+    "tamazight"
+  ],
+  "udm": [
+    "udmurtčina"
+  ],
+  "ug": [
+    "ujgurčina"
+  ],
+  "uk": [
+    "ukrajinčina"
+  ],
+  "ur": [
+    "urdčina"
+  ],
+  "uz": [
+    "uzbečtina"
+  ],
+  "vi": [
+    "vietnamčina"
+  ],
+  "vo": [
+    "volapük"
+  ],
+  "wa": [
+    "valónčina"
+  ],
+  "wo": [
+    "wolofčina"
+  ],
+  "xal": [
+    "kalmyčtina"
+  ],
+  "xh": [
+    "xhoština"
+  ],
+  "yi": [
+    "jidiš"
+  ],
+  "yo": [
+    "jorubčina"
+  ],
+  "yue": [
+    "kantončina"
+  ],
+  "za": [
+    "čuangčina"
+  ],
+  "zh": [
+    "čínština"
+  ],
+  "zu": [
+    "zuluština"
+  ]
+}


### PR DESCRIPTION
This commit adds code to generate languages.json for Czech and Slovak. I haven't run Wiktextract on these languages yet, but maybe the code is already useful to others who want to work on other Wiktionaries because it shows how to parse the source code instead of expanding the templates (because sometimes you can't expand them as there is no function to invoke).