### PR TITLE
Loading the dump into a SQLite DB

### DIFF
--- a/usertools/sqlite_dictionary.py
+++ b/usertools/sqlite_dictionary.py
@@ -249,10 +249,10 @@ if __name__ == "__main__":
     )
 
     if args.word:
-        res = wikt.search_word(args.word)
+        res = wikt.search_word_with_forms(args.word)
         for word in res:
             print(
-                word["word"], word["lang"], word["pos"], word["senses"], word["forms"]
+                word["word"], word["lang"], word["pos"], word["senses"]
             )
 
     # Usage from python

--- a/usertools/sqlite_dictionary.py
+++ b/usertools/sqlite_dictionary.py
@@ -96,7 +96,6 @@ class WiktionaryDictionary:
         # SQLITE does not save collations in the file (but indexes on the collation are saved - they don't have to be recreated)
         self._conn.create_collation("NODIACRITIC", collate_unicode_no_diacritic_no_case)
 
-        # Enable foreign keys
         self._cur.execute("PRAGMA foreign_keys = ON;")
 
     def _load_dump_in_sqlite(self) -> None:
@@ -106,10 +105,7 @@ class WiktionaryDictionary:
 
         already_added_keys: set[str] = set()
         with open(self._input_dump, "r", encoding="utf-8") as f:
-            # We create the table
             self._cur.execute("CREATE TABLE wiktionary (id INTEGER PRIMARY KEY);")
-            # we parse the json
-            # for line in f:
             for line in tqdm.tqdm(f, total=8500000):
                 obj = json.loads(line)
                 # Now we look at the obj. If it has keys that are not in the
@@ -173,7 +169,6 @@ class WiktionaryDictionary:
         insert_cur = self._conn.cursor()
 
         already_existing_columns: set[str] = set()
-        # for word_id, json_array in self._cur:
         for word_id, json_array in tqdm.tqdm(self._cur, total=8500000):
             if json_array is not None:
                 for elem in json.loads(json_array):
@@ -217,6 +212,7 @@ class WiktionaryDictionary:
         ]
 
     def search_word_with_forms(self, word: str) -> list[dict]:
+        """Searches a word and its forms in the sqlite database."""
         # This searches either in the word column or in the forms table, using a join
         cursor = self._cur.execute(
             "SELECT * FROM wiktionary WHERE word=? COLLATE NODIACRITIC OR id IN (SELECT fid FROM forms_form_idx WHERE form=? COLLATE NODIACRITIC);",
@@ -229,6 +225,7 @@ class WiktionaryDictionary:
 
 
 if __name__ == "__main__":
+
     # Command line interface
     import argparse
 

--- a/usertools/sqlite_dictionary.py
+++ b/usertools/sqlite_dictionary.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sqlite3
 import time
 import unicodedata
@@ -24,9 +25,37 @@ def collate_unicode_no_diacritic_no_case(str1: str, str2: str):
         return 0
 
 
+def get_sqlite_type_for_python_type(python_type: type) -> str:
+    if python_type == str:
+        return "TEXT"
+    elif python_type == int:
+        return "INTEGER"
+    elif python_type == list:
+        return "TEXT"
+    elif python_type == dict:
+        return "TEXT"
+    elif python_type == bool:
+        return "INTEGER"
+    elif python_type == float:
+        return "REAL"
+    else:
+        raise ValueError(f"Unknown python type: {python_type}")
+
+
+def format_python_value_for_sqlite(value: object) -> object:
+    """Formats a python value to be inserted into a sqlite database. Note: Doesn't support classes."""
+    if isinstance(value, list):
+        return json.dumps(value, ensure_ascii=False)
+    elif isinstance(value, dict):
+        return json.dumps(value, ensure_ascii=False)
+    else:
+        return value
+
+
 class WiktionaryDictionary:
     """This class is a wrapper around a sqlite database containing the Wiktionary dump.
     It can be used to query the database."""
+
     def __init__(
         self,
         input_dump: str | None = None,
@@ -36,6 +65,11 @@ class WiktionaryDictionary:
         # if input dump and output sqlite path are given, load the dump into the sqlite file
         self._input_dump = input_dump
         if input_dump and output_sqlite_path:
+            # Delete the sqlite file if it already exists
+            try:
+                os.remove(output_sqlite_path)
+            except FileNotFoundError:
+                pass
             self._sqlite_file = output_sqlite_path
             # Open the sqlite file
             self._set_up_db()
@@ -49,7 +83,7 @@ class WiktionaryDictionary:
             raise ValueError(
                 "Either input_dump and output_sqlite_path or input_sqlite_file must be given"
             )
-        
+
         self._conn.commit()
 
     def _set_up_db(self):
@@ -61,6 +95,8 @@ class WiktionaryDictionary:
         # SQLITE does not save collations in the file (but indexes on the collation are saved - they don't have to be recreated)
         self._conn.create_collation("NODIACRITIC", collate_unicode_no_diacritic_no_case)
 
+        # Enable foreign keys
+        self._cur.execute("PRAGMA foreign_keys = ON;")
 
     def _load_dump_in_sqlite(self) -> None:
         """Loads the dump into a sqlite database."""
@@ -69,9 +105,7 @@ class WiktionaryDictionary:
         already_added_keys: set[str] = set()
         with open(self._input_dump, "r", encoding="utf-8") as f:
             # We create the table
-            self._cur.execute(
-                "CREATE TABLE wiktionary (id INTEGER PRIMARY KEY) STRICT;"
-            )
+            self._cur.execute("CREATE TABLE wiktionary (id INTEGER PRIMARY KEY);")
             # we parse the json
             for line in f:
                 obj = json.loads(line)
@@ -81,43 +115,17 @@ class WiktionaryDictionary:
                     if key not in already_added_keys:
                         # Now we detect the type of the value
                         value = obj[key]
-                        if isinstance(value, str):
-                            self._cur.execute(
-                                f"ALTER TABLE wiktionary ADD COLUMN {key} TEXT;"
-                            )
-                        elif isinstance(value, int):
-                            self._cur.execute(
-                                f"ALTER TABLE wiktionary ADD COLUMN {key} INTEGER;"
-                            )
-                        elif isinstance(value, list):
-                            self._cur.execute(
-                                f"ALTER TABLE wiktionary ADD COLUMN {key} TEXT;"
-                            )
-                        elif isinstance(value, dict):
-                            self._cur.execute(
-                                f"ALTER TABLE wiktionary ADD COLUMN {key} TEXT;"
-                            )
-                        elif isinstance(value, bool):
-                            self._cur.execute(
-                                f"ALTER TABLE wiktionary ADD COLUMN {key} INTEGER;"
-                            )
-                        elif isinstance(value, float):
-                            self._cur.execute(
-                                f"ALTER TABLE wiktionary ADD COLUMN {key} REAL;"
-                            )
-                        else:
-                            # We have an unknown type, so we add a text column
-                            print(f"Unknown type for key {key}: {type(value)}")
-                            self._cur.execute(
-                                f"ALTER TABLE wiktionary ADD COLUMN {key} TEXT;"
-                            )
+
+                        sqlite_type = get_sqlite_type_for_python_type(type(value))
+                        self._cur.execute(
+                            f"ALTER TABLE wiktionary ADD COLUMN {key} {sqlite_type};"
+                        )
+
                         already_added_keys.add(key)
                 # Now we have to convert the values to the correct type
                 for key in obj.keys():
-                    value = obj[key]
-                    if isinstance(value, list) or isinstance(value, dict):
-                        # We have a list or a dict, so we convert it to a string
-                        obj[key] = json.dumps(value, ensure_ascii=False)
+                    obj[key] = format_python_value_for_sqlite(obj[key])
+
                 # Now we insert the obj in the table
                 self._cur.execute(
                     "INSERT INTO wiktionary ("
@@ -128,17 +136,58 @@ class WiktionaryDictionary:
                     tuple(obj.values()),
                 )
 
-                # We commit the changes
+            # We create indexes for the important columns
+            self._cur.execute(
+                "CREATE INDEX word_index ON wiktionary (word COLLATE NODIACRITIC);"
+            )
+            self._cur.execute("CREATE INDEX lang_index ON wiktionary (lang);")
 
-            # We create indexes for the 
-            self._cur.execute("CREATE INDEX word_index ON wiktionary (word COLLATE NODIACRITIC);")
-            self._cur.execute("CREATE INDEX lemma_index ON wiktionary (lang);")
+            self._create_index_table_for_json_array("forms", "form")
             self._conn.commit()
+
+    def _create_index_table_for_json_array(self, column_name: str, key: str) -> None:
+        # https://sqlite.org/forum/forumpost/dfd4739c57
+        self._cur.execute(
+            f"""CREATE TABLE {column_name}_{key}_idx (
+            fid INTEGER NOT NULL,
+            elem TEXT NOT NULL,
+            --PRIMARY key (fid, elem),
+            FOREIGN KEY (fid) REFERENCES wiktionary (id)            
+            );"""
+        )
+
+        self._cur.execute(f"""SELECT id, {column_name} FROM wiktionary;""")
+        already_existing_columns: set[str] = set()
+        for word_id, json_array in self._cur.fetchall():
+            if json_array is not None:
+                for elem in json.loads(json_array):
+                    for elem_key in elem.keys():
+                        # We have to check if the column already exists
+                        if elem_key not in already_existing_columns:
+                            # We get the type of the value
+                            sqlite_type = get_sqlite_type_for_python_type(
+                                type(elem[elem_key])
+                            )
+                            self._cur.execute(
+                                f"""ALTER TABLE {column_name}_{key}_idx ADD COLUMN {elem_key} {sqlite_type};"""
+                            )
+                            already_existing_columns.add(elem_key)
+                    # Now we insert the element in the index table
+                    values = [
+                        format_python_value_for_sqlite(value) for value in elem.values()
+                    ]
+
+                    self._cur.execute(
+                        f"""INSERT INTO {column_name}_{key}_idx (fid, elem, {", ".join(elem.keys())}) VALUES (?, ?, {", ".join(["?"] * len(elem.keys()))});""",
+                        (word_id, json.dumps(elem, ensure_ascii=False), *values),
+                    )
 
     def search_word(self, word: str) -> list[dict]:
         """Searches a word in the sqlite database."""
 
-        cursor = self._cur.execute("SELECT * FROM wiktionary WHERE word=? COLLATE NODIACRITIC;", (word,))
+        cursor = self._cur.execute(
+            "SELECT * FROM wiktionary WHERE word=? COLLATE NODIACRITIC;", (word,)
+        )
         return [
             dict(zip([column[0] for column in cursor.description], row))
             for row in cursor.fetchall()
@@ -146,17 +195,62 @@ class WiktionaryDictionary:
 
 
 if __name__ == "__main__":
+    # Command line interface
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Searches a word in the Wiktionary dump."
+    )
+    parser.add_argument(
+        "--word",
+        type=str,
+        help="The word to search for.",
+    )
+    parser.add_argument(
+        "--input-dump",
+        type=str,
+        help="The path to the Wiktionary dump.",
+    )
+    parser.add_argument(
+        "--output-sqlite",
+        type=str,
+        help="The path to the sqlite file to create.",
+    )
+    parser.add_argument(
+        "--input-sqlite",
+        type=str,
+        help="The path to the sqlite file to read.",
+    )
+    args = parser.parse_args()
+
+    wikt = WiktionaryDictionary(
+        input_dump=args.input_dump,
+        output_sqlite_path=args.output_sqlite,
+        input_sqlite_file=args.input_sqlite,
+    )
+
+    if args.word:
+        res = wikt.search_word(args.word)
+        for word in res:
+            print(
+                word["word"], word["lang"], word["pos"], word["senses"], word["forms"]
+            )
+
+    # Test code
     # wikt = WiktionaryDictionary(
-    #     input_dump="kaikki.org-dictionary-Czech.jsonl",
-    #     output_sqlite_path="czech-wikt.db"
+    #    input_dump="kaikki.org-dictionary-Czech.jsonl",
+    #    output_sqlite_path="czech-wikt.db"
     # )
 
-    wikt = WiktionaryDictionary(input_sqlite_file="czech-wikt.db")
+    # wikt = WiktionaryDictionary(input_sqlite_file="czech-wikt.db")
+#
+# t0 = time.time()
+# res = wikt.search_word("Kun")
+# for word in res:
+#    print(word["word"], word["lang"], word["pos"], word["senses"])
+#    # This will also return the word kůň
+#
+# print(time.time() - t0)
 
-    t0 = time.time()
-    res = wikt.search_word("Kun")
-    for word in res:
-        print(word["word"], word["lang"], word["pos"], word["senses"])
-        # This will also return the word kůň
 
-    print(time.time() - t0)
+# self._cur.execute(f"""INSERT INTO {column_name}_{key}_idx (fid, elem) VALUES (?, ?);""", (word_id, elem[key]))

--- a/usertools/sqlite_dictionary.py
+++ b/usertools/sqlite_dictionary.py
@@ -1,0 +1,162 @@
+import json
+import sqlite3
+import time
+import unicodedata
+
+
+def strip_accents(s: str):
+    return "".join(
+        c for c in unicodedata.normalize("NFD", s) if unicodedata.category(c) != "Mn"
+    )
+
+
+def collate_unicode_no_diacritic_no_case(str1: str, str2: str):
+    # By default sqlite has no unicode case insensitive collation. This additionally removes all accents.
+    # Standard SQLite is not even to search for cyrillic strings without case sensitivity.
+
+    s1 = strip_accents(str1).lower()
+    s2 = strip_accents(str2).lower()
+    if s1 < s2:
+        return -1
+    elif s1 > s2:
+        return 1
+    else:
+        return 0
+
+
+class WiktionaryDictionary:
+    """This class is a wrapper around a sqlite database containing the Wiktionary dump.
+    It can be used to query the database."""
+    def __init__(
+        self,
+        input_dump: str | None = None,
+        input_sqlite_file: str | None = None,
+        output_sqlite_path: str | None = None,
+    ) -> None:
+        # if input dump and output sqlite path are given, load the dump into the sqlite file
+        self._input_dump = input_dump
+        if input_dump and output_sqlite_path:
+            self._sqlite_file = output_sqlite_path
+            # Open the sqlite file
+            self._set_up_db()
+            self._load_dump_in_sqlite()
+        # if input sqlite file is given, use that
+        elif input_sqlite_file:
+            self._sqlite_file = input_sqlite_file
+            self._set_up_db()
+            self._cur = self._conn.cursor()
+        else:
+            raise ValueError(
+                "Either input_dump and output_sqlite_path or input_sqlite_file must be given"
+            )
+        
+        self._conn.commit()
+
+    def _set_up_db(self):
+        # Open the sqlite file
+        self._conn = sqlite3.connect(self._sqlite_file)
+        self._cur = self._conn.cursor()
+
+        # This collation has to be created every time the SQLITE file is opened because
+        # SQLITE does not save collations in the file (but indexes on the collation are saved - they don't have to be recreated)
+        self._conn.create_collation("NODIACRITIC", collate_unicode_no_diacritic_no_case)
+
+
+    def _load_dump_in_sqlite(self) -> None:
+        """Loads the dump into a sqlite database."""
+        # We have a json lines file, so we can read it line by line
+
+        already_added_keys: set[str] = set()
+        with open(self._input_dump, "r", encoding="utf-8") as f:
+            # We create the table
+            self._cur.execute(
+                "CREATE TABLE wiktionary (id INTEGER PRIMARY KEY) STRICT;"
+            )
+            # we parse the json
+            for line in f:
+                obj = json.loads(line)
+                # Now we look at the obj. If it has keys that are not in the
+                # already_added_keys set, we add them to the table
+                for key in obj.keys():
+                    if key not in already_added_keys:
+                        # Now we detect the type of the value
+                        value = obj[key]
+                        if isinstance(value, str):
+                            self._cur.execute(
+                                f"ALTER TABLE wiktionary ADD COLUMN {key} TEXT;"
+                            )
+                        elif isinstance(value, int):
+                            self._cur.execute(
+                                f"ALTER TABLE wiktionary ADD COLUMN {key} INTEGER;"
+                            )
+                        elif isinstance(value, list):
+                            self._cur.execute(
+                                f"ALTER TABLE wiktionary ADD COLUMN {key} TEXT;"
+                            )
+                        elif isinstance(value, dict):
+                            self._cur.execute(
+                                f"ALTER TABLE wiktionary ADD COLUMN {key} TEXT;"
+                            )
+                        elif isinstance(value, bool):
+                            self._cur.execute(
+                                f"ALTER TABLE wiktionary ADD COLUMN {key} INTEGER;"
+                            )
+                        elif isinstance(value, float):
+                            self._cur.execute(
+                                f"ALTER TABLE wiktionary ADD COLUMN {key} REAL;"
+                            )
+                        else:
+                            # We have an unknown type, so we add a text column
+                            print(f"Unknown type for key {key}: {type(value)}")
+                            self._cur.execute(
+                                f"ALTER TABLE wiktionary ADD COLUMN {key} TEXT;"
+                            )
+                        already_added_keys.add(key)
+                # Now we have to convert the values to the correct type
+                for key in obj.keys():
+                    value = obj[key]
+                    if isinstance(value, list) or isinstance(value, dict):
+                        # We have a list or a dict, so we convert it to a string
+                        obj[key] = json.dumps(value, ensure_ascii=False)
+                # Now we insert the obj in the table
+                self._cur.execute(
+                    "INSERT INTO wiktionary ("
+                    + ", ".join(obj.keys())
+                    + ") VALUES ("
+                    + ", ".join(["?"] * len(obj.keys()))
+                    + ");",
+                    tuple(obj.values()),
+                )
+
+                # We commit the changes
+
+            # We create indexes for the 
+            self._cur.execute("CREATE INDEX word_index ON wiktionary (word COLLATE NODIACRITIC);")
+            self._cur.execute("CREATE INDEX lemma_index ON wiktionary (lang);")
+            self._conn.commit()
+
+    def search_word(self, word: str) -> list[dict]:
+        """Searches a word in the sqlite database."""
+
+        cursor = self._cur.execute("SELECT * FROM wiktionary WHERE word=? COLLATE NODIACRITIC;", (word,))
+        return [
+            dict(zip([column[0] for column in cursor.description], row))
+            for row in cursor.fetchall()
+        ]
+
+
+if __name__ == "__main__":
+    # wikt = WiktionaryDictionary(
+    #     input_dump="kaikki.org-dictionary-Czech.jsonl",
+    #     output_sqlite_path="czech-wikt.db"
+    # )
+
+    wikt = WiktionaryDictionary(input_sqlite_file="czech-wikt.db")
+
+    t0 = time.time()
+    res = wikt.search_word("Kun")
+    for word in res:
+        print(word["word"], word["lang"], word["pos"], word["senses"])
+        # This will also return the word kůň
+
+    print(time.time() - t0)


### PR DESCRIPTION
I think for a lot of applications it is useful to have the data as an SQLite file, mostly because it allows searching for words in 1 - 2 milliseconds and to filter things like languages. This script generates the columns automatically so there shouldn't be a lot of maintenance burden. It also demonstrates how to get a proper collation because by default SQLite is pretty weak there and doesn't even support case insensitive search for cyrillic, for example. (And because I found it to be a somewhat confusing topic.)

Additionally I added a way to not only search the words but also the inflections for words (both diacritic/case insensitive). It seems to work with the entire dump. From the 15 GB dump you get a 23 GB database (due to indexing).