### PR TITLE
don't classify desc as romanization if it is in data["categories"]

### DIFF
--- a/wiktextract/form_descriptions.py
+++ b/wiktextract/form_descriptions.py
@@ -1631,7 +1631,8 @@ def parse_word_head(ctx, pos, text, data, is_reconstruction,
                        continue
                     elif (cls in ("romanization", "english") and
                         not have_romanization and
-                        classify_desc(titleword) == "other"):
+                        classify_desc(titleword) == "other" and
+                        not ("categories" in data and desc in data["categories"])):
                         # Assume it to be a romanization
                         add_related(ctx, data, ["romanization"], [desc],
                                     text, True, is_reconstruction, head_group,
@@ -1778,7 +1779,8 @@ def parse_word_head(ctx, pos, text, data, is_reconstruction,
                         # Check if the parenthesized part is likely a
                         # romanization
                         if ((have_ruby or classify_desc(base) == "other") and
-                            classify_desc(paren) == "romanization"):
+                            classify_desc(paren) == "romanization" and 
+                            not ("categories" in data and desc in data["categories"])):
                             for r in split_at_comma_semi(paren, extra=[" or "]):
                                 add_related(ctx, data, ["romanization"], [r],
                                             text, True, is_reconstruction,


### PR DESCRIPTION
Noticed some spurious romanizations. Consider for example [Reconstruction:Latin/sufferio](https://en.wiktionary.org/wiki/Reconstruction:Latin/sufferio).  `parse_word_head()` was going through the cleaned version of `{{la-verb|4|*sufferiō|*sufferīv|*suffert}} {{lb|la|Proto-Romance}}`, which is `*sufferiō (present infinitive *sufferīre, perfect active *sufferīvī, supine *suffertum); fourth conjugation (Proto-Romance)`, and was determining `Proto-Romance` to be a romanization. This can be ruled out as a romanization since `{{lb}}` generates the category `Proto-Romance`, which is in `data["categories"]`. So this PR adds a check to make sure cases like this are avoided. 

Now, the spurious romanization is gone, but there now is a `DEBUG: unrecognized head form: Proto-Romance` that gets logged as the `desc` ends up not being classified. I left this alone as I'm not sure what the general system is for these classifications. (It's possible this check should be moved up higher in the `for desc_i, desc in enumerate(new_desc):` loop, depending what that system is...)

(There happens to be an unrelated Lua execution error on this page when invoking `{{VL-conj-4th}}`, but that is neither here nor there for this PR.)