### PR TITLE
add to uppercase_tags to avoid spurious romanizations

### DIFF
--- a/wiktextract/tags.py
+++ b/wiktextract/tags.py
@@ -1479,7 +1479,12 @@ uppercase_tags = set([
     "Mallorca",
     "Malta",
     "Malyangapa",
+    # [ used in Kipchak entries e.g. {{head|qwm|noun|tr=aχ as}} {{tlb|qwm|Armeno-Kipchak}}
+    "Armeno-Kipchak", 
+    "Armenian Kipchak",
     "Mamluk-Kipchak",
+    "Mamluk",
+    # ]
     "Mandalay Taishanese",
     "Mandarin",  # Dialect/Language in Chinese
     "Mandi",
@@ -1791,7 +1796,14 @@ uppercase_tags = set([
     "Prokem",
     "Protestant",
     "Proto-Slavic",
-    "Proto-Romance",
+    # [ used in Reconstruction:Latin entries, e.g. {{la-verb|4|*sufferiō|*sufferīv|*suffert}} {{lb|la|Proto-Romance}}
+    "Proto-Balkan-Romance",
+    "Proto-Ibero-Romance",
+    "Proto-Italo-Western-Romance",
+    "Proto-Gallo-Romance",
+    "Proto-Romance", 
+    "Proto-Western-Romance",
+    # ]
     "Provençal",
     "Provençau",  # Dialect of Occitan
     "Pskov",
@@ -2647,6 +2659,56 @@ uppercase_tags = set([
     "Afar",  # afoofa/Afar
     "Saru",  # Ainu/ecioka
     "Old Albanian",
+    # [ used in Ashokan Prakrit entries, e.g. {{inc-ash-noun|g=f}} {{tlb|inc-ash|Delhi-Meerut|Delhi-Topra|...
+    # see https://en.wiktionary.org/wiki/Module:labels/data/lang/inc-ash
+    # and https://en.wiktionary.org/wiki/Module:inc-ash/dial/data
+    "Shahbazgarhi",
+    "Mansehra",
+    "Kanadahar",
+    "Ranigat",
+    "Kalsi",
+    "Delhi-Topra",
+    "Delhi-Meerut",
+    "Rampurva",
+    "Lauriya-Nandangarh",
+    "Lauriya-Araraj",
+    "Lumbini",
+    "Nigali-Sagar",
+    "Sarnath",
+    "Rupnath",
+    "Bairat",
+    "Sanchi",
+    "Allahabad-Kosambi",
+    "Sahasram",
+    "Gujarra",
+    "Barabar",
+    "Calcutta-Bairat",
+    "Dhauli",
+    "Jaugada",
+    "Girnar",
+    "Sopara",
+    "Yerragudi",
+    "Siddapura",
+    "Brahmagiri",
+    "Maski",
+    "Barabar Hill",
+    "Barabar Caves",
+    "Bhabru",
+    "Kaushambi",
+    "Khalsi",
+    "Kosambi",
+    "Lauria-Nandangarh",
+    "Lauria-Araraj",
+    "Mathia",
+    "Radhia",
+    "Rummindei",
+    "Topra",
+    "Meerut",
+    # ]
+    # [ used in Proto-Uralic entries e.g. {{head|urj-pro|noun}} {{tlb|urj-pro|Finno-Permic}}
+    "Finno-Permic",
+    "Finno-Volgaic"
+    # ]
 ])
 
 


### PR DESCRIPTION
See #233. 

A general speculation:

The cases in this PR all result from head lines like: `{{some-head-template|args...}} {{tlb|args...}}` or `{{some-head-template|args...}} {{lb|args...}}`, where the `{{tlb}}`/`{{lb}}` expansion adds something in parentheses that gets misinterpreted as a romanization (e.g. `*kesä (Finno-Permic)`). I feel like it should be possible to put something more robust in place to deal with this general case by looking at the [language-specific data](https://en.wiktionary.org/wiki/Special:PrefixIndex/Module:labels/data/lang/) in [`Module:labels/data`](https://en.wiktionary.org/wiki/Module:labels/data) and disallowing every possible label in the current language. For example [`Module:labels/data/lang/qwm`](https://en.wiktionary.org/wiki/Module:labels/data/lang/qwm) is the following:

```lua
local labels = {}

local function alias(a, b) for _, v in ipairs(b) do labels[v] = a end end -- allows aliases to be entered as a list

labels["Armeno-Kipchak"] = {
	Wikipedia = "Armeno-Kipchak language",
	plain_categories = {"Armeno-Kipchak"},
}
alias("Armeno-Kipchak", {"Armenian Kipchak"})

labels["Mamluk-Kipchak"] = {
	Wikipedia = "Kipchaks#Language",
	plain_categories = {"Mamluk-Kipchak"},
}
alias("Mamluk-Kipchak", {"Mamluk"})

return labels
```

So by this we can see that `Armeno-Kipchak` and `Mamluk-Kipchak` should be disallowed as romanizations. 

Unfortunately it seems a bit more complicated, as the Ashokan Prakrit labels seem to be coming not from [Module:labels/data/lang/inc-ash](https://en.wiktionary.org/wiki/Module:labels/data/lang/inc-ash) as expected but from [Module:inc-ash/dial/data](https://en.wiktionary.org/wiki/Module:inc-ash/dial/data), and I couldn't see how `Module:labels` is actually getting this data from poking around briefly. 