### PR TITLE
add Proto-Georgian-Zan/Proto-Kartvelian uppercase_tags

### DIFF
--- a/wiktextract/tags.py
+++ b/wiktextract/tags.py
@@ -2707,7 +2707,15 @@ uppercase_tags = set([
     # ]
     # [ used in Proto-Uralic entries e.g. {{head|urj-pro|noun}} {{tlb|urj-pro|Finno-Permic}}
     "Finno-Permic",
-    "Finno-Volgaic"
+    "Finno-Volgaic",
+    # ]
+    # [ used in Proto-Georgian-Zan/Proto-Kartvelian entries e.g. {{head|ccs-pro|noun}} {{tlb|ccs-pro|Fähnrich-Sarǯvelaʒe}}
+    "Čikobava",
+    "Klimov",
+    "Fähnrich-Sarǯvelaʒe",
+    "Fähnrich",
+    "Fähnrich-Sarǯvelaʒe 2000",
+    "Fähnrich 2007"
     # ]
 ])
 


### PR DESCRIPTION
If I understood correctly the comment in #233, then these should also go here, as they are analogous to dialects.