### PR TITLE
Add Chinese Wiktionary extractor

### DIFF
--- a/wiktextract/clean.py
+++ b/wiktextract/clean.py
@@ -1381,8 +1381,8 @@ def clean_value(wxr, title, no_strip=False, no_html_strip=False):
     # Change <div> and </div> to newlines.  Ditto for tr, li, table, dl, ul, ol
     title = re.sub(r"(?si)</?(div|tr|li|table|dl|ul|ol)\b[^>]*>",
                    "\n", title)
-    # Change </dt> and </dd> into newlines; these generate new rows/lines.
-    title = re.sub(r"(?si)</(dt|dd)\s*>", "\n", title)
+    # Change <dt> and <dd> into newlines; these generate new rows/lines.
+    title = re.sub(r"<d[dt]>", "\n", title)
     # Change <td> </td> to spaces.  Ditto for th.
     title = re.sub(r"(?si)</?(td|th)\b[^>]*>", " ", title)
     # Change <sup> ... </sup> to ^

--- a/wiktextract/config.py
+++ b/wiktextract/config.py
@@ -60,20 +60,22 @@ class WiktionaryConfig(object):
         "FORM_OF_TEMPLATES",
     )
 
-    def __init__(self,
-                 dump_file_lang_code="en",
-                 capture_language_codes=["en", "mul"],
-                 capture_translations=True,
-                 capture_pronunciation=True,
-                 capture_linkages=True,
-                 capture_compounds=True,
-                 capture_redirects=True,
-                 capture_examples=True,
-                 capture_etymologies=True,
-                 capture_inflections=True,
-                 capture_descendants=True,
-                 verbose=False,
-                 expand_tables=False):
+    def __init__(
+        self,
+        dump_file_lang_code="en",
+        capture_language_codes=["en", "mul"],
+        capture_translations=True,
+        capture_pronunciation=True,
+        capture_linkages=True,
+        capture_compounds=True,
+        capture_redirects=True,
+        capture_examples=True,
+        capture_etymologies=True,
+        capture_inflections=True,
+        capture_descendants=True,
+        verbose=False,
+        expand_tables=False
+    ):
         if capture_language_codes is not None:
             assert isinstance(capture_language_codes, (list, tuple, set))
             for x in capture_language_codes:

--- a/wiktextract/extractor/en/page.py
+++ b/wiktextract/extractor/en/page.py
@@ -33,7 +33,7 @@ from wiktextract.inflection import parse_inflection_section, TableContext
 # Matches head tag
 head_tag_re = None
 
-floating_table_templates = {
+FLOATING_TABLE_TEMPLATES = {
     # az-suffix-form creates a style=floatright div that is otherwise
     # deleted; if it is not pre-expanded, we can intercept the template
     # so we add this set into do_not_pre_expand, and intercept the
@@ -46,18 +46,17 @@ floating_table_templates = {
     "tr-suffix-forms",
     "tt-suffix-forms",
     "uz-suffix-forms",
-
 }
 # These two should contain template names that should always be
 # pre-expanded when *first* processing the tree, or not pre-expanded
 # so that the template are left in place with their identifying
 # name intact for later filtering.
 
-do_not_pre_expand_templates = set()
-do_not_pre_expand_templates.update(floating_table_templates)
+DO_NOT_PRE_EXPAND_TEMPLATES = set()
+DO_NOT_PRE_EXPAND_TEMPLATES.update(FLOATING_TABLE_TEMPLATES)
 
 # Additional templates to be expanded in the pre-expand phase
-additional_expand_templates = {
+ADDITIONAL_EXPAND_TEMPLATES = {
     "multitrans",
     "multitrans-nowiki",
     "trans-top",
@@ -1035,10 +1034,14 @@ def parse_language(wxr, langnode, language, lang_code):
         # XXX bookmark
         # print(posnode.children)
 
-        floaters, poschildren = recursively_extract(posnode.children,
-                                   lambda x: isinstance(x, WikiNode) and
-                                   x.kind == NodeKind.TEMPLATE and
-                                   x.args[0][0] in floating_table_templates)
+        floaters, poschildren = recursively_extract(
+            posnode.children,
+            lambda x: (
+                isinstance(x, WikiNode) and
+                x.kind == NodeKind.TEMPLATE and
+                x.args[0][0] in FLOATING_TABLE_TEMPLATES
+            )
+        )
         tempnode = WikiNode(NodeKind.LEVEL5, 0)
         tempnode.args = ['Inflection']
         tempnode.children = floaters
@@ -1903,10 +1906,13 @@ def parse_language(wxr, langnode, language, lang_code):
                 return "\n" + text
             return None
 
-        tree = wxr.wtp.parse(subpage_content, pre_expand=True,
-                         post_template_fn=multitrans_post_fn,
-                         additional_expand=additional_expand_templates,
-                         do_not_pre_expand=do_not_pre_expand_templates)
+        tree = wxr.wtp.parse(
+            subpage_content,
+            pre_expand=True,
+            post_template_fn=multitrans_post_fn,
+            additional_expand=ADDITIONAL_EXPAND_TEMPLATES,
+            do_not_pre_expand=DO_NOT_PRE_EXPAND_TEMPLATES
+        )
         assert tree.kind == NodeKind.ROOT
         ret = recurse(tree, seq)
         if ret is None:
@@ -3377,10 +3383,13 @@ def parse_page(
 
     # Parse the page, pre-expanding those templates that are likely to
     # influence parsing
-    tree = wxr.wtp.parse(text, pre_expand=True,
-                     post_template_fn=multitrans_post_fn,
-                     additional_expand=additional_expand_templates,
-                     do_not_pre_expand=do_not_pre_expand_templates)
+    tree = wxr.wtp.parse(
+        text,
+        pre_expand=True,
+        post_template_fn=multitrans_post_fn,
+        additional_expand=ADDITIONAL_EXPAND_TEMPLATES,
+        do_not_pre_expand=DO_NOT_PRE_EXPAND_TEMPLATES
+    )
     # from wikitextprocessor.parser import print_tree
     # print("PAGE PARSE:", print_tree(tree))
 
@@ -3408,7 +3417,10 @@ def parse_page(
                       .format(lang), sortid="page/3019")
             continue
         lang_code = wxr.config.LANGUAGES_BY_NAME.get(lang)
-        if wxr.config.capture_language_codes and lang_code not in wxr.config.capture_language_codes:
+        if (
+            wxr.config.capture_language_codes
+            and lang_code not in wxr.config.capture_language_codes
+        ):
             continue
         wxr.wtp.start_section(lang)
 
@@ -3419,8 +3431,10 @@ def parse_page(
         # part-of-speech.
         for data in datas:
             if "lang" not in data:
-                wxr.wtp.debug("internal error -- no lang in data: {}".format(data),
-                          sortid="page/3034")
+                wxr.wtp.debug(
+                    "internal error -- no lang in data: {}".format(data),
+                    sortid="page/3034"
+                )
                 continue
             for k, v in top_data.items():
                 assert isinstance(v, (list, tuple))

--- a/wiktextract/extractor/en/thesaurus.py
+++ b/wiktextract/extractor/en/thesaurus.py
@@ -11,6 +11,7 @@ from wiktextract.wxr_context import WiktextractContext
 from wiktextract.datautils import ns_title_prefix_tuple
 from wiktextract.page import clean_node, LEVEL_KINDS
 from wiktextract.form_descriptions import parse_sense_qualifier
+from wiktextract.extractor.share import contains_list
 from wikitextprocessor import NodeKind, WikiNode, Page
 
 
@@ -58,18 +59,6 @@ IGNORED_SUBTITLE_TAGS_MAP = {
     "common": [],
     "rare": ["rare"],
 }
-
-
-def contains_list(contents):
-    """Returns True if there is a list somewhere nested in contents."""
-    if isinstance(contents, (list, tuple)):
-        return any(contains_list(x) for x in contents)
-    if not isinstance(contents, WikiNode):
-        return False
-    kind = contents.kind
-    if kind == NodeKind.LIST:
-        return True
-    return contains_list(contents.children) or contains_list(contents.args)
 
 
 def extract_thesaurus_data(wxr: WiktextractContext) -> None:

--- a/wiktextract/extractor/share.py
+++ b/wiktextract/extractor/share.py
@@ -1,0 +1,20 @@
+from typing import List, Union
+
+from wikitextprocessor import WikiNode, NodeKind
+
+
+WIKIMEDIA_COMMONS_URL = "https://commons.wikimedia.org/wiki/Special:FilePath/"
+
+
+def contains_list(
+    contents: Union[WikiNode, List[Union[WikiNode, str]]]
+) -> bool:
+    """Returns True if there is a list somewhere nested in contents."""
+    if isinstance(contents, (list, tuple)):
+        return any(contains_list(x) for x in contents)
+    if not isinstance(contents, WikiNode):
+        return False
+    kind = contents.kind
+    if kind == NodeKind.LIST:
+        return True
+    return contains_list(contents.children) or contains_list(contents.args)

--- a/wiktextract/extractor/zh/page.py
+++ b/wiktextract/extractor/zh/page.py
@@ -275,8 +275,22 @@ def extract_examples(
                             else:
                                 key = "translation"
                             example_data[key] = expanded_line
-                    elif template_name == "zh-usex":
-                        pass
+                    elif template_name in {"zh-x", "zh-usex"}:
+                        for expanded_line in expanded_text.splitlines():
+                            if expanded_line.endswith("體]"):
+                                # expanded simplified or traditional Chinese
+                                # example sentence usually ends with
+                                # "繁體]" or "簡體]"
+                                if example_data.get("text") is not None:
+                                    example_data["text"].append(expanded_line)
+                                else:
+                                    example_data["text"] = [expanded_line]
+                            elif expanded_line.endswith("]"):
+                                example_data["roman"] = expanded_line
+                            elif expanded_line.startswith("來自："):
+                                example_data["ref"] = expanded_line[3:]
+                            else:
+                                example_data["translation"] = expanded_line
                     else:
                         example_data["text"] = expanded_text
 

--- a/wiktextract/extractor/zh/page.py
+++ b/wiktextract/extractor/zh/page.py
@@ -1,0 +1,293 @@
+import copy
+import logging
+import re
+import string
+
+from typing import Dict, List, Union, Any
+
+from wikitextprocessor import WikiNode, NodeKind
+from wiktextract.wxr_context import WiktextractContext
+from wiktextract.page import clean_node, LEVEL_KINDS
+
+
+# Templates that are used to form panels on pages and that
+# should be ignored in various positions
+PANEL_TEMPLATES = {
+    "CJKV",
+    "French personal pronouns",
+    "French possessive adjectives",
+    "French possessive pronouns",
+    "Han etym",
+    "Japanese demonstratives",
+    "Latn-script",
+    "Webster 1913",
+    "attention",
+    "attn",
+    "character info",
+    "character info/new",
+    "character info/var",
+    "delete",
+    "dial syn",
+    "dialect synonyms",
+    "examples",
+    "hu-corr",
+    "hu-suff-pron",
+    "interwiktionary",
+    "ja-kanjitab",
+    "ko-hanja-search",
+    "maintenance box",
+    "maintenance line",
+    "merge",
+    "morse links",
+    "move",
+    "multiple images",
+    "picdic",
+    "picdicimg",
+    "picdiclabel",
+    "punctuation",
+    "reconstructed",
+    "request box",
+    "rfap",
+    "rfc",
+    "rfc-header",
+    "rfc-level",
+    "rfc-sense",
+    "rfd",
+    "rfdate",
+    "rfdatek",
+    "rfdef",
+    "rfe",
+    "rfe/dowork",
+    "rfgender",
+    "rfi",
+    "rfinfl",
+    "rfp",
+    "rfquotek",
+    "rfscript",
+    "rftranslit",
+    "selfref",
+    "stroke order",
+    "t-needed",
+    "unblock",
+    "unsupportedpage",
+    "wrongtitle",
+    "zh-forms",
+    "zh-hanzi-box",
+}
+
+# Template name prefixes used for language-specific panel templates (i.e.,
+# templates that create side boxes or notice boxes or that should generally
+# be ignored).
+PANEL_PREFIXES = {
+    "list:compass points/",
+    "list:Gregorian calendar months/",
+    "RQ:",
+}
+
+# Additional templates to be expanded in the pre-expand phase
+ADDITIONAL_EXPAND_TEMPLATES = {
+    "multitrans",
+    "multitrans-nowiki",
+    "trans-top",
+    "trans-top-also",
+    "trans-bottom",
+    "checktrans-top",
+    "checktrans-bottom",
+    "col1",
+    "col2",
+    "col3",
+    "col4",
+    "col5",
+    "col1-u",
+    "col2-u",
+    "col3-u",
+    "col4-u",
+    "col5-u",
+    "check deprecated lang param usage",
+    "deprecated code",
+    "ru-verb-alt-ё",
+    "ru-noun-alt-ё",
+    "ru-adj-alt-ё",
+    "ru-proper noun-alt-ё",
+    "ru-pos-alt-ё",
+    "ru-alt-ё",
+    # langhd is needed for pre-expanding language heading templates in the
+    # Chinese Wiktionary dump file: https://zh.wiktionary.org/wiki/Template:-en-
+    "langhd",
+}
+
+
+def append_dict(
+    page_data: List[Dict], field: str, value: Any, base_data: Dict
+) -> bool:
+    if (
+        page_data[-1].get(field) is not None
+        and len(page_data[-1]["senses"]) > 0
+    ):
+        page_data.append(copy.deepcopy(base_data))
+    else:
+        page_data[-1][field] = value
+
+
+def recursive_parse(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    base_data: Dict,
+    node: Union[WikiNode, List[Union[WikiNode, str]]],
+) -> None:
+    if isinstance(node, list):
+        for x in node:
+            recursive_parse(wxr, page_data, base_data, x)
+        return
+    if not isinstance(node, WikiNode):
+        return
+    if node.kind in LEVEL_KINDS:
+        subtitle = clean_node(wxr, None, node.args)
+        subtitle = subtitle.rstrip(string.digits)
+        if subtitle in wxr.config.OTHER_SUBTITLES["ignored_sections"]:
+            pass
+        elif subtitle in wxr.config.POS_SUBTITLES:
+            pos_type = wxr.config.POS_SUBTITLES[subtitle]["pos"]
+            base_data["pos"] = pos_type
+            append_dict(page_data, "pos", pos_type, base_data)
+            for node in node.children:
+                if isinstance(node, WikiNode) and node.kind == NodeKind.LIST:
+                    extract_gloss(wxr, page_data, node.children)
+                else:
+                    recursive_parse(wxr, page_data, base_data, node)
+        elif subtitle in wxr.config.OTHER_SUBTITLES["etymology"]:
+            extract_etymology(wxr, page_data, base_data, node.children)
+        elif subtitle in wxr.config.OTHER_SUBTITLES["pronunciation"]:
+            extract_pronunciation(wxr, page_data, base_data, node.children)
+
+
+def extract_gloss(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    nodes: List[Union[WikiNode, str]],
+) -> None:
+    for node in filter(
+        lambda n: isinstance(n, WikiNode) and n.kind == NodeKind.LIST_ITEM,
+        nodes,
+    ):
+        gloss = clean_node(
+            wxr,
+            None,
+            [
+                child
+                for child in node.children
+                if not isinstance(child, WikiNode)
+                or child.kind != NodeKind.LIST
+            ],
+        )
+        extract_sense_tags(wxr, page_data, gloss)
+
+
+def extract_sense_tags(
+    wxr: WiktextractContext, page_data: List[Dict], raw_gloss: str
+) -> None:
+    if raw_gloss.startswith("("):
+        label_end = raw_gloss.find(")")
+        label = raw_gloss[1:label_end]
+        gloss = raw_gloss[label_end + 2 :]  # also remove space after ")"
+        # labels: https://zh.wiktionary.org/wiki/Module:Labels/data
+        tags = re.split(r",|或", label)
+        page_data[-1]["senses"].append(
+            {"glosses": [gloss], "raw_glosses": [raw_gloss], "tags": tags}
+        )
+    else:
+        page_data[-1]["senses"].append({"glosses": [raw_gloss]})
+
+
+def extract_etymology(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    base_data: Dict,
+    nodes: List[Union[WikiNode, str]],
+) -> None:
+    for index, node in enumerate(nodes):
+        if isinstance(node, WikiNode) and node.kind == NodeKind.TEMPLATE:
+            etymology = clean_node(
+                wxr,
+                None,
+                [
+                    child
+                    for child in node.children
+                    if not isinstance(child, WikiNode)
+                    or (
+                        child.kind != NodeKind.LIST
+                        and child.kind not in LEVEL_KINDS
+                    )
+                ],
+            )
+            base_data["etymology_text"] = etymology
+            append_dict(page_data, "etymology_text", etymology, base_data)
+            recursive_parse(wxr, page_data, base_data, nodes[index + 1 :])
+            return
+
+
+def extract_pronunciation(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    base_data: Dict,
+    nodes: List[Union[WikiNode, str]],
+) -> None:
+    for index, node in enumerate(nodes):
+        if isinstance(node, WikiNode) and node.kind == NodeKind.TEMPLATE:
+            # extract ipa
+            base_data["sounds"] = "sounds_placeholder"
+            append_dict(page_data, "sounds", "sounds_placeholder", base_data)
+            recursive_parse(wxr, page_data, base_data, nodes[index + 1 :])
+            return
+
+
+def parse_page(
+    wxr: WiktextractContext, page_title: str, page_text: str
+) -> List[Dict[str, str]]:
+    if wxr.config.verbose:
+        logging.info(f"Parsing page: {page_title}")
+
+    wxr.config.word = page_title
+    wxr.wtp.start_page(page_title)
+
+    # Parse the page, pre-expanding those templates that are likely to
+    # influence parsing
+    tree = wxr.wtp.parse(
+        page_text,
+        pre_expand=True,
+        additional_expand=ADDITIONAL_EXPAND_TEMPLATES,
+    )
+
+    page_data = []
+    for node in filter(
+        # ignore link created by `also` template at the page top
+        lambda n: isinstance(n, WikiNode) and n.kind != NodeKind.LINK,
+        tree.children,
+    ):
+        if node.kind != NodeKind.LEVEL2:
+            logging.warning(f"Unexpected top-level node: {node}")
+            continue
+        lang_name = clean_node(wxr, None, node.args)
+        if lang_name not in wxr.config.LANGUAGES_BY_NAME:
+            logging.warning(
+                f"Unrecognized language name at top-level {lang_name}"
+            )
+            continue
+        lang_code = wxr.config.LANGUAGES_BY_NAME.get(lang_name)
+        if (
+            wxr.config.capture_language_codes
+            and lang_code not in wxr.config.capture_language_codes
+        ):
+            continue
+        wxr.wtp.start_section(lang_name)
+
+        base_data = {
+            "lang": lang_name,
+            "lang_code": lang_code,
+            "word": wxr.wtp.title,
+            "senses": [],
+        }
+        page_data.append(copy.deepcopy(base_data))
+        recursive_parse(wxr, page_data, base_data, node.children)
+
+    return page_data

--- a/wiktextract/extractor/zh/page.py
+++ b/wiktextract/extractor/zh/page.py
@@ -354,11 +354,14 @@ def parse_page(
     )
 
     page_data = []
-    for node in filter(
+    for node in filter(lambda n: isinstance(n, WikiNode), tree.children):
         # ignore link created by `also` template at the page top
-        lambda n: isinstance(n, WikiNode) and n.kind != NodeKind.LINK,
-        tree.children,
-    ):
+        if node.kind == NodeKind.TEMPLATE and node.args[0][0].lower() in {
+            "also",
+            "see also",
+            "亦",
+        }:
+            continue
         if node.kind != NodeKind.LEVEL2:
             logging.warning(f"Unexpected top-level node: {node}")
             continue

--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -341,9 +341,12 @@ def clean_node(
         return None
 
     # print("clean_node: value={!r}".format(value))
-    v = wxr.wtp.node_to_html(value, node_handler_fn=clean_node_handler_fn,
-                         template_fn=template_fn,
-                         post_template_fn=post_template_fn)
+    v = wxr.wtp.node_to_html(
+        value,
+        node_handler_fn=clean_node_handler_fn,
+        template_fn=template_fn,
+        post_template_fn=post_template_fn
+    )
     # print("clean_node: v={!r}".format(v))
 
     # Capture categories if sense_data has been given.  We also track


### PR DESCRIPTION
I have tested a few Chinese Wiktionary pages([大家](https://zh.wiktionary.org/zh/大家), [manga](https://zh.wiktionary.org/wiki/manga), [癸卯](https://zh.wiktionary.org/wiki/癸卯)), and the code can extract etymology, gloss, example and pronunciation data.

Changes:
- I changed the "english" key to "translation" in the "examples" dictionary for `zh/page.py` extractor, but didn't change the code in `en/page.py` file.
- and use a spacial page link to create the ogg file link

For future works:
- categories data aren't created in this pull request
- sense tags aren't translated, that could be done by extracting translation data from https://zh.wiktionary.org/wiki/Module:Labels/data.
- `extract_examples()`, `extract_pronunciation()` could be moved to separate files if they grow longer 