### PR TITLE
Update scripts for processing language data

### DIFF
--- a/usertools/language_data.py
+++ b/usertools/language_data.py
@@ -2,7 +2,7 @@
 #
 # Usage:
 #
-# python language_data.py enwiktionary_dump_file [--languages languages_output_file] [--families families_output_file]
+# python language_data.py en enwiktionary_dump_file [--languages languages_output_file] [--families families_output_file]
 
 import argparse
 from wikitextprocessor import Wtp
@@ -11,7 +11,7 @@ from wiktextract.wxr_context import WiktextractContext
 from wikitextprocessor.dumpparser import process_dump
 import json
 
-lua_mod = r"""
+LUA_CODE = r"""
 local export = {}
 
 function export.languages()
@@ -69,7 +69,7 @@ function export.languages()
     for code, data in pairs(etyData) do
         ret[code] = getData(code, data, "etymology-only")
     end
-    
+
     ret = require("Module:table").deepcopy(ret)
 
     return require("Module:JSON").toJSON(ret)
@@ -82,7 +82,7 @@ function export.families()
 
     -- https://en.wiktionary.org/wiki/Module:families/data
     local famData = mw.loadData("Module:families/data")
-    
+
     local function getSuperfamilies(fam)
         -- We reverse the order of superfamilies to correspond with the ordering of
         -- lang ancestors, i.e. remotest to nearest (see above).
@@ -102,7 +102,7 @@ function export.families()
                 if a_fam == code then
                     return rev(superfamilies)
                 end
-            end 
+            end
             table.insert(superfamilies, code)
             superfamily = superfamily:getFamily()
         end
@@ -123,7 +123,7 @@ function export.families()
             wikipediaArticle = fam:getWikipediaArticle(),
         }
     end
-    
+
     ret = require("Module:table").deepcopy(ret)
 
     return require("Module:JSON").toJSON(ret)
@@ -133,35 +133,46 @@ end
 return export
 """
 
-def export_data(wxr, kind, path):
+
+def export_data(wxr: WiktextractContext, kind: str, path: str) -> None:
     wxr.wtp.start_page(f"{kind} data export")
     data = wxr.wtp.expand(f"{{{{#invoke:lang-data-export|{kind}}}}}")
-
     data = json.loads(data)
-    with open(path, "w") as fout:
+    with open(path, "w", encoding="utf-8") as fout:
         json.dump(data, fout, indent=2, ensure_ascii=False, sort_keys=True)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-    description="Export Wiktionary language and family data to JSON")
-    parser.add_argument("dump", type=str,
-                        help="Wiktionary xml dump file path")
-    parser.add_argument("--languages", type=str, default="languages.json",
-                            help="Language data output file path")
-    parser.add_argument("--families", type=str, default="families.json",
-                            help="Family data output file path")
+        description="Export Wiktionary language and family data to JSON"
+    )
+    parser.add_argument("lang_code", type=str, help="Dump file language code")
+    parser.add_argument("dump", type=str, help="Wiktionary xml dump file path")
+    parser.add_argument(
+        "--languages",
+        type=str,
+        default="languages.json",
+        help="Language data output file path",
+    )
+    parser.add_argument(
+        "--families",
+        type=str,
+        default="families.json",
+        help="Family data output file path",
+    )
     args = parser.parse_args()
-
-    wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
-    def page_handler(model, title, text):
-        if title.startswith("Module:"):
-            wxr.wtp.add_page(model, title, text)
-
-    process_dump(wxr, args.dump, page_handler=page_handler)
-
-    wxr.wtp.add_page("Scribunto", "Module:lang-data-export", lua_mod, transient=True)
-
+    wxr = WiktextractContext(Wtp(lang_code=args.lang_code), WiktionaryConfig())
+    module_ns_id = wxr.wtp.NAMESPACE_DATA["Module"]["id"]
+    module_ns_name = wxr.wtp.NAMESPACE_DATA["Module"]["name"]
+    process_dump(wxr.wtp, args.dump, {module_ns_id})
+    wxr.wtp.add_page(
+        f"{module_ns_name}:Lang-data-export"
+        if args.lang_code == "zh"
+        else f"{module_ns_name}:lang-data-export",
+        module_ns_id,
+        body=LUA_CODE,
+        model="Scribunto",
+    )
+    wxr.wtp.db_conn.commit()
     export_data(wxr, "languages", args.languages)
     export_data(wxr, "families", args.families)
-


### PR DESCRIPTION
The zh.lua file needs update because the `Module:Languages/alldata` page got deleted from Chinese Wiktionary. But the languages JSON file can also be updated via the MediaWiki API(`get_data_remote.py`), which should still work.