### PR TITLE
Add Wikimedia language codes to `data/en/languages.json`

### DIFF
--- a/get_languages.py
+++ b/get_languages.py
@@ -5,12 +5,43 @@ import sys
 from pathlib import Path
 
 
-def save_json_file(data: dict[str, list[str]],
-                   lang_code: str,
-                   file_name: str = "languages.json") -> None:
+def add_wikimedia_language_codes(data: dict[str, list[str]]) -> None:
+    # https://en.wiktionary.org/wiki/Wiktionary:Wikimedia_language_codes
+    # https://en.wiktionary.org/wiki/Module:wikimedia_languages/data
+    wikimedia_codes = {
+        "als": "gsw",
+        "bat-smg": "sgs",
+        "be-tarask": "be",
+        "bs": "sh",
+        "bxr": "bua",
+        "diq": "zza",
+        "eml": "egl",
+        "fiu-vro": "vro",
+        "hr": "sh",
+        "ksh": "gmw-cfr",
+        "ku": "kmr",
+        "kv": "kpv",
+        "nrm": "nrf",
+        "roa-rup": "rup",
+        "roa-tara": "roa-tar",
+        "simple": "en",
+        "sr": "sh",
+        "zh-classical": "ltc",
+        "zh-min-nan": "nan",
+        "zh-yue": "yue",
+    }
+    for wikimedia_code, iso_code in wikimedia_codes.items():
+        if iso_code in data and wikimedia_code not in data:
+            data[wikimedia_code] = data[iso_code]
+
+
+def save_json_file(
+    data: dict[str, list[str]], lang_code: str, file_name: str = "languages.json"
+) -> None:
     data_folder = Path(f"wiktextract/data/{lang_code}")
     if not data_folder.exists():
         data_folder.mkdir()
+    add_wikimedia_language_codes(data)
     with data_folder.joinpath(file_name).open("w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False, sort_keys=True)
 

--- a/wiktextract/data/en/languages.json
+++ b/wiktextract/data/en/languages.json
@@ -811,6 +811,29 @@
   "alr": [
     "Alutor"
   ],
+  "als": [
+    "Alemannic German",
+    "Swiss German",
+    "Walser German",
+    "Walserdeutsch",
+    "Walser",
+    "Wallisertiitsch",
+    "Italian Walser",
+    "Pomattertitsch",
+    "Formazza",
+    "Kampel",
+    "Remmaljertittschu",
+    "Rimella",
+    "Chalchoufe",
+    "Titzschu",
+    "Alagna",
+    "Greschóneytitsch",
+    "Greschóney",
+    "Greschoney",
+    "Gressoney",
+    "Éischemtöitschu",
+    "Issime"
+  ],
   "alt": [
     "Southern Altai"
   ],
@@ -2162,6 +2185,9 @@
   "bas": [
     "Basaa"
   ],
+  "bat-smg": [
+    "Samogitian"
+  ],
   "bau": [
     "Badanchi",
     "Bada",
@@ -2473,6 +2499,9 @@
     "Badeshi"
   ],
   "be": [
+    "Belarusian"
+  ],
+  "be-tarask": [
     "Belarusian"
   ],
   "bea": [
@@ -3696,6 +3725,9 @@
   "brz": [
     "Bilbil"
   ],
+  "bs": [
+    "Serbo-Croatian"
+  ],
   "bsa": [
     "Abinomn"
   ],
@@ -4173,6 +4205,9 @@
   ],
   "bxq": [
     "Beele"
+  ],
+  "bxr": [
+    "Buryat"
   ],
   "bxs": [
     "Busam"
@@ -6017,6 +6052,9 @@
   "dip": [
     "Northeastern Dinka"
   ],
+  "diq": [
+    "Zazaki"
+  ],
   "dir": [
     "Dirim"
   ],
@@ -6766,6 +6804,9 @@
   "emk": [
     "Eastern Maninkakan"
   ],
+  "eml": [
+    "Emilian"
+  ],
   "emm": [
     "Mamulique"
   ],
@@ -7164,6 +7205,9 @@
   ],
   "fiu-fin-pro": [
     "Proto-Finnic"
+  ],
+  "fiu-vro": [
+    "Võro"
   ],
   "fiw": [
     "Fiwaga"
@@ -9093,6 +9137,9 @@
     "Hawaiian Sign Language",
     "Hula",
     "Hawaii Sign Language"
+  ],
+  "hr": [
+    "Serbo-Croatian"
   ],
   "hra": [
     "Hrangkhol"
@@ -12059,6 +12106,14 @@
   "ksg": [
     "Kusaghe"
   ],
+  "ksh": [
+    "Central Franconian",
+    "Mittelfränkisch",
+    "Ripuarian",
+    "Moselle Franconian",
+    "Colognian",
+    "Kölsch"
+  ],
   "ksi": [
     "Krisa"
   ],
@@ -12218,6 +12273,10 @@
     "ǁX'auǁ'e",
     "Juǀ'hoansi"
   ],
+  "ku": [
+    "Northern Kurdish",
+    "Kurmanji"
+  ],
   "ku-pro": [
     "Proto-Kurdish"
   ],
@@ -12304,6 +12363,10 @@
   ],
   "kuz": [
     "Kunza"
+  ],
+  "kv": [
+    "Komi-Zyrian",
+    "Komi"
   ],
   "kva": [
     "Bagvalal"
@@ -20635,7 +20698,13 @@
     "Saintongeais",
     "Maraîchin"
   ],
+  "roa-rup": [
+    "Aromanian"
+  ],
   "roa-tar": [
+    "Tarantino"
+  ],
+  "roa-tara": [
     "Tarantino"
   ],
   "roa-tou": [
@@ -21914,6 +21983,9 @@
     "Mende",
     "Mende (New Guinea)"
   ],
+  "simple": [
+    "English"
+  ],
   "sio-pro": [
     "Proto-Siouan"
   ],
@@ -22651,6 +22723,9 @@
   ],
   "squ": [
     "Squamish"
+  ],
+  "sr": [
+    "Serbo-Croatian"
   ],
   "sra": [
     "Saruga"
@@ -28573,6 +28648,20 @@
   ],
   "zh": [
     "Chinese"
+  ],
+  "zh-classical": [
+    "Middle Chinese",
+    "Late Middle Chinese",
+    "Early Middle Chinese"
+  ],
+  "zh-min-nan": [
+    "Min Nan",
+    "Taiwanese"
+  ],
+  "zh-yue": [
+    "Cantonese",
+    "Yue",
+    "Yüeh"
   ],
   "zhb": [
     "Zhaba"


### PR DESCRIPTION
Wikimedia projects use some nonexistent/retired ISO 639 language codes. Fixes #217.