### PR TITLE
update Chinese and English language data

### DIFF
--- a/languages/lua/zh.lua
+++ b/languages/lua/zh.lua
@@ -7,8 +7,8 @@ function export.languages()
     local m_zh = require("Module:Zh")
     -- https://zh.wiktionary.org/wiki/Module:Languages
     local m_languages = require("Module:Languages")
-    -- https://zh.wiktionary.org/wiki/Module:Languages/alldata
-    local allData = mw.loadData("Module:Languages/alldata")
+    -- https://zh.wiktionary.org/wiki/Module:Languages/data/all
+    local allData = mw.loadData("Module:Languages/data/all")
 
     local function addNames(allNames, names)
         for _, name in ipairs(names) do
@@ -25,11 +25,15 @@ function export.languages()
         local lang = m_languages.getByCode(code)
         local canonicalName = lang:getCanonicalName()
         addNames(names, {canonicalName})
-        -- the true arg gets ONLY otherNames, not including aliases/varieties
-        local otherNames = lang:getOtherNames(true)
-        addNames(names, otherNames)
-        local aliases = lang:getAliases()
+
+        -- There are methods getAliases() and getOtherNames(), but
+        -- getOtherNames() doesn't work as of 2023-06-27.
+        lang:loadInExtraData()
+        local aliases = lang._rawData.aliases or (lang._extraData and lang._extraData.aliases) or {}
         addNames(names, aliases)
+        local otherNames = lang._rawData.otherNames or (lang._extraData and lang._extraData.otherNames) or {}
+        addNames(names, otherNames)
+
         ret[code] = names
     end
     

--- a/wiktextract/data/en/languages.json
+++ b/wiktextract/data/en/languages.json
@@ -1182,8 +1182,17 @@
   ],
   "aoc": [
     "Pemon",
+    "Pemón",
     "Arekuna",
-    "Arecuna"
+    "Arecuna",
+    "Taurepan",
+    "Taurepán",
+    "Taurepang",
+    "Taulipang",
+    "Taulipáng",
+    "Kamarakoto",
+    "Camaracoto",
+    "Camaragoto"
   ],
   "aod": [
     "Andarum"
@@ -4097,7 +4106,8 @@
   ],
   "btm": [
     "Mandailing Batak",
-    "Batak Mandailing"
+    "Batak Mandailing",
+    "Mandailing"
   ],
   "btn": [
     "Ratagnon"
@@ -4116,7 +4126,8 @@
   ],
   "bts": [
     "Simalungun Batak",
-    "Batak Simalungun"
+    "Batak Simalungun",
+    "Simalungun"
   ],
   "btt": [
     "Bete-Bendi"
@@ -5709,6 +5720,10 @@
   "crp-rsn": [
     "Russenorsk"
   ],
+  "crp-tnw": [
+    "Tangwang",
+    "Tangwanghua"
+  ],
   "crp-tpr": [
     "Taimyr Pidgin Russian"
   ],
@@ -5982,6 +5997,15 @@
   "cus-pro": [
     "Proto-Cushitic"
   ],
+  "cus-som-pro": [
+    "Proto-Somaloid",
+    "Proto-Sam",
+    "Proto-Macro-Somali"
+  ],
+  "cus-sou-pro": [
+    "Proto-South Cushitic",
+    "Proto-Rift"
+  ],
   "cut": [
     "Teutila Cuicatec"
   ],
@@ -6160,7 +6184,8 @@
     "Doka"
   ],
   "dbj": [
-    "Ida'an"
+    "Ida'an",
+    "Idahan"
   ],
   "dbl": [
     "Dyirbal"
@@ -6784,6 +6809,9 @@
   "dra-okn": [
     "Old Kannada",
     "Halegannada"
+  ],
+  "dra-ote": [
+    "Old Telugu"
   ],
   "dra-pro": [
     "Proto-Dravidian"
@@ -8349,6 +8377,10 @@
   ],
   "gih": [
     "Githabul"
+  ],
+  "gii": [
+    "Girirra",
+    "Gariire"
   ],
   "gil": [
     "Gilbertese",
@@ -10232,7 +10264,8 @@
   ],
   "ilo": [
     "Ilocano",
-    "Ilokano"
+    "Ilokano",
+    "Iloko"
   ],
   "ils": [
     "International Sign"
@@ -10604,8 +10637,8 @@
     "Iteri"
   ],
   "its": [
-    "Isekiri",
-    "Itsekiri"
+    "Itsekiri",
+    "Isekiri"
   ],
   "itt": [
     "Maeng Itneg"
@@ -10891,7 +10924,8 @@
     "Ngomba"
   ],
   "jhi": [
-    "Jehai"
+    "Jehai",
+    "Jahai"
   ],
   "jhs": [
     "Jhankot Sign Language"
@@ -14423,7 +14457,9 @@
   ],
   "lrl": [
     "Larestani",
-    "Achomi"
+    "Achomi",
+    "Lari",
+    "Khodmooni"
   ],
   "lrm": [
     "Marama"
@@ -14573,7 +14609,7 @@
     "Lumbu"
   ],
   "luq": [
-    "Lucumi"
+    "Lucumí"
   ],
   "lur": [
     "Laura"
@@ -14947,7 +14983,8 @@
     "Massalat"
   ],
   "mdh": [
-    "Maguindanao"
+    "Maguindanao",
+    "Maguindanaon"
   ],
   "mdi": [
     "Mamvu"
@@ -15303,7 +15340,8 @@
     "Inner Mbugu"
   ],
   "mhe": [
-    "Besisi"
+    "Besisi",
+    "Mah Meri"
   ],
   "mhf": [
     "Mamaa"
@@ -15879,7 +15917,9 @@
     "Min Bei"
   ],
   "mnq": [
-    "Minriq"
+    "Minriq",
+    "Mendriq",
+    "Menriq"
   ],
   "mnr": [
     "Mono (California)",
@@ -16705,7 +16745,9 @@
     "Mvuba"
   ],
   "mxi": [
-    "Mozarabic"
+    "Mozarabic",
+    "Ajami",
+    "Andalusi Romance"
   ],
   "mxj": [
     "Miju",
@@ -19091,7 +19133,8 @@
   "okn": [
     "Oki-No-Erabu",
     "Okino-Erabu",
-    "Okinoerabu"
+    "Okinoerabu",
+    "Oki-no-Erabu"
   ],
   "oko": [
     "Old Korean"
@@ -20889,6 +20932,25 @@
     "Proto-Kra-Dai",
     "Proto-Tai-Kadai"
   ],
+  "qfa-xgx-tuh": [
+    "Tuyuhun",
+    "'Azha"
+  ],
+  "qfa-xgx-tuo": [
+    "Tuoba",
+    "Tabghach",
+    "Taghbach"
+  ],
+  "qfa-xgx-wuh": [
+    "Wuhuan",
+    "Wuwan",
+    "Awar"
+  ],
+  "qfa-xgx-xbi": [
+    "Xianbei",
+    "Serbi",
+    "Shirwi"
+  ],
   "qfa-yen-pro": [
     "Proto-Yeniseian"
   ],
@@ -22484,7 +22546,8 @@
     "Gallurese"
   ],
   "sdo": [
-    "Bukar-Sadung Bidayuh"
+    "Bukar-Sadung Bidayuh",
+    "Bukar-Sadong"
   ],
   "sdp": [
     "Sherdukpen"
@@ -22844,7 +22907,8 @@
   "shy": [
     "Tachawit",
     "Shawiya Berber",
-    "Chaouïa"
+    "Chaouïa",
+    "Tacawit"
   ],
   "shz": [
     "Syenara Senoufo"
@@ -23669,7 +23733,8 @@
     "Siriano"
   ],
   "srk": [
-    "Serudung Murut"
+    "Serudung Murut",
+    "Serudung"
   ],
   "srl": [
     "Isirawa"
@@ -26127,7 +26192,8 @@
     "Ulithian"
   ],
   "ulk": [
-    "Meriam"
+    "Meriam",
+    "Meriam Mir"
   ],
   "ull": [
     "Ullatan"
@@ -27897,6 +27963,11 @@
   ],
   "xgn-pro": [
     "Proto-Mongolic"
+  ],
+  "xgn-rou": [
+    "Rouran",
+    "Ruanruan",
+    "Ruan-ruan"
   ],
   "xgr": [
     "Garza"

--- a/wiktextract/data/zh/languages.json
+++ b/wiktextract/data/zh/languages.json
@@ -26,8 +26,7 @@
   ],
   "aag": [
     "安布拉克語",
-    "安布拉克语",
-    "Ambrak"
+    "安布拉克语"
   ],
   "aah": [
     "Abu' Arapesh",
@@ -42,7 +41,6 @@
   "aak": [
     "安卡維語",
     "安卡维语",
-    "Ankave",
     "Angave"
   ],
   "aal": [
@@ -59,12 +57,12 @@
   "aaq": [
     "佩諾布斯科特語",
     "佩诺布斯科特语",
-    "Penobscot",
     "Eastern Abenaki",
     "Eastern Abnaki"
   ],
   "aas": [
-    "Aasax",
+    "阿薩語",
+    "阿萨语",
     "Aasáx",
     "Asa",
     "Aramanik",
@@ -72,29 +70,24 @@
   ],
   "aau": [
     "阿包語",
-    "阿包语",
-    "Abau"
+    "阿包语"
   ],
   "aav-khs-pro": [
     "原始卡西語",
     "原始卡西语",
-    "Proto-Khasian",
     "Proto-Khasic"
   ],
   "aav-nic-pro": [
     "原始尼科巴語",
-    "原始尼科巴语",
-    "Proto-Nicobarese"
+    "原始尼科巴语"
   ],
   "aav-pkl-pro": [
     "原始布那-卡西-林甘語",
-    "原始布那-卡西-林甘语",
-    "Proto-Pnar-Khasi-Lyngngam"
+    "原始布那-卡西-林甘语"
   ],
   "aav-pro": [
     "原始南亞語",
-    "原始南亚语",
-    "Proto-Austroasiatic"
+    "原始南亚语"
   ],
   "aaw": [
     "Solong",
@@ -106,8 +99,7 @@
   ],
   "aaz": [
     "阿馬拉斯語",
-    "阿马拉斯语",
-    "Amarasi"
+    "阿马拉斯语"
   ],
   "ab": [
     "阿布哈茲語",
@@ -132,13 +124,12 @@
   ],
   "abd": [
     "北甘馬粦阿埃塔語",
-    "北甘马粦阿埃塔语",
+    "北甘马磷阿埃塔语",
     "Manide"
   ],
   "abe": [
     "阿貝納基語",
     "阿贝纳基语",
-    "Abenaki",
     "Western Abenaki",
     "Abnaki",
     "Western Abnaki"
@@ -151,8 +142,7 @@
   ],
   "abh": [
     "塔吉克阿拉伯語",
-    "塔吉克阿拉伯语",
-    "Tajiki Arabic"
+    "塔吉克阿拉伯语"
   ],
   "abi": [
     "Abidji"
@@ -189,8 +179,7 @@
   ],
   "abq": [
     "阿巴扎語",
-    "阿巴扎语",
-    "Abaza"
+    "阿巴扎语"
   ],
   "abr": [
     "Abron",
@@ -198,8 +187,7 @@
   ],
   "abs": [
     "安汶馬來語",
-    "安汶马来语",
-    "Ambonese Malay"
+    "安汶马来语"
   ],
   "abt": [
     "Ambulas"
@@ -210,7 +198,6 @@
   "abv": [
     "巴林阿拉伯語",
     "巴林阿拉伯语",
-    "Baharna Arabic",
     "Bahrani Arabic"
   ],
   "abw": [
@@ -218,13 +205,11 @@
   ],
   "abx": [
     "阿巴克農語",
-    "阿巴克农语",
-    "Inabaknon"
+    "阿巴克农语"
   ],
   "aby": [
     "阿比亞語",
-    "阿比亚语",
-    "Aneme Wake"
+    "阿比亚语"
   ],
   "abz": [
     "Abui"
@@ -243,14 +228,12 @@
   "ace": [
     "亞齊語",
     "亚齐语",
-    "Acehnese",
     "Achinese",
     "Atjehnese"
   ],
   "ach": [
     "阿喬利語",
     "阿乔利语",
-    "Acholi",
     "Acoli",
     "Shuli",
     "Acooli"
@@ -278,18 +261,13 @@
   "acm": [
     "美索不達米亞阿拉伯語",
     "美索不达米亚阿拉伯语",
-    "伊拉克阿拉伯語",
-    "伊拉克阿拉伯语",
-    "Iraqi Arabic",
     "Mesopotamian Arabic"
   ],
   "acn": [
     "阿昌語",
     "阿昌语",
-    "Achang",
     "Xiandao",
-    "Ngochang",
-    "Ngachang"
+    "Chintaw"
   ],
   "acp": [
     "Eastern Acipa"
@@ -318,30 +296,25 @@
   "acw": [
     "漢志阿拉伯語",
     "汉志阿拉伯语",
-    "Hijazi Arabic",
     "Hejazi Arabic",
     "West Arabian Arabic"
   ],
   "acx": [
     "阿曼阿拉伯語",
-    "阿曼阿拉伯语",
-    "Omani Arabic"
+    "阿曼阿拉伯语"
   ],
   "acy": [
     "塞浦路斯阿拉伯語",
-    "塞浦路斯阿拉伯语",
-    "Cypriot Arabic"
+    "塞浦路斯阿拉伯语"
   ],
   "acz": [
     "阿克隆語",
     "阿克隆语",
-    "Acheron",
     "Asheron"
   ],
   "ada": [
     "阿當梅語",
     "阿当梅语",
-    "Adangme",
     "Dangme"
   ],
   "adb": [
@@ -356,13 +329,11 @@
   ],
   "adf": [
     "多法爾阿拉伯語",
-    "多法尔阿拉伯语",
-    "Dhofari Arabic"
+    "多法尔阿拉伯语"
   ],
   "adg": [
     "安德格雷賓哈語",
-    "安德格雷宾哈语",
-    "Andegerebinha"
+    "安德格雷宾哈语"
   ],
   "adh": [
     "Adhola"
@@ -370,7 +341,6 @@
   "adi": [
     "阿迪語",
     "阿迪语",
-    "Adi",
     "Abor",
     "Ashing",
     "Minyong",
@@ -398,7 +368,6 @@
   "ado": [
     "阿布語",
     "阿布语",
-    "Abu",
     "Adjora"
   ],
   "adp": [
@@ -416,8 +385,7 @@
   ],
   "adt": [
     "阿德尼亞馬塔納語",
-    "阿德尼亚马塔纳语",
-    "Adnyamathanh"
+    "阿德尼亚马塔纳语"
   ],
   "adu": [
     "Aduge"
@@ -426,47 +394,32 @@
     "Amondawa",
     "Amundava"
   ],
-  "adx": [
-    "安多藏語",
-    "安多藏语",
-    "Amdo Tibetan",
-    "Amdo",
-    "Panang"
-  ],
   "ady": [
     "阿迪格語",
     "阿迪格语",
-    "Adyghe",
     "West Circassian"
   ],
   "adz": [
     "阿哲拉語",
-    "阿哲拉语",
-    "Adzera"
+    "阿哲拉语"
   ],
   "ae": [
     "阿維斯陀語",
     "阿维斯陀语",
     "Zend",
-    "古巴克特里亞語",
-    "古巴克特里亚语"
+    "Old Bactrian"
   ],
   "aea": [
     "阿雷巴語",
-    "阿雷巴语",
-    "Areba"
+    "阿雷巴语"
   ],
   "aeb": [
     "突尼斯阿拉伯語",
-    "突尼斯阿拉伯语",
-    "突尼西亞阿拉伯語",
-    "突尼西亚阿拉伯语",
-    "Tunisian Arabic"
+    "突尼斯阿拉伯语"
   ],
   "aed": [
     "阿根廷手語",
-    "阿根廷手语",
-    "Argentine Sign Language"
+    "阿根廷手语"
   ],
   "aee": [
     "Northeast Pashayi",
@@ -481,23 +434,19 @@
   ],
   "aem": [
     "阿楞語",
-    "阿楞语",
-    "Arem"
+    "阿楞语"
   ],
   "aen": [
     "亞美尼亞手語",
-    "亚美尼亚手语",
-    "Armenian Sign Language"
+    "亚美尼亚手语"
   ],
   "aeq": [
     "埃爾語",
-    "埃尔语",
-    "Aer"
+    "埃尔语"
   ],
   "aer": [
     "東阿蘭達語",
-    "东阿兰达语",
-    "Eastern Arrernte"
+    "东阿兰达语"
   ],
   "aes": [
     "Alsea",
@@ -525,23 +474,17 @@
   ],
   "af": [
     "南非語",
-    "南非语",
-    "阿非利堪斯語",
-    "阿非利堪斯语",
-    "南非荷蘭語",
-    "南非荷兰语"
+    "南非语"
   ],
   "afa-pro": [
     "原始亞非語",
     "原始亚非语",
-    "Proto-Afroasiatic",
     "Proto-Afro-Asiatic",
     "Hamito-Semitic"
   ],
   "afb": [
     "海灣阿拉伯語",
-    "海湾阿拉伯语",
-    "Gulf Arabic"
+    "海湾阿拉伯语"
   ],
   "afd": [
     "Andai"
@@ -551,8 +494,7 @@
   ],
   "afg": [
     "阿富汗手語",
-    "阿富汗手语",
-    "Afghan Sign Language"
+    "阿富汗手语"
   ],
   "afh": [
     "阿弗里希利語",
@@ -620,8 +562,7 @@
   ],
   "agk": [
     "伊薩羅格阿埃塔語",
-    "伊萨罗格阿埃塔语",
-    "Isarog Agta"
+    "伊萨罗格阿埃塔语"
   ],
   "agl": [
     "Fembe",
@@ -629,8 +570,7 @@
   ],
   "agm": [
     "安加塔哈語",
-    "安加塔哈语",
-    "Angaataha"
+    "安加塔哈语"
   ],
   "agn": [
     "阿古塔農語",
@@ -645,8 +585,7 @@
   ],
   "agr": [
     "阿瓜魯那語",
-    "阿瓜鲁那语",
-    "Aguaruna"
+    "阿瓜鲁那语"
   ],
   "ags": [
     "Esimbi",
@@ -654,8 +593,7 @@
   ],
   "agt": [
     "中卡加延阿埃塔語",
-    "中卡加延阿埃塔语",
-    "Central Cagayan Agta"
+    "中卡加延阿埃塔语"
   ],
   "agu": [
     "Aguacateca",
@@ -678,7 +616,6 @@
   "agx": [
     "阿古爾語",
     "阿古尔语",
-    "Aghul",
     "Agul"
   ],
   "agy": [
@@ -686,8 +623,7 @@
   ],
   "agz": [
     "伊里加山阿埃塔語",
-    "伊里加山阿埃塔语",
-    "Mount Iriga Agta"
+    "伊里加山阿埃塔语"
   ],
   "aha": [
     "Ahanta"
@@ -722,8 +658,7 @@
   ],
   "aho": [
     "阿洪姆語",
-    "阿洪姆语",
-    "Ahom"
+    "阿洪姆语"
   ],
   "ahp": [
     "Aproumu Aizi"
@@ -731,7 +666,6 @@
   "ahr": [
     "阿希拉尼語",
     "阿希拉尼语",
-    "Ahirani",
     "Khandeshi",
     "Khandesi"
   ],
@@ -739,7 +673,8 @@
     "Ashe"
   ],
   "aht": [
-    "Ahtna"
+    "阿特納語",
+    "阿特纳语"
   ],
   "aia": [
     "Arosi"
@@ -747,8 +682,6 @@
   "aib": [
     "艾努語",
     "艾努语",
-    "Aynu",
-    "Ainu",
     "Äynu",
     "Ainu (China)",
     "Aini",
@@ -762,8 +695,7 @@
   ],
   "aid": [
     "阿爾吉特語",
-    "阿尔吉特语",
-    "Alngith"
+    "阿尔吉特语"
   ],
   "aie": [
     "Amara"
@@ -774,38 +706,20 @@
   "aig": [
     "安提瓜和巴布達克里奧爾英語",
     "安提瓜和巴布达克里奥尔英语",
-    "Antigua and Barbuda Creole English",
     "Leeward Caribbean Creole English",
     "Antiguan Creole English",
     "Kokoy Creole English",
     "Saint Kitts Creole",
     "Montserrat Creole",
-    "Anguillan Creole",
-    "向風加勒比克里奧爾英語",
-    "向风加勒比克里奥尔英语",
-    "安提瓜克里奧爾英語",
-    "安提瓜克里奥尔英语",
-    "Kokoy Creole English",
-    "聖基茨克里奧爾語",
-    "圣基茨克里奥尔语",
-    "蒙特塞拉特克里奧爾語",
-    "蒙特塞拉特克里奥尔语",
-    "安圭拉克里奧爾語",
-    "安圭拉克里奥尔语"
+    "Anguillan Creole"
   ],
   "aih": [
     "錦語",
-    "锦语",
-    "Ai-Cham",
-    "錦話",
-    "锦话",
-    "甲姆話",
-    "甲姆话"
+    "锦语"
   ],
   "aii": [
     "亞述新亞拉姆語",
-    "亚述新亚拉姆语",
-    "Assyrian Neo-Aramaic"
+    "亚述新亚拉姆语"
   ],
   "aij": [
     "Lishanid Noshan"
@@ -822,15 +736,11 @@
   "ain": [
     "阿伊努語",
     "阿伊努语",
-    "愛奴語",
-    "爱奴语",
-    "Ainu",
     "Ainu (Japan)"
   ],
   "aio": [
     "艾通語",
     "艾通语",
-    "Aiton",
     "Tai Aiton",
     "Aitonia",
     "Sham Doaniya"
@@ -861,7 +771,6 @@
   "ajg": [
     "阿賈語",
     "阿贾语",
-    "Adja",
     "Aja",
     "Aja (Benin)",
     "Aja (Togo)",
@@ -870,7 +779,6 @@
   "aji": [
     "阿日厄語",
     "阿日厄语",
-    "Ajië",
     "Houailou"
   ],
   "ajn": [
@@ -878,18 +786,7 @@
   ],
   "ajp": [
     "南黎凡特阿拉伯語",
-    "南黎凡特阿拉伯语",
-    "South Levantine Arabic"
-  ],
-  "ajt": [
-    "猶太突尼西亞阿拉伯語",
-    "犹太突尼西亚阿拉伯语",
-    "Judeo-Tunisian Arabic"
-  ],
-  "aju": [
-    "猶太摩洛哥阿拉伯語",
-    "犹太摩洛哥阿拉伯语",
-    "Judeo-Moroccan Arabic"
+    "南黎凡特阿拉伯语"
   ],
   "ajw": [
     "Ajawa"
@@ -904,7 +801,7 @@
   "akb": [
     "昂科拉巴塔克語",
     "昂科拉巴塔克语",
-    "Angkola Batak, Batak Angkola"
+    "Batak Angkola"
   ],
   "akc": [
     "Mpur"
@@ -940,13 +837,11 @@
   ],
   "akk": [
     "阿卡德語",
-    "阿卡德语",
-    "Akkadian"
+    "阿卡德语"
   ],
   "akl": [
     "阿克蘭語",
     "阿克兰语",
-    "Aklanon",
     "Aklan",
     "Akeanon"
   ],
@@ -966,8 +861,7 @@
   ],
   "akr": [
     "阿拉基語",
-    "阿拉基语",
-    "Araki"
+    "阿拉基语"
   ],
   "aks": [
     "Akaselem",
@@ -983,8 +877,7 @@
   ],
   "akv": [
     "阿赫瓦赫語",
-    "阿赫瓦赫语",
-    "Akhvakh"
+    "阿赫瓦赫语"
   ],
   "akw": [
     "Akwa"
@@ -1002,8 +895,7 @@
   ],
   "akz": [
     "亞拉巴馬語",
-    "亚拉巴马语",
-    "Alabama"
+    "亚拉巴马语"
   ],
   "ala": [
     "Alago"
@@ -1011,9 +903,6 @@
   "alc": [
     "卡瓦斯卡爾語",
     "卡瓦斯卡尔语",
-    "阿拉卡盧夫語",
-    "阿拉卡卢夫语",
-    "Kawésqar",
     "Qawasqar",
     "Alacaluf"
   ],
@@ -1026,7 +915,6 @@
   "ale": [
     "阿留申語",
     "阿留申语",
-    "Aleut",
     "Aleutian"
   ],
   "alf": [
@@ -1035,34 +923,28 @@
   "alg-aga": [
     "阿加萬語",
     "阿加万语",
-    "Agawam",
     "Agwam",
     "Agaam"
   ],
   "alg-pro": [
     "原始阿爾岡昆語",
-    "原始阿尔冈昆语",
-    "Proto-Algonquian"
+    "原始阿尔冈昆语"
   ],
   "alh": [
     "阿拉瓦語",
-    "阿拉瓦语",
-    "Alawa"
+    "阿拉瓦语"
   ],
   "ali": [
     "阿邁蒙語",
-    "阿迈蒙语",
-    "Amaimon"
+    "阿迈蒙语"
   ],
   "alj": [
     "阿蘭岡語",
-    "阿兰冈语",
-    "Alangan"
+    "阿兰冈语"
   ],
   "alk": [
     "阿拉克語",
-    "阿拉克语",
-    "Alak"
+    "阿拉克语"
   ],
   "all": [
     "Allar",
@@ -1076,23 +958,19 @@
   ],
   "alp": [
     "阿魯尼語",
-    "阿鲁尼语",
-    "Alune"
+    "阿鲁尼语"
   ],
   "alq": [
     "阿爾岡昆語",
-    "阿尔冈昆语",
-    "Algonquin"
+    "阿尔冈昆语"
   ],
   "alr": [
     "阿留特語",
-    "阿留特语",
-    "Alutor"
+    "阿留特语"
   ],
   "alt": [
     "南阿爾泰語",
     "南阿尔泰语",
-    "Southern Altai",
     "Southern Altay",
     "Altai",
     "Altay"
@@ -1100,7 +978,6 @@
   "alu": [
     "阿雷阿雷語",
     "阿雷阿雷语",
-    "'Are'are",
     "Areare"
   ],
   "alv-ama": [
@@ -1114,24 +991,21 @@
   ],
   "alv-bua-pro": [
     "原始布阿語",
-    "原始布阿语",
-    "Proto-Bua"
+    "原始布阿语"
   ],
   "alv-cng-pro": [
     "Proto-Cangin"
   ],
   "alv-edo-pro": [
     "原始類埃多語",
-    "原始类埃多语",
-    "Proto-Edoid"
+    "原始类埃多语"
   ],
   "alv-fli-pro": [
     "Proto-Fali"
   ],
   "alv-gbe-pro": [
     "原始格貝語",
-    "原始格贝语",
-    "Proto-Gbe"
+    "原始格贝语"
   ],
   "alv-gng-pro": [
     "Proto-Guang"
@@ -1139,16 +1013,17 @@
   "alv-gtm-pro": [
     "原始中多哥語",
     "原始中多哥语",
-    "Proto-Central Togo",
     "Proto-Ghana-Togo Mountain"
   ],
   "alv-gwa": [
     "瓜拉語",
-    "瓜拉语",
-    "Gwara"
+    "瓜拉语"
   ],
   "alv-hei-pro": [
     "Proto-Heiban"
+  ],
+  "alv-ido-pro": [
+    "Proto-Idomoid"
   ],
   "alv-igb-pro": [
     "Proto-Igboid"
@@ -1164,13 +1039,15 @@
   ],
   "alv-pro": [
     "原始大西洋-剛果語",
-    "原始大西洋-刚果语",
-    "Proto-Atlantic-Congo"
+    "原始大西洋-刚果语"
+  ],
+  "alv-von-pro": [
+    "原始沃爾特-尼日爾語",
+    "原始沃尔特-尼日尔语"
   ],
   "alv-yor-pro": [
     "類約魯巴語支",
-    "类约鲁巴语支",
-    "Proto-Yoruboid"
+    "类约鲁巴语支"
   ],
   "alw": [
     "Alaba",
@@ -1183,8 +1060,7 @@
   ],
   "aly": [
     "阿利亞瓦拉語",
-    "阿利亚瓦拉语",
-    "Alyawarr"
+    "阿利亚瓦拉语"
   ],
   "alz": [
     "Alur"
@@ -1216,7 +1092,7 @@
   "ami": [
     "阿美語",
     "阿美语",
-    "Amis"
+    "Nataoran Amis"
   ],
   "amj": [
     "Amdang",
@@ -1233,14 +1109,12 @@
   "amm": [
     "阿瑪語",
     "阿玛语",
-    "Ama",
     "Ama (New Guinea)",
     "Ama (Papua New Guinea)"
   ],
   "amn": [
     "阿瑪納卜語",
-    "阿玛纳卜语",
-    "Amanab"
+    "阿玛纳卜语"
   ],
   "amo": [
     "Amo",
@@ -1261,8 +1135,7 @@
   ],
   "ams": [
     "南奄美大島語",
-    "南奄美大岛语",
-    "Southern Amami-Oshima"
+    "南奄美大岛语"
   ],
   "amt": [
     "Amto"
@@ -1270,7 +1143,6 @@
   "amu": [
     "格雷羅阿穆茲戈語",
     "格雷罗阿穆兹戈语",
-    "Guerrero Amuzgo",
     "Amuzgo",
     "Xochistlahuaca Amuzgo",
     "Northern Amuzgo",
@@ -1281,8 +1153,7 @@
   ],
   "amw": [
     "西現代亞拉姆語",
-    "西现代亚拉姆语",
-    "Western Neo-Aramaic"
+    "西现代亚拉姆语"
   ],
   "amx": [
     "Anmatyerre",
@@ -1291,14 +1162,12 @@
   "amy": [
     "阿米語",
     "阿米语",
-    "Ami",
     "Ame",
     "Amijangal"
   ],
   "amz": [
     "阿坦帕雅語",
-    "阿坦帕雅语",
-    "Atampaya"
+    "阿坦帕雅语"
   ],
   "an": [
     "阿拉貢語",
@@ -1336,8 +1205,7 @@
   ],
   "ane": [
     "哈拉楚語",
-    "哈拉楚语",
-    "Xârâcùù"
+    "哈拉楚语"
   ],
   "anf": [
     "Animere"
@@ -1345,10 +1213,7 @@
   "ang": [
     "古英語",
     "古英语",
-    "Old English",
-    "Anglo-Saxon",
-    "盎格魯-撒克遜語",
-    "盎格鲁-撒克逊语"
+    "Anglo-Saxon"
   ],
   "anh": [
     "Nend",
@@ -1357,8 +1222,7 @@
   ],
   "ani": [
     "安迪語",
-    "安迪语",
-    "Andi"
+    "安迪语"
   ],
   "anj": [
     "Anor"
@@ -1375,7 +1239,6 @@
   "anm": [
     "阿納爾語",
     "阿纳尔语",
-    "Anal",
     "Anaal",
     "Namfau"
   ],
@@ -1387,27 +1250,23 @@
   ],
   "anp": [
     "昂加語",
-    "昂加语",
-    "Angika"
+    "昂加语"
   ],
   "anq": [
     "加洛瓦語",
     "加洛瓦语",
-    "Jarawa",
     "Jarawa (India)"
   ],
   "anr": [
     "安德赫語",
-    "安德赫语",
-    "Andh"
+    "安德赫语"
   ],
   "ans": [
     "Anserma"
   ],
   "ant": [
     "安塔卡林亞語",
-    "安塔卡林亚语",
-    "Antakarinya"
+    "安塔卡林亚语"
   ],
   "anu": [
     "Anuak",
@@ -1437,16 +1296,24 @@
   ],
   "aoa": [
     "安哥拉克里奧爾語",
-    "安哥拉克里奥尔语",
-    "Angolar"
+    "安哥拉克里奥尔语"
   ],
   "aob": [
     "Abom"
   ],
   "aoc": [
     "Pemon",
+    "Pemón",
     "Arekuna",
-    "Arecuna"
+    "Arecuna",
+    "Taurepan",
+    "Taurepán",
+    "Taurepang",
+    "Taulipang",
+    "Taulipáng",
+    "Kamarakoto",
+    "Camaracoto",
+    "Camaragoto"
   ],
   "aod": [
     "Andarum"
@@ -1466,7 +1333,6 @@
   "aoi": [
     "阿寧迪爾雅夸語",
     "阿宁迪尔雅夸语",
-    "Anindilyakwa",
     "Enindhilyagwa"
   ],
   "aoj": [
@@ -1500,29 +1366,19 @@
   "aou": [
     "阿歐語",
     "阿欧语",
-    "阿歐話",
-    "阿欧话",
-    "阿歐方言",
-    "阿欧方言",
-    "阿歐仡佬語",
-    "阿欧仡佬语",
-    "紅仡佬語",
-    "红仡佬语",
-    "紅豐仡佬語",
-    "红丰仡佬语"
+    "Ayo",
+    "A'ou Gelao"
   ],
   "aox": [
     "Atorada"
   ],
   "aoz": [
     "瓦布梅托語",
-    "瓦布梅托语",
-    "Uab Meto"
+    "瓦布梅托语"
   ],
   "apa-pro": [
     "原始阿帕契語",
     "原始阿帕契语",
-    "Proto-Apachean",
     "Proto-Apache",
     "Proto-Southern Athabaskan"
   ],
@@ -1533,21 +1389,18 @@
   ],
   "apc": [
     "北黎凡特阿拉伯語",
-    "北黎凡特阿拉伯语",
-    "North Levantine Arabic"
+    "北黎凡特阿拉伯语"
   ],
   "apd": [
     "蘇丹阿拉伯語",
-    "苏丹阿拉伯语",
-    "Sudanese Arabic"
+    "苏丹阿拉伯语"
   ],
   "ape": [
     "Bukiyip"
   ],
   "apf": [
     "帕拉南阿埃塔語",
-    "帕拉南阿埃塔语",
-    "Pahanan Agta"
+    "帕拉南阿埃塔语"
   ],
   "apg": [
     "Ampanang"
@@ -1567,7 +1420,6 @@
   "apk": [
     "平原阿帕契語",
     "平原阿帕契语",
-    "Plains Apache",
     "Kiowa Apache"
   ],
   "apl": [
@@ -1623,8 +1475,7 @@
   ],
   "apw": [
     "西阿帕契語",
-    "西阿帕契语",
-    "Western Apacheii"
+    "西阿帕契语"
   ],
   "apx": [
     "Aputai"
@@ -1632,8 +1483,7 @@
   "apy": [
     "阿帕萊語",
     "阿帕莱语",
-    "Apalai",
-    "Apalaí"
+    "Apalai"
   ],
   "apz": [
     "Safeyoka"
@@ -1650,8 +1500,7 @@
   ],
   "aql-pro": [
     "原始阿爾吉克語",
-    "原始阿尔吉克语",
-    "Proto-Algic"
+    "原始阿尔吉克语"
   ],
   "aqm": [
     "Atohwaim"
@@ -1678,31 +1527,21 @@
   "ar": [
     "阿拉伯語",
     "阿拉伯语",
-    "現代標準阿拉伯語",
-    "现代标准阿拉伯语",
-    "標準阿拉伯語",
-    "标准阿拉伯语",
-    "書面阿拉伯語",
-    "书面阿拉伯语",
-    "Classical Arabic"
+    "Standard Arabic",
+    "Literary Arabic",
+    "High Arabic"
   ],
   "arc": [
     "亞拉姆語",
-    "亚拉姆语",
-    "Aramaic",
-    "Imperial Aramaic",
-    "Official Aramaic",
-    "Biblical Aramaic"
+    "亚拉姆语"
   ],
   "ard": [
     "阿拉巴納語",
-    "阿拉巴纳语",
-    "Arabana"
+    "阿拉巴纳语"
   ],
   "are": [
     "西阿蘭達語",
-    "西阿兰达语",
-    "Western Arrernte"
+    "西阿兰达语"
   ],
   "arh": [
     "Arhuaco",
@@ -1723,7 +1562,6 @@
   "arn": [
     "馬普切語",
     "马普切语",
-    "Mapudungun",
     "Mapuche",
     "Mapudungün",
     "Mapuzugün",
@@ -1736,13 +1574,11 @@
   ],
   "arp": [
     "阿拉帕霍語",
-    "阿拉帕霍语",
-    "Arapaho"
+    "阿拉帕霍语"
   ],
   "arq": [
     "阿爾及利亞阿拉伯語",
-    "阿尔及利亚阿拉伯语",
-    "Algerian Arabic"
+    "阿尔及利亚阿拉伯语"
   ],
   "arr": [
     "Arara-Karo",
@@ -1762,26 +1598,22 @@
   ],
   "ars": [
     "內志阿拉伯語",
-    "内志阿拉伯语",
-    "Najdi Arabic"
+    "内志阿拉伯语"
   ],
   "art-blk": [
     "Bolak"
   ],
   "art-bsp": [
     "黑暗語",
-    "黑暗语",
-    "Black Speech"
+    "黑暗语"
   ],
   "art-com": [
     "溝通語",
-    "沟通语",
-    "Communicationssprache"
+    "沟通语"
   ],
   "art-dtk": [
     "多斯拉克語",
-    "多斯拉克语",
-    "Dothraki"
+    "多斯拉克语"
   ],
   "art-elo": [
     "Eloi"
@@ -1794,8 +1626,7 @@
   ],
   "art-man": [
     "曼達洛語",
-    "曼达洛语",
-    "Mandalorian"
+    "曼达洛语"
   ],
   "art-mun": [
     "Mundolinco"
@@ -1821,7 +1652,6 @@
   "arw": [
     "阿拉瓦克語",
     "阿拉瓦克语",
-    "Arawak",
     "Arowak",
     "Lokono"
   ],
@@ -1834,13 +1664,11 @@
   ],
   "ary": [
     "摩洛哥阿拉伯語",
-    "摩洛哥阿拉伯语",
-    "Moroccan Arabic"
+    "摩洛哥阿拉伯语"
   ],
   "arz": [
     "埃及阿拉伯語",
-    "埃及阿拉伯语",
-    "Egyptian Arabic"
+    "埃及阿拉伯语"
   ],
   "as": [
     "阿薩姆語",
@@ -1859,8 +1687,7 @@
   ],
   "asb": [
     "阿西內本語",
-    "阿西内本语",
-    "Assiniboine"
+    "阿西内本语"
   ],
   "asc": [
     "Casuarina Coast Asmat"
@@ -1868,16 +1695,12 @@
   "ase": [
     "美國手語",
     "美国手语",
-    "American Sign Language",
     "Ameslan",
     "ASL"
   ],
   "asf": [
     "澳洲手語",
     "澳洲手语",
-    "澳大利亞手語",
-    "澳大利亚手语",
-    "Auslan",
     "Australian Sign Language"
   ],
   "asg": [
@@ -1907,13 +1730,11 @@
   ],
   "ask": [
     "阿什昆語",
-    "阿什昆语",
-    "Ashkun"
+    "阿什昆语"
   ],
   "asl": [
     "阿西魯魯語",
-    "阿西鲁鲁语",
-    "Asilulu"
+    "阿西鲁鲁语"
   ],
   "asn": [
     "Xingú Asuriní"
@@ -1923,13 +1744,11 @@
   ],
   "asp": [
     "阿爾及利亞手語",
-    "阿尔及利亚手语",
-    "Algerian Sign Language"
+    "阿尔及利亚手语"
   ],
   "asq": [
     "奧地利手語",
-    "奥地利手语",
-    "Austrian Sign Language"
+    "奥地利手语"
   ],
   "asr": [
     "Asuri",
@@ -1940,8 +1759,7 @@
   ],
   "ast": [
     "阿斯圖里亞斯語",
-    "阿斯图里亚斯语",
-    "Asturian"
+    "阿斯图里亚斯语"
   ],
   "asu": [
     "Tocantins Asurini",
@@ -1958,7 +1776,6 @@
   "asw": [
     "澳洲原住民手語",
     "澳洲原住民手语",
-    "Australian Aboriginal Sign Language",
     "Australian Aborigines Sign Language"
   ],
   "asx": [
@@ -1977,13 +1794,11 @@
   ],
   "atb": [
     "載瓦語",
-    "载瓦语",
-    "Zaiwa"
+    "载瓦语"
   ],
   "atc": [
     "阿查瓦卡語",
-    "阿查瓦卡语",
-    "Atsahuaca"
+    "阿查瓦卡语"
   ],
   "atd": [
     "亞他-馬諾博語",
@@ -2003,26 +1818,21 @@
   ],
   "ath-pro": [
     "原始德內語",
-    "原始德内语",
-    "Proto-Athabaskan",
-    "原始阿薩巴斯卡語",
-    "原始阿萨巴斯卡语"
+    "原始德内语"
   ],
   "ati": [
     "Attié"
   ],
   "atj": [
     "阿提卡梅克語",
-    "阿提卡梅克语",
-    "Atikamekw"
+    "阿提卡梅克语"
   ],
   "atk": [
     "Ati"
   ],
   "atl": [
     "伊拉亞山阿埃塔語",
-    "伊拉亚山阿埃塔语",
-    "Mount Iraya Agta"
+    "伊拉亚山阿埃塔语"
   ],
   "atm": [
     "Ata"
@@ -2047,8 +1857,7 @@
   ],
   "att": [
     "帕姆普羅納-阿塔語",
-    "帕姆普罗纳-阿塔语",
-    "Pamplona Atta"
+    "帕姆普罗纳-阿塔语"
   ],
   "atu": [
     "Reel"
@@ -2056,7 +1865,6 @@
   "atv": [
     "北阿爾泰語",
     "北阿尔泰语",
-    "Northern Altai",
     "Northern Altay",
     "Altai",
     "Altay"
@@ -2073,21 +1881,18 @@
   ],
   "atz": [
     "阿爾塔語",
-    "阿尔塔语",
-    "Arta"
+    "阿尔塔语"
   ],
   "aua": [
     "Asumboa"
   ],
   "aub": [
     "阿盧固語",
-    "阿卢固语",
-    "Alugu"
+    "阿卢固语"
   ],
   "auc": [
     "瓦奧語",
     "瓦奥语",
-    "Huaorani",
     "Waorani",
     "Sabela",
     "Wao",
@@ -2100,13 +1905,11 @@
   ],
   "aud": [
     "阿努塔語",
-    "阿努塔语",
-    "Anuta"
+    "阿努塔语"
   ],
   "auf-pro": [
     "原始阿拉萬語",
     "原始阿拉万语",
-    "Proto-Arawa",
     "Proto-Arawan",
     "Proto-Arauan"
   ],
@@ -2118,15 +1921,13 @@
   ],
   "aui": [
     "阿努基語",
-    "阿努基语",
-    "Anuki"
+    "阿努基语"
   ],
   "auj": [
     "奧吉拉語",
     "奥吉拉语",
-    "Augila",
     "Awjilah",
-    "Awjila"
+    "Augila"
   ],
   "auk": [
     "Heyo"
@@ -2197,8 +1998,7 @@
   ],
   "aus-cww-pro": [
     "原始中新南威爾士語",
-    "原始中新南威尔士语",
-    "Proto-Central New South Wales"
+    "原始中新南威尔士语"
   ],
   "aus-dal-pro": [
     "Proto-Daly"
@@ -2232,13 +2032,11 @@
   ],
   "aus-nyu-pro": [
     "原始紐爾紐爾語",
-    "原始纽尔纽尔语",
-    "Proto-Nyulnyulan"
+    "原始纽尔纽尔语"
   ],
   "aus-pam-pro": [
     "原始帕馬-恩永甘語",
-    "原始帕马-恩永甘语",
-    "Proto-Pama-Nyungan"
+    "原始帕马-恩永甘语"
   ],
   "aus-tul": [
     "Tulua",
@@ -2255,8 +2053,7 @@
   ],
   "aus-wdj-pro": [
     "原始伊瓦伊賈語",
-    "原始伊瓦伊贾语",
-    "Proto-Iwaidjan"
+    "原始伊瓦伊贾语"
   ],
   "aus-won": [
     "Wong-gie"
@@ -2292,7 +2089,6 @@
   "auz": [
     "烏茲別克阿拉伯語",
     "乌兹别克阿拉伯语",
-    "Uzbeki Arabic",
     "Uzbek Arabic"
   ],
   "av": [
@@ -2306,7 +2102,6 @@
   "avd": [
     "阿爾維里-維達里語",
     "阿尔维里-维达里语",
-    "Alviri-Vidari",
     "Alviri",
     "Vidari"
   ],
@@ -2319,8 +2114,7 @@
   ],
   "avm": [
     "昂卡穆蒂語",
-    "昂卡穆蒂语",
-    "Angkamuthi"
+    "昂卡穆蒂语"
   ],
   "avn": [
     "Avatime"
@@ -2336,8 +2130,7 @@
   ],
   "avu": [
     "阿沃卡雅語",
-    "阿沃卡雅语",
-    "Avokaya"
+    "阿沃卡雅语"
   ],
   "avv": [
     "Avá-Canoeiro",
@@ -2347,7 +2140,7 @@
   "awa": [
     "阿瓦德語",
     "阿瓦德语",
-    "Awadhi"
+    "Oudhi"
   ],
   "awb": [
     "Awa (New Guinea)",
@@ -2446,7 +2239,6 @@
   "awd-pro": [
     "原始阿拉瓦克語",
     "原始阿拉瓦克语",
-    "Proto-Arawak",
     "Proto-Arawakan",
     "Proto-Maipurean",
     "Proto-Maipuran"
@@ -2467,7 +2259,6 @@
   "awd-taa-pro": [
     "原始泰諾-阿拉瓦克語",
     "原始泰诺-阿拉瓦克语",
-    "Proto-Ta-Arawak",
     "Proto-Ta-Arawakan",
     "Proto-Caribbean Northern Arawak"
   ],
@@ -2492,7 +2283,6 @@
   "awg": [
     "安古蒂姆里語",
     "安古蒂姆里语",
-    "Anguthimri",
     "Alngith",
     "Leningitij",
     "Mpakwithi"
@@ -2503,13 +2293,11 @@
   "awi": [
     "阿溫語",
     "阿温语",
-    "Aekyom",
     "Awin"
   ],
   "awk": [
     "阿瓦巴卡爾語",
-    "阿瓦巴卡尔语",
-    "Awabakal"
+    "阿瓦巴卡尔语"
   ],
   "awm": [
     "Arawum"
@@ -2540,8 +2328,7 @@
   ],
   "awx": [
     "阿瓦拉語",
-    "阿瓦拉语",
-    "Awara"
+    "阿瓦拉语"
   ],
   "awy": [
     "Edera Awyu"
@@ -2568,20 +2355,17 @@
   "axl": [
     "南阿蘭達語",
     "南阿兰达语",
-    "Lower Southern Aranda",
     "Lower Southern Arrernte",
     "Southern Arrernte",
     "Southern Aranda"
   ],
   "axm": [
     "中古亞美尼亞語",
-    "中古亚美尼亚语",
-    "Middle Armenian"
+    "中古亚美尼亚语"
   ],
   "axx": [
     "哈拉古雷語",
     "哈拉古雷语",
-    "Xaragure",
     "Xârâgurè"
   ],
   "ay": [
@@ -2598,7 +2382,6 @@
   "ayd": [
     "阿雅巴德胡語",
     "阿雅巴德胡语",
-    "Ayabadhu",
     "Ayapathu",
     "Badhu"
   ],
@@ -2618,13 +2401,11 @@
   ],
   "ayl": [
     "利比亞阿拉伯語",
-    "利比亚阿拉伯语",
-    "Libyan Arabic"
+    "利比亚阿拉伯语"
   ],
   "ayn": [
     "也門阿拉伯語",
-    "也门阿拉伯语",
-    "Yemeni Arabic"
+    "也门阿拉伯语"
   ],
   "ayo": [
     "Ayoreo",
@@ -2636,8 +2417,7 @@
   ],
   "ayp": [
     "北美索不達米亞阿拉伯語",
-    "北美索不达米亚阿拉伯语",
-    "North Mesopotamian Arabic"
+    "北美索不达米亚阿拉伯语"
   ],
   "ayq": [
     "Ayi",
@@ -2670,8 +2450,7 @@
     "阿塞拜疆语",
     "Azeri",
     "Azari",
-    "亞塞拜然語",
-    "亚塞拜然语",
+    "Azeri Turkic",
     "Azerbaijani Turkic"
   ],
   "aza": [
@@ -2691,18 +2470,15 @@
   ],
   "azc-nah-pro": [
     "原始納瓦語",
-    "原始纳瓦语",
-    "Proto-Nahuan"
+    "原始纳瓦语"
   ],
   "azc-num-pro": [
     "原始努姆語",
-    "原始努姆语",
-    "Proto-Numic"
+    "原始努姆语"
   ],
   "azc-pro": [
     "原始猶他-阿茲特克語",
-    "原始犹他-阿兹特克语",
-    "Proto-Uto-Aztecan"
+    "原始犹他-阿兹特克语"
   ],
   "azc-tak-pro": [
     "Proto-Takic"
@@ -2712,26 +2488,22 @@
   ],
   "azd": [
     "東杜蘭戈納瓦特爾語",
-    "东杜兰戈纳瓦特尔语",
-    "Eastern Durango Nahuatl"
+    "东杜兰戈纳瓦特尔语"
   ],
   "azg": [
     "聖彼德羅阿穆茲戈語",
     "圣彼德罗阿穆兹戈语",
-    "San Pedro Amuzgos Amuzgo",
     "Upper Eastern Amuzgo",
     "Oaxaca Amuzgo"
   ],
   "azm": [
     "伊帕拉帕阿穆茲戈語",
     "伊帕拉帕阿穆兹戈语",
-    "Ipalapa Amuzgo",
     "Lower Eastern Amuzgo"
   ],
   "azn": [
     "西杜蘭戈納瓦特爾語",
-    "西杜兰戈纳瓦特尔语",
-    "Western Durango Nahuatl"
+    "西杜兰戈纳瓦特尔语"
   ],
   "azo": [
     "Awing"
@@ -2741,8 +2513,7 @@
   ],
   "azz": [
     "高地普埃布拉納瓦特爾語",
-    "高地普埃布拉纳瓦特尔语",
-    "Highland Puebla Nahuatl"
+    "高地普埃布拉纳瓦特尔语"
   ],
   "ba": [
     "巴什基爾語",
@@ -2751,7 +2522,6 @@
   "baa": [
     "巴巴塔納語",
     "巴巴塔纳语",
-    "Babatana",
     "Mbambatana",
     "Bambatana"
   ],
@@ -2776,7 +2546,6 @@
   "bah": [
     "巴哈馬克里奧爾語",
     "巴哈马克里奥尔语",
-    "Bahamian Creole",
     "Bahamian Creole English",
     "Bahamian",
     "Bahamas Creole",
@@ -2788,32 +2557,22 @@
   "bal": [
     "俾路支語",
     "俾路支语",
-    "Baluchi",
-    "Balochi",
-    "Southern Baluchi",
-    "Southern Balochi",
-    "Eastern Baluchi",
-    "Eastern Balochi",
-    "Western Baluchi",
-    "Western Balochi"
+    "Balochi"
   ],
   "ban": [
     "巴厘語",
-    "巴厘语",
-    "Balinese"
+    "巴厘语"
   ],
   "bao": [
     "Waimaha"
   ],
   "bap": [
     "班塔瓦語",
-    "班塔瓦语",
-    "Bantawa"
+    "班塔瓦语"
   ],
   "bar": [
     "巴伐利亞語",
     "巴伐利亚语",
-    "Bavarian",
     "Austro-Bavarian"
   ],
   "bas": [
@@ -2837,7 +2596,6 @@
   "bax": [
     "巴姆穆語",
     "巴姆穆语",
-    "Bamum",
     "Bamun"
   ],
   "bay": [
@@ -2848,13 +2606,11 @@
   ],
   "bbb": [
     "巴賴語",
-    "巴赖语",
-    "Barai"
+    "巴赖语"
   ],
   "bbc": [
     "托巴巴塔克語",
     "托巴巴塔克语",
-    "Toba Batak",
     "Batak Toba"
   ],
   "bbd": [
@@ -2888,14 +2644,12 @@
   "bbk": [
     "巴邦基語",
     "巴邦基语",
-    "Babanki",
     "Kejom",
     "Kidzem"
   ],
   "bbl": [
     "巴茨語",
     "巴茨语",
-    "Bats",
     "Batsbi",
     "Tsova-Tush"
   ],
@@ -2907,8 +2661,7 @@
   ],
   "bbn": [
     "烏尼阿帕語",
-    "乌尼阿帕语",
-    "Uneapa"
+    "乌尼阿帕语"
   ],
   "bbo": [
     "Konabéré",
@@ -2958,9 +2711,6 @@
   "bca": [
     "中部白語",
     "中部白语",
-    "劍川話",
-    "剑川话",
-    "Central Bai",
     "Jianchuan Bai"
   ],
   "bcb": [
@@ -2982,8 +2732,7 @@
   ],
   "bch": [
     "巴里艾語",
-    "巴里艾语",
-    "Bariai"
+    "巴里艾语"
   ],
   "bci": [
     "Baoule",
@@ -2995,13 +2744,11 @@
   ],
   "bck": [
     "布納巴語",
-    "布纳巴语",
-    "Bunaba"
+    "布纳巴语"
   ],
   "bcl": [
     "中比科爾語",
     "中比科尔语",
-    "Bikol Central",
     "Central Bikol",
     "Bikol"
   ],
@@ -3103,7 +2850,6 @@
   "bdj": [
     "拜語",
     "拜语",
-    "Bai",
     "Belanda",
     "Biri",
     "BGamba",
@@ -3114,11 +2860,11 @@
   "bdk": [
     "布都赫語",
     "布都赫语",
-    "Budukh",
     "Budugh"
   ],
   "bdl": [
-    "Indonesian Bajau",
+    "印尼巴瑤語",
+    "印尼巴瑶语",
     "Indonesian Bajo",
     "Sulawesi Bajau",
     "Sulawesi Bajaw",
@@ -3142,30 +2888,29 @@
   ],
   "bdq": [
     "巴拿語",
-    "巴拿语",
-    "Bahnar"
+    "巴拿语"
   ],
   "bdr": [
     "西海岸巴瑤語",
-    "西海岸巴瑶语",
-    "West Coast Bajau"
+    "西海岸巴瑶语"
   ],
   "bds": [
-    "Burunge"
+    "布龍吉語",
+    "布龙吉语"
   ],
   "bdt": [
     "Bokoto"
   ],
   "bdu": [
-    "Oroko",
+    "奧羅科語",
+    "奥罗科语",
     "Bima",
     "Bakundu-Balue",
     "Balundu-Bima"
   ],
   "bdv": [
     "博多帕爾賈語",
-    "博多帕尔贾语",
-    "Bodo Parja"
+    "博多帕尔贾语"
   ],
   "bdw": [
     "Baham"
@@ -3175,22 +2920,25 @@
   ],
   "bdy": [
     "班賈朗語",
-    "班贾朗语",
-    "Bandjalang"
+    "班贾朗语"
   ],
   "bdz": [
     "巴德斯語",
-    "巴德斯语",
-    "Badeshi"
+    "巴德斯语"
   ],
   "be": [
     "白俄羅斯語",
-    "白俄罗斯语"
+    "白俄罗斯语",
+    "Belorussian",
+    "Belarusan",
+    "Bielorussian",
+    "Byelorussian",
+    "Belarussian",
+    "White Russian"
   ],
   "bea": [
     "達內-扎阿語",
     "达内-扎阿语",
-    "Beaver",
     "Dane-zaa",
     "Danezaa",
     "Danezaa ZaageɁ"
@@ -3213,7 +2961,6 @@
   "beg": [
     "馬來奕語",
     "马来奕语",
-    "Belait",
     "Lemeting"
   ],
   "beh": [
@@ -3253,10 +3000,19 @@
     "Bembe",
     "Kibeembe"
   ],
+  "ber-fog": [
+    "Fogaha",
+    "El-Fogaha",
+    "El-Foqaha",
+    "Foqaha",
+    "Fuqaha"
+  ],
   "ber-pro": [
     "原始柏柏爾語",
-    "原始柏柏尔语",
-    "Proto-Berber"
+    "原始柏柏尔语"
+  ],
+  "ber-zuw": [
+    "Zuwara"
   ],
   "bes": [
     "Besme"
@@ -3269,7 +3025,6 @@
   "beu": [
     "布拉加爾語",
     "布拉加尔语",
-    "Blagar",
     "Belagar"
   ],
   "bev": [
@@ -3299,7 +3054,6 @@
   "bfa": [
     "巴里語",
     "巴里语",
-    "Bari",
     "Pojulu",
     "Pöjulu",
     "Fadjulu",
@@ -3309,15 +3063,11 @@
   ],
   "bfb": [
     "鮑里巴雷里語",
-    "鲍里巴雷里语",
-    "Pauri Bareli"
+    "鲍里巴雷里语"
   ],
   "bfc": [
     "北部白語",
     "北部白语",
-    "碧江話",
-    "碧江话",
-    "Northern Bai",
     "Bijiang Bai",
     "Laemae",
     "Lama",
@@ -3342,7 +3092,6 @@
   "bfi": [
     "英國手語",
     "英国手语",
-    "British Sign Language",
     "BSL"
   ],
   "bfj": [
@@ -3376,18 +3125,15 @@
   "bfs": [
     "南部白語",
     "南部白语",
-    "大理話",
-    "大理话",
-    "Southern Bai",
     "Dali Bai"
   ],
   "bft": [
     "巴爾蒂語",
-    "巴尔蒂语",
-    "Balti"
+    "巴尔蒂语"
   ],
   "bfu": [
-    "Gahri"
+    "布南語",
+    "布南语"
   ],
   "bfw": [
     "Bondo",
@@ -3398,13 +3144,11 @@
   ],
   "bfy": [
     "巴格里語",
-    "巴格里语",
-    "Bagheli"
+    "巴格里语"
   ],
   "bfz": [
     "馬哈蘇帕哈里語",
-    "马哈苏帕哈里语",
-    "Mahasu Pahari"
+    "马哈苏帕哈里语"
   ],
   "bg": [
     "保加利亞語",
@@ -3420,26 +3164,22 @@
   ],
   "bgc": [
     "哈爾彥維語",
-    "哈尔彦维语",
-    "Haryanvi"
+    "哈尔彦维语"
   ],
   "bgd": [
     "拉特維巴雷里語",
-    "拉特维巴雷里语",
-    "Rathwi Bareli"
+    "拉特维巴雷里语"
   ],
   "bge": [
     "包利雅語",
-    "包利雅语",
-    "Bauria"
+    "包利雅语"
   ],
   "bgf": [
     "Bangandu"
   ],
   "bgg": [
     "布貢語",
-    "布贡语",
-    "Bugun"
+    "布贡语"
   ],
   "bgi": [
     "嘉安語",
@@ -3460,8 +3200,7 @@
   ],
   "bgq": [
     "巴格里語",
-    "巴格里语",
-    "Bagri"
+    "巴格里语"
   ],
   "bgr": [
     "Bawm Chin",
@@ -3470,13 +3209,11 @@
   ],
   "bgs": [
     "塔加巴瓦語",
-    "塔加巴瓦语",
-    "Tagabawa"
+    "塔加巴瓦语"
   ],
   "bgt": [
     "布戈圖語",
     "布戈图语",
-    "Bughotu",
     "Bugotu"
   ],
   "bgu": [
@@ -3487,13 +3224,11 @@
   ],
   "bgw": [
     "巴特里語",
-    "巴特里语",
-    "Bhatri"
+    "巴特里语"
   ],
   "bgx": [
     "巴爾幹加告茲土耳其語",
     "巴尔干加告兹土耳其语",
-    "Balkan Gagauz Turkish",
     "Balkan Turkic"
   ],
   "bgy": [
@@ -3512,8 +3247,7 @@
   ],
   "bhb": [
     "比里語",
-    "比里语",
-    "Bhili"
+    "比里语"
   ],
   "bhc": [
     "Biga"
@@ -3525,8 +3259,7 @@
   ],
   "bhe": [
     "巴雅語",
-    "巴雅语",
-    "Bhaya"
+    "巴雅语"
   ],
   "bhf": [
     "Odiai"
@@ -3546,8 +3279,7 @@
   ],
   "bhi": [
     "比拉里語",
-    "比拉里语",
-    "Bhilali"
+    "比拉里语"
   ],
   "bhj": [
     "Bahing"
@@ -3568,8 +3300,7 @@
   ],
   "bho": [
     "博杰普爾語",
-    "博杰普尔语",
-    "Bhojpuri"
+    "博杰普尔语"
   ],
   "bhp": [
     "Bima",
@@ -3580,18 +3311,15 @@
   ],
   "bhs": [
     "布瓦爾語",
-    "布瓦尔语",
-    "Buwal"
+    "布瓦尔语"
   ],
   "bht": [
     "巴梯亞里語",
-    "巴梯亚里语",
-    "Bhattiyali"
+    "巴梯亚里语"
   ],
   "bhu": [
     "本賈語",
-    "本贾语",
-    "Bhunjia"
+    "本贾语"
   ],
   "bhv": [
     "Bahau"
@@ -3602,7 +3330,6 @@
   "bhx": [
     "巴萊語",
     "巴莱语",
-    "Bhalay",
     "Bhalay-Gowlan"
   ],
   "bhy": [
@@ -3621,8 +3348,7 @@
   ],
   "bia": [
     "巴迪馬亞語",
-    "巴迪马亚语",
-    "Badimaya"
+    "巴迪马亚语"
   ],
   "bib": [
     "Bissa"
@@ -3661,7 +3387,6 @@
   "bin": [
     "埃多語",
     "埃多语",
-    "Edo",
     "Bini"
   ],
   "bio": [
@@ -3708,7 +3433,6 @@
   "bjb": [
     "巴爾恩加爾拉語",
     "巴尔恩加尔拉语",
-    "Barngarla",
     "Parnkalla",
     "Banggarla",
     "Parnkala",
@@ -3744,7 +3468,6 @@
   "bje": [
     "標敏語",
     "标敏语",
-    "Biao-Jiao Mien",
     "Biao Min",
     "Jiaogong Mian"
   ],
@@ -3774,13 +3497,11 @@
   ],
   "bjm": [
     "巴傑蘭語",
-    "巴杰兰语",
-    "Bajelani"
+    "巴杰兰语"
   ],
   "bjn": [
     "班查語",
     "班查语",
-    "Banjarese",
     "Banjar"
   ],
   "bjo": [
@@ -3818,8 +3539,7 @@
   ],
   "bjz": [
     "巴魯加語",
-    "巴鲁加语",
-    "Baruga"
+    "巴鲁加语"
   ],
   "bka": [
     "Kyak",
@@ -3832,8 +3552,7 @@
   ],
   "bkd": [
     "布基語",
-    "布基语",
-    "Binukid"
+    "布基语"
   ],
   "bkf": [
     "Beeke"
@@ -3853,13 +3572,11 @@
   ],
   "bkk": [
     "布羅克斯卡特語",
-    "布罗克斯卡特语",
-    "Brokskat"
+    "布罗克斯卡特语"
   ],
   "bkl": [
     "貝里克語",
-    "贝里克语",
-    "Berik"
+    "贝里克语"
   ],
   "bkm": [
     "康姆語（喀麥隆）",
@@ -3892,8 +3609,7 @@
   ],
   "bks": [
     "馬斯巴特索索貢語",
-    "马斯巴特索索贡语",
-    "Masbate Sorsogon"
+    "马斯巴特索索贡语"
   ],
   "bkt": [
     "Boloki"
@@ -3921,9 +3637,7 @@
   "bla": [
     "黑腳語",
     "黑脚语",
-    "Blackfoot",
-    "錫克錫卡語",
-    "锡克锡卡语",
+    "Siksika",
     "Blackfeet"
   ],
   "blb": [
@@ -3939,8 +3653,7 @@
   ],
   "ble": [
     "肯托赫-巴蘭塔語",
-    "肯托赫-巴兰塔语",
-    "Balanta-Kentohe"
+    "肯托赫-巴兰塔语"
   ],
   "blf": [
     "Buol"
@@ -3965,7 +3678,6 @@
   "blk": [
     "勃歐語",
     "勃欧语",
-    "Pa'o Karen",
     "Pa'o",
     "Black Karen"
   ],
@@ -3981,7 +3693,8 @@
     "Beli (South Sudan)"
   ],
   "bln": [
-    "Southern Catanduanes Bicolano",
+    "南卡坦端內斯比科爾語",
+    "南卡坦端内斯比科尔语",
     "Virac"
   ],
   "blo": [
@@ -4011,7 +3724,6 @@
   "blt": [
     "傣黯語",
     "傣黯语",
-    "Tai Dam",
     "Tai Noi",
     "Black Tai"
   ],
@@ -4074,8 +3786,7 @@
   ],
   "bmj": [
     "博特-邁希語",
-    "博特-迈希语",
-    "Bote-Majhi"
+    "博特-迈希语"
   ],
   "bmk": [
     "Ghayavi"
@@ -4099,13 +3810,11 @@
   ],
   "bmr": [
     "穆伊納內語",
-    "穆伊纳内语",
-    "Muinane"
+    "穆伊纳内语"
   ],
   "bmt": [
     "標曼語",
-    "标曼语",
-    "Biao Mon"
+    "标曼语"
   ],
   "bmu": [
     "Somba-Siawari"
@@ -4168,13 +3877,11 @@
   ],
   "bnn": [
     "布農語",
-    "布农语",
-    "Bunun"
+    "布农语"
   ],
   "bno": [
     "班頓語",
-    "班顿语",
-    "Asi"
+    "班顿语"
   ],
   "bnp": [
     "Bola"
@@ -4188,7 +3895,6 @@
   "bns": [
     "布恩德里語",
     "布恩德里语",
-    "Bundeli",
     "Bundelkhandi"
   ],
   "bnt-bal": [
@@ -4199,6 +3905,9 @@
   ],
   "bnt-boy": [
     "Boma Yumu"
+  ],
+  "bnt-bwa": [
+    "Bwala"
   ],
   "bnt-cmw": [
     "Chimwiini",
@@ -4217,8 +3926,7 @@
   ],
   "bnt-lal": [
     "拉拉語（南非）",
-    "拉拉语（南非）",
-    "Lala (South Africa)"
+    "拉拉语（南非）"
   ],
   "bnt-lwl": [
     "Lwel",
@@ -4233,35 +3941,30 @@
   ],
   "bnt-ngu-pro": [
     "原始恩古尼語",
-    "原始恩古尼语",
-    "Proto-Nguni"
+    "原始恩古尼语"
   ],
   "bnt-phu": [
     "普提語",
     "普提语",
-    "Phuthi",
     "Siphuthi"
   ],
   "bnt-pro": [
     "原始班圖語",
-    "原始班图语",
-    "Proto-Bantu"
+    "原始班图语"
   ],
   "bnt-sbo": [
     "South Boma"
   ],
   "bnt-sts-pro": [
     "原始索托-茨瓦納語",
-    "原始索托-茨瓦纳语",
-    "Proto-Sotho-Tswana"
+    "原始索托-茨瓦纳语"
   ],
   "bnu": [
     "Bentong"
   ],
   "bnv": [
     "貝內拉夫語",
-    "贝内拉夫语",
-    "Beneraf"
+    "贝内拉夫语"
   ],
   "bnw": [
     "Bisis"
@@ -4271,8 +3974,7 @@
   ],
   "bny": [
     "民都魯語",
-    "民都鲁语",
-    "Bintulu"
+    "民都鲁语"
   ],
   "bnz": [
     "Beezen"
@@ -4310,8 +4012,7 @@
   ],
   "bol": [
     "博雷語",
-    "博雷语",
-    "Bole"
+    "博雷语"
   ],
   "bom": [
     "Berom",
@@ -4331,8 +4032,7 @@
   ],
   "bor": [
     "博羅洛語",
-    "博罗洛语",
-    "Borôro"
+    "博罗洛语"
   ],
   "bot": [
     "Bongo"
@@ -4340,7 +4040,6 @@
   "bou": [
     "邦代語",
     "邦代语",
-    "Bondei",
     "Boondei",
     "Boondéi"
   ],
@@ -4377,8 +4076,7 @@
   ],
   "bpd": [
     "班達-班達語",
-    "班达-班达语",
-    "Banda-Banda"
+    "班达-班达语"
   ],
   "bpg": [
     "Bonggo"
@@ -4386,7 +4084,6 @@
   "bph": [
     "博特利赫語",
     "博特利赫语",
-    "Botlikh",
     "Botlix"
   ],
   "bpi": [
@@ -4406,8 +4103,7 @@
   ],
   "bpn": [
     "藻敏語",
-    "藻敏语",
-    "Dzao Min"
+    "藻敏语"
   ],
   "bpo": [
     "Anasi"
@@ -4429,8 +4125,7 @@
   ],
   "bpt": [
     "巴羅角語",
-    "巴罗角语",
-    "Barrow Point"
+    "巴罗角语"
   ],
   "bpu": [
     "Bongu"
@@ -4440,20 +4135,17 @@
   ],
   "bpx": [
     "帕爾雅巴雷里語",
-    "帕尔雅巴雷里语",
-    "Palya Bareli"
+    "帕尔雅巴雷里语"
   ],
   "bpy": [
     "比什奴普萊利亞-曼尼普爾語",
     "比什奴普莱利亚-曼尼普尔语",
-    "Bishnupriya Manipuri",
     "Bishnupriya",
     "Manipuri Bishnupriya"
   ],
   "bpz": [
     "比爾巴語",
-    "比尔巴语",
-    "Bilba"
+    "比尔巴语"
   ],
   "bqa": [
     "Tchumbuli"
@@ -4475,14 +4167,12 @@
     "Bago-Kusuntu"
   ],
   "bqh": [
-    "Baima"
+    "白馬語",
+    "白马语"
   ],
   "bqi": [
     "巴赫蒂亞里語",
-    "巴赫蒂亚里语",
-    "Bakhtiari",
-    "巴克鐵力語",
-    "巴克铁力语"
+    "巴赫蒂亚里语"
   ],
   "bqj": [
     "Bandial"
@@ -4498,16 +4188,14 @@
   ],
   "bqn": [
     "保加利亞手語",
-    "保加利亚手语",
-    "Bulgarian Sign Language"
+    "保加利亚手语"
   ],
   "bqo": [
     "Balo"
   ],
   "bqp": [
     "布撒語",
-    "布撒语",
-    "Busa"
+    "布撒语"
   ],
   "bqq": [
     "Biritai"
@@ -4547,7 +4235,6 @@
   "bra": [
     "布萊語",
     "布莱语",
-    "Braj",
     "Braj Bhasha"
   ],
   "brb": [
@@ -4559,7 +4246,6 @@
   "brc": [
     "伯比斯克里奧爾荷蘭語",
     "伯比斯克里奥尔荷兰语",
-    "Berbice Creole Dutch",
     "Berbice Dutch",
     "Berbice Dutch Creole",
     "Berbice Creole"
@@ -4577,8 +4263,7 @@
   ],
   "brh": [
     "布拉灰語",
-    "布拉灰语",
-    "Brahui"
+    "布拉灰语"
   ],
   "bri": [
     "Mokpwe"
@@ -4601,7 +4286,8 @@
     "Boruca"
   ],
   "bro": [
-    "Brokkat"
+    "布羅卡特語",
+    "布罗卡特语"
   ],
   "brp": [
     "Barapasi"
@@ -4622,10 +4308,12 @@
     "Njwande"
   ],
   "bru": [
-    "Eastern Bru"
+    "東布魯語",
+    "东布鲁语"
   ],
   "brv": [
-    "Western Bru"
+    "西布魯語",
+    "西布鲁语"
   ],
   "brw": [
     "Bellari"
@@ -4646,13 +4334,11 @@
   ],
   "bsa": [
     "阿比諾姆語",
-    "阿比诺姆语",
-    "Abinomn"
+    "阿比诺姆语"
   ],
   "bsb": [
     "汶萊米沙鄢語",
-    "汶莱米沙鄢语",
-    "Brunei Bisaya"
+    "汶莱米沙鄢语"
   ],
   "bsc": [
     "Bassari",
@@ -4673,8 +4359,7 @@
   ],
   "bsg": [
     "巴斯卡爾迪語",
-    "巴斯卡尔迪语",
-    "Bashkardi"
+    "巴斯卡尔迪语"
   ],
   "bsh": [
     "Kamkata-viri",
@@ -4688,8 +4373,7 @@
   ],
   "bsk": [
     "布魯夏斯基語",
-    "布鲁夏斯基语",
-    "Burushaski"
+    "布鲁夏斯基语"
   ],
   "bsl": [
     "Basa-Gumna"
@@ -4708,8 +4392,7 @@
   ],
   "bsq": [
     "巴薩語",
-    "巴萨语",
-    "Bassa"
+    "巴萨语"
   ],
   "bsr": [
     "Bassa-Kontagora",
@@ -4740,8 +4423,7 @@
   ],
   "bsy": [
     "沙巴米沙鄢語",
-    "沙巴米沙鄢语",
-    "Sabah Bisaya"
+    "沙巴米沙鄢语"
   ],
   "bta": [
     "Bata"
@@ -4753,7 +4435,6 @@
   "btd": [
     "代里巴塔克語",
     "代里巴塔克语",
-    "Dairi Batak",
     "Batak Dairi"
   ],
   "bte": [
@@ -4773,34 +4454,25 @@
   ],
   "btj": [
     "巴占馬來語",
-    "巴占马来语",
-    "Bacanese Malay"
+    "巴占马来语"
   ],
   "btk-pro": [
     "原始巴塔克語",
-    "原始巴塔克语",
-    "Proto-Batak",
-    "Proto-Abkhaz-Abaza",
-    "Proto-Abazgi",
-    "Proto-Abkhaz-Tapanta"
+    "原始巴塔克语"
   ],
   "btm": [
     "曼代靈巴塔克語",
     "曼代灵巴塔克语",
-    "曼代靈語",
-    "曼代灵语",
-    "Mandailing Batak",
-    "Batak Mandailing"
+    "Batak Mandailing",
+    "Mandailing"
   ],
   "btn": [
     "拉達農語",
-    "拉达农语",
-    "Ratagnon"
+    "拉达农语"
   ],
   "bto": [
     "伊里加比科拉諾語",
-    "伊里加比科拉诺语",
-    "Iriga Bicolano"
+    "伊里加比科拉诺语"
   ],
   "btp": [
     "Budibud"
@@ -4815,7 +4487,8 @@
   "bts": [
     "西馬隆貢巴塔克語",
     "西马隆贡巴塔克语",
-    "Batak Simalungun"
+    "Batak Simalungun",
+    "Simalungun"
   ],
   "btt": [
     "Bete-Bendi"
@@ -4825,18 +4498,15 @@
   ],
   "btv": [
     "巴特里語",
-    "巴特里语",
-    "Bateri"
+    "巴特里语"
   ],
   "btw": [
     "布圖阿農語",
-    "布图阿农语",
-    "Butuanon"
+    "布图阿农语"
   ],
   "btx": [
     "卡羅巴塔克語",
     "卡罗巴塔克语",
-    "Karo Batak",
     "Batak Karo"
   ],
   "bty": [
@@ -4845,13 +4515,11 @@
   "btz": [
     "阿拉斯-克盧埃特語",
     "阿拉斯-克卢埃特语",
-    "Alas-Kluet Batak",
     "Batak Alas-Kluet"
   ],
   "bua": [
     "布里亞特語",
     "布里亚特语",
-    "Buryat",
     "Buriat"
   ],
   "bub": [
@@ -4872,13 +4540,11 @@
   ],
   "bug": [
     "布吉語",
-    "布吉语",
-    "Buginese"
+    "布吉语"
   ],
   "buh": [
     "優諾語",
     "优诺语",
-    "Younuo Bunu",
     "Yuno"
   ],
   "bui": [
@@ -4975,8 +4641,7 @@
   ],
   "bvl": [
     "玻利維亞手語",
-    "玻利维亚手语",
-    "Bolivian Sign Language"
+    "玻利维亚手语"
   ],
   "bvm": [
     "Bamunka"
@@ -4995,8 +4660,7 @@
   ],
   "bvr": [
     "布拉拉語",
-    "布拉拉语",
-    "Burarra"
+    "布拉拉语"
   ],
   "bvt": [
     "Bati (Indonesia)",
@@ -5017,7 +4681,8 @@
     "Bole"
   ],
   "bvy": [
-    "Baybayanon",
+    "拜拜語",
+    "拜拜语",
     "Babay",
     "Utudnon",
     "Leyte"
@@ -5054,7 +4719,6 @@
   "bwi": [
     "巴尼瓦語",
     "巴尼瓦语",
-    "Baniwa",
     "Baniba",
     "Baniva",
     "Carutana",
@@ -5080,7 +4744,6 @@
   "bwn": [
     "唔奈語",
     "唔奈语",
-    "Wunai Bunu",
     "Hm Nai",
     "Ng-nai",
     "Wunai"
@@ -5113,7 +4776,6 @@
   "bwr": [
     "布拉語",
     "布拉语",
-    "Bura",
     "Bura-Pabir",
     "Pabir",
     "Burra"
@@ -5134,7 +4796,6 @@
   "bwx": [
     "布努語",
     "布努语",
-    "Bu-Nao Bunu",
     "Bu Nao",
     "Bunu",
     "Dongnu",
@@ -5187,13 +4848,11 @@
   ],
   "bxi": [
     "皮爾拉塔帕語",
-    "皮尔拉塔帕语",
-    "Pirlatapa"
+    "皮尔拉塔帕语"
   ],
   "bxj": [
     "巴永古語",
-    "巴永古语",
-    "Bayungu"
+    "巴永古语"
   ],
   "bxk": [
     "Bukusu"
@@ -5203,8 +4862,7 @@
   ],
   "bxn": [
     "布爾杜納語",
-    "布尔杜纳语",
-    "Burduna"
+    "布尔杜纳语"
   ],
   "bxo": [
     "Barikanchi",
@@ -5233,7 +4891,6 @@
   "bya": [
     "巴拉望巴塔克語",
     "巴拉望巴塔克语",
-    "Palawan Batak",
     "Batak"
   ],
   "byb": [
@@ -5268,21 +4925,18 @@
   ],
   "byk": [
     "標話",
-    "标话",
-    "Biao"
+    "标话"
   ],
   "byl": [
     "Bayono"
   ],
   "bym": [
     "比賈拉語",
-    "比贾拉语",
-    "Bidyara"
+    "比贾拉语"
   ],
   "byn": [
     "比林語",
     "比林语",
-    "Blin",
     "Bilin",
     "Bilen",
     "Belen",
@@ -5299,7 +4953,6 @@
   "byq": [
     "巴賽語",
     "巴赛语",
-    "Basay",
     "Basai"
   ],
   "byr": [
@@ -5345,27 +4998,20 @@
   "bzg": [
     "巴布薩語",
     "巴布萨语",
-    "Babuza",
     "Favorlang",
     "Poavosa",
-    "Taokas",
-    "道卡斯語",
-    "道卡斯语",
-    "虎尾壟語",
-    "虎尾垄语"
+    "Taokas"
   ],
   "bzh": [
     "Mapos Buang"
   ],
   "bzi": [
-    "Bisu"
+    "Bisu",
+    "Mbisu"
   ],
   "bzj": [
     "伯利茲克里奧爾語",
     "伯利兹克里奥尔语",
-    "貝里斯克里奧爾語",
-    "贝里斯克里奥尔语",
-    "Belizean Creole",
     "Belizean Creole English",
     "Belizean Kriol",
     "Belize Kriol English",
@@ -5374,7 +5020,6 @@
   "bzk": [
     "尼加拉瓜克里奧爾語",
     "尼加拉瓜克里奥尔语",
-    "Nicaraguan Creole",
     "Miskito Coast Creole",
     "Nicaraguan Creole English",
     "Nicaragua Creole English"
@@ -5387,8 +5032,7 @@
   ],
   "bzm": [
     "波朗多語",
-    "波朗多语",
-    "Bolondo"
+    "波朗多语"
   ],
   "bzn": [
     "Boano (Maluku)",
@@ -5408,13 +5052,11 @@
   ],
   "bzr": [
     "比里語",
-    "比里语",
-    "Biri"
+    "比里语"
   ],
   "bzs": [
     "巴西手語",
     "巴西手语",
-    "Brazilian Sign Language",
     "LGB",
     "LSB",
     "LSCB",
@@ -5444,43 +5086,35 @@
   ],
   "ca": [
     "加泰羅尼亞語",
-    "加泰罗尼亚语",
-    "加泰隆語",
-    "加泰隆语"
+    "加泰罗尼亚语"
   ],
   "caa": [
     "喬爾蒂語",
     "乔尔蒂语",
-    "Ch'orti'",
     "Chorti"
   ],
   "cab": [
     "加里富納語",
-    "加里富纳语",
-    "Garifuna"
+    "加里富纳语"
   ],
   "cac": [
     "丘赫語",
-    "丘赫语",
-    "Chuj"
+    "丘赫语"
   ],
   "cad": [
     "喀多語",
-    "喀多语",
-    "Caddo"
+    "喀多语"
   ],
   "cae": [
     "Laalaa"
   ],
   "caf": [
     "南達凱爾語",
-    "南达凯尔语",
-    "Southern Carrier"
+    "南达凯尔语"
   ],
   "cag": [
     "尼瓦克萊語",
-    "尼瓦克莱语",
-    "Nivaclé"
+    "尼瓦克莱语"
   ],
   "cah": [
     "Cahuarano"
@@ -5491,15 +5125,13 @@
   "cak": [
     "喀克其奎語",
     "喀克其奎语",
-    "Kaqchikel",
     "Cakchiquel",
     "Kakchiquel",
     "Cachiquel"
   ],
   "cal": [
     "加羅林語",
-    "加罗林语",
-    "Carolinian"
+    "加罗林语"
   ],
   "cam": [
     "Cemuhî"
@@ -5512,13 +5144,11 @@
   ],
   "cap": [
     "奇帕亞語",
-    "奇帕亚语",
-    "Chipaya"
+    "奇帕亚语"
   ],
   "caq": [
     "卡爾尼科巴語",
     "卡尔尼科巴语",
-    "Car Nicobarese",
     "Car"
   ],
   "car": [
@@ -5543,14 +5173,12 @@
   "cau-abz-pro": [
     "原始阿布哈茲-阿巴扎語",
     "原始阿布哈兹-阿巴扎语",
-    "Proto-Abkhaz-Abaza",
     "Proto-Abazgi",
     "Proto-Abkhaz-Tapanta"
   ],
   "cau-ava-pro": [
     "原始阿瓦爾-安迪語",
     "原始阿瓦尔-安迪语",
-    "Proto-Avaro-Andian",
     "Proto-Avar-Andian",
     "Proto-Avar-Andi",
     "Proto-Avar-Andic",
@@ -5559,43 +5187,36 @@
   "cau-cir-pro": [
     "原始切爾克斯語",
     "原始切尔克斯语",
-    "Proto-Circassian",
     "Proto-Adyghe-Kabardian",
     "Proto-Adyghe-Circassian"
   ],
   "cau-drg-pro": [
     "原始達爾金語",
     "原始达尔金语",
-    "Proto-Dargwa",
     "Proto-Dargin"
   ],
   "cau-lzg-pro": [
     "原始列茲金語",
     "原始列兹金语",
-    "Proto-Lezghian",
     "Proto-Lezgi",
     "Proto-Lezgian",
     "Proto-Lezgic"
   ],
   "cau-nec-pro": [
     "原始東北高加索語",
-    "原始东北高加索语",
-    "Proto-Northeast Caucasian"
+    "原始东北高加索语"
   ],
   "cau-nkh-pro": [
     "原始納克語",
-    "原始纳克语",
-    "Proto-Nakh"
+    "原始纳克语"
   ],
   "cau-nwc-pro": [
     "原始西北高加索語",
-    "原始西北高加索语",
-    "Proto-Northwest Caucasian"
+    "原始西北高加索语"
   ],
   "cau-tsz-pro": [
     "原始采茲語",
     "原始采兹语",
-    "Proto-Tsezian",
     "Proto-Tsezic",
     "Proto-Didoic"
   ],
@@ -5653,8 +5274,7 @@
   ],
   "cba-pro": [
     "原始奇布查語",
-    "原始奇布查语",
-    "Proto-Chibchan"
+    "原始奇布查语"
   ],
   "cbb": [
     "Cabiyarí"
@@ -5683,9 +5303,6 @@
   "cbi": [
     "查茨語",
     "查茨语",
-    "查帕拉語",
-    "查帕拉语",
-    "Chachi",
     "Cha'palaa",
     "Chapalaa",
     "Cha'palaachi",
@@ -5698,7 +5315,6 @@
   "cbk": [
     "查瓦卡諾語",
     "查瓦卡诺语",
-    "Chavacano",
     "Zamboanga Chavacano"
   ],
   "cbl": [
@@ -5753,8 +5369,7 @@
   ],
   "ccc": [
     "查米庫羅語",
-    "查米库罗语",
-    "Chamicuro"
+    "查米库罗语"
   ],
   "ccd": [
     "Cafundó"
@@ -5779,23 +5394,20 @@
   ],
   "ccm": [
     "馬六甲克里奧爾馬來語",
-    "马六甲克里奥尔马来语",
-    "Malaccan Creole Malay"
+    "马六甲克里奥尔马来语"
   ],
   "ccn-pro": [
     "原始北高加索語",
-    "原始北高加索语",
-    "Proto-North Caucasian"
+    "原始北高加索语"
   ],
   "cco": [
     "科馬爾特佩克-奇南特克語",
-    "科马尔特佩克-奇南特克语",
-    "Comaltepec Chinantec"
+    "科马尔特佩克-奇南特克语"
   ],
   "ccp": [
     "查克馬語",
     "查克马语",
-    "Chakma"
+    "Changmha"
   ],
   "ccr": [
     "Cacaopera"
@@ -5803,13 +5415,11 @@
   "ccs-gzn-pro": [
     "原始格魯吉亞-贊語",
     "原始格鲁吉亚-赞语",
-    "Proto-Georgian-Zan",
     "Proto-Karto-Zan"
   ],
   "ccs-pro": [
     "原始南高加索語",
-    "原始南高加索语",
-    "Proto-Kartvelian"
+    "原始南高加索语"
   ],
   "cda": [
     "Choni"
@@ -5817,7 +5427,6 @@
   "cdc-cbm-pro": [
     "原始中乍得語",
     "原始中乍得语",
-    "Proto-Central Chadic",
     "Proto-Central-Chadic",
     "Proto-Biu-Mandara"
   ],
@@ -5826,8 +5435,7 @@
   ],
   "cdc-pro": [
     "原始乍得語",
-    "原始乍得语",
-    "Proto-Chadic"
+    "原始乍得语"
   ],
   "cdd-pro": [
     "Proto-Caddoan"
@@ -5840,23 +5448,19 @@
   ],
   "cdh": [
     "昌貝阿里語",
-    "昌贝阿里语",
-    "Chambeali"
+    "昌贝阿里语"
   ],
   "cdi": [
     "楚德里語",
-    "楚德里语",
-    "Chodri"
+    "楚德里语"
   ],
   "cdj": [
     "楚拉希語",
-    "楚拉希语",
-    "Churahi"
+    "楚拉希语"
   ],
   "cdm": [
     "切彭語",
-    "切彭语",
-    "Chepang"
+    "切彭语"
   ],
   "cdn": [
     "Chaudangsi"
@@ -5864,7 +5468,6 @@
   "cdo": [
     "閩東語",
     "闽东语",
-    "Min Dong",
     "Min Dong Chinese"
   ],
   "cdr": [
@@ -5872,15 +5475,11 @@
   ],
   "cds": [
     "乍得手語",
-    "乍得手语",
-    "查德手語",
-    "查德手语",
-    "Chadian Sign Language"
+    "乍得手语"
   ],
   "cdy": [
     "茶洞語",
-    "茶洞语",
-    "Chadong"
+    "茶洞语"
   ],
   "cdz": [
     "Koda"
@@ -5894,10 +5493,7 @@
   ],
   "ceb": [
     "宿霧語",
-    "宿雾语",
-    "Cebuano",
-    "宿務語",
-    "宿务语"
+    "宿雾语"
   ],
   "ceg": [
     "Chamacoco"
@@ -5905,7 +5501,6 @@
   "cel-bry-pro": [
     "原始布立吞語",
     "原始布立吞语",
-    "Proto-Brythonic",
     "Proto-Brittonic"
   ],
   "cel-gal": [
@@ -5913,13 +5508,11 @@
   ],
   "cel-gau": [
     "高盧語",
-    "高卢语",
-    "Gaulish"
+    "高卢语"
   ],
   "cel-pro": [
     "原始凱爾特語",
-    "原始凯尔特语",
-    "Proto-Celtic"
+    "原始凯尔特语"
   ],
   "cen": [
     "Cen",
@@ -5950,8 +5543,7 @@
   ],
   "cgc": [
     "卡加揚語",
-    "卡加扬语",
-    "Kagayanen"
+    "卡加扬语"
   ],
   "cgg": [
     "奇加語",
@@ -5967,18 +5559,15 @@
   ],
   "chb": [
     "奇布查語",
-    "奇布查语",
-    "Chibcha"
+    "奇布查语"
   ],
   "chc": [
     "卡托巴語",
-    "卡托巴语",
-    "Catawba"
+    "卡托巴语"
   ],
   "chd": [
     "高地瓦哈卡瓊塔爾語",
     "高地瓦哈卡琼塔尔语",
-    "Highland Oaxaca Chontal",
     "Oaxaca Chontal",
     "Oaxacan Chontal",
     "Chontal",
@@ -5989,13 +5578,11 @@
   ],
   "chf": [
     "塔巴斯科瓊塔爾語",
-    "塔巴斯科琼塔尔语",
-    "Tabasco Chontal"
+    "塔巴斯科琼塔尔语"
   ],
   "chg": [
     "察合臺語",
-    "察合台语",
-    "Chagatai"
+    "察合台语"
   ],
   "chh": [
     "Chinook"
@@ -6005,38 +5592,31 @@
   ],
   "chj": [
     "奧希特蘭奇南特克語",
-    "奥希特兰奇南特克语",
-    "Ojitlán Chinantec"
+    "奥希特兰奇南特克语"
   ],
   "chk": [
     "楚克語",
-    "楚克语",
-    "Chuukese"
+    "楚克语"
   ],
   "chl": [
     "卡維拉語",
-    "卡维拉语",
-    "Cahuilla"
+    "卡维拉语"
   ],
   "chm-pro": [
     "原始馬里語",
-    "原始马里语",
-    "Proto-Mari"
+    "原始马里语"
   ],
   "chn": [
     "契努克語",
-    "契努克语",
-    "Chinook Jargon"
+    "契努克语"
   ],
   "cho": [
     "喬克托語",
-    "乔克托语",
-    "Choctaw"
+    "乔克托语"
   ],
   "chp": [
     "契帕瓦語",
     "契帕瓦语",
-    "Chipewyan",
     "Dëne Sųłiné",
     "Dënesųłiné",
     "Dëne",
@@ -6046,13 +5626,12 @@
   ],
   "chq": [
     "基奧基特佩克奇南特克語",
-    "基奥基特佩克奇南特克语",
-    "Quiotepec Chinantec"
+    "基奥基特佩克奇南特克语"
   ],
   "chr": [
     "切羅基語",
     "切罗基语",
-    "Cherokee"
+    "Tsalagi"
   ],
   "cht": [
     "Cholón"
@@ -6071,26 +5650,22 @@
   ],
   "chy": [
     "夏延語",
-    "夏延语",
-    "Cheyenne"
+    "夏延语"
   ],
   "chz": [
     "奧蘇馬辛奇南特克語",
-    "奥苏马辛奇南特克语",
-    "Ozumacín Chinantec"
+    "奥苏马辛奇南特克语"
   ],
   "cia": [
     "吉阿吉阿語",
-    "吉阿吉阿语",
-    "Cia-Cia"
+    "吉阿吉阿语"
   ],
   "cib": [
     "Ci Gbe"
   ],
   "cic": [
     "奇卡索語",
-    "奇卡索语",
-    "Chickasaw"
+    "奇卡索语"
   ],
   "cid": [
     "Chimariko"
@@ -6100,13 +5675,11 @@
   ],
   "cih": [
     "奇納里語",
-    "奇纳里语",
-    "Chinali"
+    "奇纳里语"
   ],
   "cik": [
     "奇特庫利金瑙里語",
-    "奇特库利金瑙里语",
-    "Chitkuli Kinnauri"
+    "奇特库利金瑙里语"
   ],
   "cim": [
     "辛布里語",
@@ -6117,8 +5690,7 @@
   ],
   "cip": [
     "恰帕內克語",
-    "恰帕内克语",
-    "Chiapanec"
+    "恰帕内克语"
   ],
   "cir": [
     "Tiri",
@@ -6133,8 +5705,7 @@
   ],
   "cja": [
     "西占語",
-    "西占语",
-    "Western Cham"
+    "西占语"
   ],
   "cje": [
     "Chru"
@@ -6144,32 +5715,28 @@
   ],
   "cji": [
     "查馬拉爾語",
-    "查马拉尔语",
-    "Chamalal"
+    "查马拉尔语"
   ],
   "cjk": [
     "Chokwe"
   ],
   "cjm": [
     "東占語",
-    "东占语",
-    "Eastern Cham"
+    "东占语"
   ],
   "cjn": [
     "Chenapian"
   ],
   "cjo": [
     "帕胡納爾-阿舍寧卡語",
-    "帕胡纳尔-阿舍宁卡语",
-    "Ashéninka Pajonal"
+    "帕胡纳尔-阿舍宁卡语"
   ],
   "cjp": [
     "Cabécar"
   ],
   "cjs": [
     "紹爾語",
-    "绍尔语",
-    "Shor"
+    "绍尔语"
   ],
   "cjv": [
     "Chuave"
@@ -6177,7 +5744,6 @@
   "cjy": [
     "晉語",
     "晋语",
-    "Jin",
     "Jinyu",
     "Jinhua",
     "Jinese",
@@ -6188,7 +5754,6 @@
   "ckb": [
     "中庫爾德語",
     "中库尔德语",
-    "Central Kurdish",
     "Sorani"
   ],
   "ckh": [
@@ -6224,18 +5789,15 @@
   ],
   "ckt": [
     "楚科奇語",
-    "楚科奇语",
-    "Chukchi"
+    "楚科奇语"
   ],
   "cku": [
     "科阿薩提語",
-    "科阿萨提语",
-    "Koasati"
+    "科阿萨提语"
   ],
   "ckv": [
     "噶瑪蘭語",
     "噶玛兰语",
-    "Kavalan",
     "Kbalan",
     "Kebalan"
   ],
@@ -6263,13 +5825,11 @@
   ],
   "cld": [
     "迦勒底新亞拉姆語",
-    "迦勒底新亚拉姆语",
-    "Chaldean Neo-Aramaic"
+    "迦勒底新亚拉姆语"
   ],
   "cle": [
     "萊勞奇南特克語",
-    "莱劳奇南特克语",
-    "Lealao Chinantec"
+    "莱劳奇南特克语"
   ],
   "clh": [
     "Chilisso"
@@ -6292,14 +5852,12 @@
   "clm": [
     "克拉勒姆語",
     "克拉勒姆语",
-    "Klallam",
     "Clallam",
     "S'Klallam"
   ],
   "clo": [
     "低地瓦哈卡瓊塔爾語",
     "低地瓦哈卡琼塔尔语",
-    "Lowland Oaxaca Chontal",
     "Oaxaca Chontal",
     "Oaxacan Chontal",
     "Chontal",
@@ -6317,7 +5875,6 @@
   "clw": [
     "楚利姆語",
     "楚利姆语",
-    "Chulym",
     "Chulim",
     "Chulym-Turkic",
     "Küerik",
@@ -6326,24 +5883,21 @@
   ],
   "cly": [
     "東部高地查蒂諾語",
-    "东部高地查蒂诺语",
-    "Eastern Highland Chatino"
+    "东部高地查蒂诺语"
   ],
   "cma": [
     "Maa"
   ],
   "cmc-pro": [
     "原始占語",
-    "原始占语",
-    "Proto-Chamic"
+    "原始占语"
   ],
   "cme": [
     "Cerma"
   ],
   "cmg": [
     "古典蒙古語",
-    "古典蒙古语",
-    "Classical Mongolian"
+    "古典蒙古语"
   ],
   "cmi": [
     "Emberá-Chamí"
@@ -6357,15 +5911,6 @@
   "cmn": [
     "官話",
     "官话",
-    "普通話",
-    "普通话",
-    "北方話",
-    "北方话",
-    "國語",
-    "国语",
-    "華話",
-    "华话",
-    "Mandarin",
     "Mandarin Chinese",
     "Putonghua",
     "Guoyu",
@@ -6387,7 +5932,6 @@
   "cms": [
     "梅薩比語",
     "梅萨比语",
-    "Messapic",
     "Messapian"
   ],
   "cmt": [
@@ -6405,8 +5949,7 @@
   ],
   "cng": [
     "北羌語",
-    "北羌语",
-    "Northern Qiang"
+    "北羌语"
   ],
   "cnh": [
     "Lai",
@@ -6420,7 +5963,6 @@
   "cnk": [
     "庫米欽語",
     "库米钦语",
-    "Khumi Chin",
     "Khumi",
     "Khami",
     "Nisay",
@@ -6430,26 +5972,18 @@
   ],
   "cnl": [
     "拉拉納奇南特克語",
-    "拉拉纳奇南特克语",
-    "Lalana Chinantec"
+    "拉拉纳奇南特克语"
   ],
   "cno": [
     "Con"
   ],
-  "cnp": [
-    "桂北平話",
-    "桂北平话",
-    "Northern Pinghua"
-  ],
   "cns": [
     "中阿斯馬特語",
-    "中阿斯马特语",
-    "Central Asmat"
+    "中阿斯马特语"
   ],
   "cnt": [
     "特佩托圖特拉奇南特克語",
-    "特佩托图特拉奇南特克语",
-    "Tepetotutla Chinantec"
+    "特佩托图特拉奇南特克语"
   ],
   "cnu": [
     "Chenoua",
@@ -6471,13 +6005,11 @@
   "coa": [
     "科科斯馬來語",
     "科科斯马来语",
-    "Cocos Islands Malay",
     "Cocos Malay"
   ],
   "cob": [
     "奇科穆塞爾特克語",
-    "奇科穆塞尔特克语",
-    "Chicomuceltec"
+    "奇科穆塞尔特克语"
   ],
   "coc": [
     "Cocopa"
@@ -6502,13 +6034,11 @@
   ],
   "cog": [
     "仲語",
-    "仲语",
-    "Chong"
+    "仲语"
   ],
   "coh": [
     "齊瓊依-齊基哈納-奇考瑪語",
-    "齐琼依-齐基哈纳-奇考玛语",
-    "Chichonyi-Chidzihana-Chikauma"
+    "齐琼依-齐基哈纳-奇考玛语"
   ],
   "coj": [
     "Cochimi"
@@ -6519,7 +6049,6 @@
   "col": [
     "哥倫比亞-韋納奇語",
     "哥伦比亚-韦纳奇语",
-    "Columbia-Wenatchi",
     "Columbia-Wenatchee",
     "Columbia-Moses",
     "Nxaamxcin",
@@ -6528,15 +6057,11 @@
   ],
   "com": [
     "科曼奇語",
-    "科曼奇语",
-    "Comanche",
-    "科曼切語",
-    "科曼切语"
+    "科曼奇语"
   ],
   "con": [
     "科梵語",
     "科梵语",
-    "Cofán",
     "Cofan",
     "Kofan",
     "Kofane",
@@ -6546,26 +6071,11 @@
   ],
   "coo": [
     "科莫克斯語",
-    "科莫克斯语",
-    "Comox"
+    "科莫克斯语"
   ],
   "cop": [
     "科普特語",
-    "科普特语",
-    "Coptic",
-    "Akhmimic",
-    "Assiutic",
-    "Bashmuric",
-    "Bohairic",
-    "Faiyumic",
-    "Fayyumic",
-    "Lycopolitan",
-    "Memphitic",
-    "Mesokemic",
-    "Oxyrhynchite",
-    "Sahidic",
-    "Subakhmimic",
-    "Thebaic"
+    "科普特语"
   ],
   "coq": [
     "Coquille"
@@ -6578,8 +6088,7 @@
   ],
   "cov": [
     "草苗語",
-    "草苗语",
-    "Cao Miao"
+    "草苗语"
   ],
   "cow": [
     "Cowlitz"
@@ -6593,14 +6102,12 @@
   "coz": [
     "喬喬特克語",
     "乔乔特克语",
-    "Chochotec",
     "Chocho",
     "Chocholtec"
   ],
   "cpa": [
     "帕蘭特拉奇南特克語",
-    "帕兰特拉奇南特克语",
-    "Palantla Chinantec"
+    "帕兰特拉奇南特克语"
   ],
   "cpb": [
     "Ucayali-Yurúa Ashéninka"
@@ -6614,19 +6121,16 @@
   ],
   "cpe-spp": [
     "薩摩亞種植園皮欽語",
-    "萨摩亚种植园皮钦语",
-    "Samoan Plantation Pidgin"
+    "萨摩亚种植园皮钦语"
   ],
   "cpg": [
     "卡帕多細亞希臘語",
     "卡帕多细亚希腊语",
-    "Cappadocian Greek",
     "Cappadocian"
   ],
   "cpi": [
     "洋涇浜英語",
-    "洋泾浜英语",
-    "Chinese Pidgin English"
+    "洋泾浜英语"
   ],
   "cpn": [
     "Cherepon",
@@ -6643,8 +6147,7 @@
   ],
   "cps": [
     "卡皮塞尼奧語",
-    "卡皮塞尼奥语",
-    "Capiznon"
+    "卡皮塞尼奥语"
   ],
   "cpu": [
     "Pichis Ashéninka"
@@ -6652,13 +6155,6 @@
   "cpx": [
     "莆仙語",
     "莆仙语",
-    "莆仙閩語",
-    "莆仙闽语",
-    "莆田話",
-    "莆田话",
-    "興化話",
-    "兴化话",
-    "Puxian",
     "Pu-Xian",
     "Puxian Min",
     "Pu-Xian Min",
@@ -6673,8 +6169,7 @@
   ],
   "cqd": [
     "川黔滇苗語",
-    "川黔滇苗语",
-    "Chuanqiandian Cluster Miao"
+    "川黔滇苗语"
   ],
   "cr": [
     "克里語",
@@ -6700,35 +6195,29 @@
   ],
   "crh": [
     "克里米亞韃靼語",
-    "克里米亚鞑靼语",
-    "Crimean Tatar"
+    "克里米亚鞑靼语"
   ],
   "cri": [
     "聖多美語",
     "圣多美语",
-    "Sãotomense",
     "Forro",
     "São Tomense"
   ],
   "crj": [
     "南部東克里語",
-    "南部东克里语",
-    "Southern East Cree"
+    "南部东克里语"
   ],
   "crk": [
     "平原克里語",
-    "平原克里语",
-    "Plains Cree"
+    "平原克里语"
   ],
   "crl": [
     "北部東克里語",
-    "北部东克里语",
-    "Northern East Cree"
+    "北部东克里语"
   ],
   "crm": [
     "穆斯克里語",
-    "穆斯克里语",
-    "Moose Cree"
+    "穆斯克里语"
   ],
   "crn": [
     "Cora"
@@ -6740,50 +6229,36 @@
   "crp-gep": [
     "西格陵蘭皮欽語",
     "西格陵兰皮钦语",
-    "West Greenlandic Pidgin",
     "Greenlandic Pidgin",
     "Greenlandic Eskimo Pidgin"
   ],
   "crp-mpp": [
     "澳門皮欽葡萄牙語",
-    "澳门皮钦葡萄牙语",
-    "Macau Pidgin Portuguese"
+    "澳门皮钦葡萄牙语"
   ],
   "crp-rsn": [
     "挪威俄語",
-    "挪威俄语",
-    "Russenorsk"
+    "挪威俄语"
+  ],
+  "crp-tnw": [
+    "唐汪話",
+    "唐汪话",
+    "Tangwanghua"
   ],
   "crp-tpr": [
     "泰梅爾皮欽俄語",
-    "泰梅尔皮钦俄语",
-    "Taimyr Pidgin Russian"
-  ],
-  "crp-ykx": [
-    "寒溪語",
-    "寒溪语",
-    "宜蘭克里奧爾語",
-    "宜兰克里奥尔语",
-    "宜蘭克里奧語",
-    "宜兰克里奥语",
-    "Yilan Creole Japanese",
-    "Kankei language",
-    "Yilan Creole"
+    "泰梅尔皮钦俄语"
   ],
   "crq": [
     "Iyo'wujwa Chorote"
   ],
   "crr": [
     "卡羅來納阿爾岡昆語",
-    "卡罗来纳阿尔冈昆语",
-    "Carolina Algonquian"
+    "卡罗来纳阿尔冈昆语"
   ],
   "crs": [
     "塞舌爾克里奧爾語",
-    "塞舌尔克里奥尔语",
-    "賽席爾克里奧爾語",
-    "赛席尔克里奥尔语",
-    "Seychellois Creole"
+    "塞舌尔克里奥尔语"
   ],
   "crt": [
     "Iyojwa'ja Chorote"
@@ -6794,14 +6269,11 @@
   ],
   "crw": [
     "遮羅語",
-    "遮罗语",
-    "Chrau"
+    "遮罗语"
   ],
   "crx": [
     "達凱爾語",
-    "达凯尔语",
-    "Carrier",
-    "Dakelh"
+    "达凯尔语"
   ],
   "cry": [
     "Cori"
@@ -6815,38 +6287,31 @@
   ],
   "csa": [
     "奇爾特佩克奇南特克語",
-    "奇尔特佩克奇南特克语",
-    "Chiltepec Chinantec"
+    "奇尔特佩克奇南特克语"
   ],
   "csb": [
     "卡舒比語",
-    "卡舒比语",
-    "Kashubian"
+    "卡舒比语"
   ],
   "csc": [
     "加泰羅尼亞手語",
-    "加泰罗尼亚手语",
-    "Catalan Sign Language"
+    "加泰罗尼亚手语"
   ],
   "csd": [
     "清邁手語",
-    "清迈手语",
-    "Chiangmai Sign Language"
+    "清迈手语"
   ],
   "cse": [
     "捷克手語",
-    "捷克手语",
-    "Czech Sign Language"
+    "捷克手语"
   ],
   "csf": [
     "古巴手語",
-    "古巴手语",
-    "Cuban Sign Language"
+    "古巴手语"
   ],
   "csg": [
     "智利手語",
-    "智利手语",
-    "Chilean Sign Language"
+    "智利手语"
   ],
   "csh": [
     "Asho Chin",
@@ -6864,45 +6329,31 @@
   ],
   "csl": [
     "中國手語",
-    "中国手语",
-    "Chinese Sign Language"
+    "中国手语"
   ],
   "csm": [
     "中部山地米沃克語",
-    "中部山地米沃克语",
-    "Central Sierra Miwok"
+    "中部山地米沃克语"
   ],
   "csn": [
     "哥倫比亞手語",
-    "哥伦比亚手语",
-    "Colombian Sign Language"
+    "哥伦比亚手语"
   ],
   "cso": [
     "索奇亞帕姆奇南特克語",
-    "索奇亚帕姆奇南特克语",
-    "Sochiapam Chinantec"
-  ],
-  "csp": [
-    "桂南平話",
-    "桂南平话",
-    "Southern Pinghua"
+    "索奇亚帕姆奇南特克语"
   ],
   "csq": [
     "克羅地亞手語",
-    "克罗地亚手语",
-    "Croatian Sign Language"
+    "克罗地亚手语"
   ],
   "csr": [
     "哥斯達黎加手語",
-    "哥斯达黎加手语",
-    "哥斯大黎加手語",
-    "哥斯大黎加手语",
-    "Costa Rican Sign Language"
+    "哥斯达黎加手语"
   ],
   "css": [
     "南奧龍尼語",
     "南奥龙尼语",
-    "Southern Ohlone",
     "Mutsun",
     "San Juan Bautista Costanoan",
     "Rumsien",
@@ -6911,8 +6362,7 @@
   ],
   "cst": [
     "北奧龍尼語",
-    "北奥龙尼语",
-    "Northern Ohlone"
+    "北奥龙尼语"
   ],
   "csu-bba-pro": [
     "Proto-Bongo-Bagirmi"
@@ -6922,8 +6372,7 @@
   ],
   "csu-pro": [
     "原始中蘇丹語",
-    "原始中苏丹语",
-    "Proto-Central Sudanic"
+    "原始中苏丹语"
   ],
   "csu-sar-pro": [
     "Proto-Sara"
@@ -6946,8 +6395,7 @@
   ],
   "cta": [
     "塔塔爾特佩克查蒂諾語",
-    "塔塔尔特佩克查蒂诺语",
-    "Tataltepec Chatino"
+    "塔塔尔特佩克查蒂诺语"
   ],
   "ctc": [
     "Chetco-Tolowa",
@@ -6960,20 +6408,17 @@
   "ctd": [
     "梯頂語",
     "梯顶语",
-    "Tedim Chin",
     "Tedim",
     "Tiddim",
     "Sukte"
   ],
   "cte": [
     "特皮納帕奇南特克語",
-    "特皮纳帕奇南特克语",
-    "Tepinapa Chinantec"
+    "特皮纳帕奇南特克语"
   ],
   "ctg": [
     "吉大港語",
-    "吉大港语",
-    "Chittagonian"
+    "吉大港语"
   ],
   "cth": [
     "Thaiphum Chin",
@@ -6981,13 +6426,11 @@
   ],
   "ctl": [
     "特拉科亞津特佩克奇南特克語",
-    "特拉科亚津特佩克奇南特克语",
-    "Tlacoatzintepec Chinantec"
+    "特拉科亚津特佩克奇南特克语"
   ],
   "ctm": [
     "奇蒂馬查語",
-    "奇蒂马查语",
-    "Chitimacha"
+    "奇蒂马查语"
   ],
   "ctn": [
     "Chhintange"
@@ -6997,18 +6440,15 @@
   ],
   "ctp": [
     "西部高地查蒂諾語",
-    "西部高地查蒂诺语",
-    "Western Highland Chatino"
+    "西部高地查蒂诺语"
   ],
   "ctp-san": [
     "聖胡安基阿伊赫查蒂諾語",
-    "圣胡安基阿伊赫查蒂诺语",
-    "San Juan Quiahije Chatino"
+    "圣胡安基阿伊赫查蒂诺语"
   ],
   "cts": [
     "北卡坦端內斯比科拉諾語",
-    "北卡坦端内斯比科拉诺语",
-    "Northern Catanduanes Bicolano"
+    "北卡坦端内斯比科拉诺语"
   ],
   "ctt": [
     "Wayanad Chetti",
@@ -7019,19 +6459,16 @@
   ],
   "ctz": [
     "薩卡特佩克查蒂諾語",
-    "萨卡特佩克查蒂诺语",
-    "Zacatepec Chatino"
+    "萨卡特佩克查蒂诺语"
   ],
   "cu": [
     "教會斯拉夫語",
     "教会斯拉夫语",
-    "古教會斯拉夫語",
-    "古教会斯拉夫语"
+    "Old Church Slavic"
   ],
   "cua": [
     "戈語",
-    "戈语",
-    "Cua"
+    "戈语"
   ],
   "cub": [
     "Cubeo",
@@ -7052,8 +6489,7 @@
   ],
   "cuc": [
     "尤斯拉奇南特克語",
-    "尤斯拉奇南特克语",
-    "Usila Chinantec"
+    "尤斯拉奇南特克语"
   ],
   "cug": [
     "Cung",
@@ -7072,7 +6508,8 @@
     "Mashco Piro"
   ],
   "cuk": [
-    "Kuna"
+    "庫那語",
+    "库那语"
   ],
   "cul": [
     "Culina",
@@ -7098,20 +6535,12 @@
   ],
   "cup": [
     "庫佩諾語",
-    "库佩诺语",
-    "Cupeño"
+    "库佩诺语"
   ],
   "cuq": [
     "仡隆語",
     "仡隆语",
-    "Cun",
-    "Gelong",
-    "村語",
-    "村语",
-    "村話",
-    "村话",
-    "哥隆語",
-    "哥隆语"
+    "Gelong"
   ],
   "cur": [
     "Chhulung"
@@ -7121,20 +6550,32 @@
     "Ashraf",
     "Af-Ashraaf"
   ],
+  "cus-hec-pro": [
+    "原始高地東庫希特語",
+    "原始高地东库希特语"
+  ],
   "cus-pro": [
     "原始庫希特語",
-    "原始库希特语",
-    "Proto-Cushitic"
+    "原始库希特语"
+  ],
+  "cus-som-pro": [
+    "原始類索馬里語",
+    "原始类索马里语",
+    "Proto-Sam",
+    "Proto-Macro-Somali"
+  ],
+  "cus-sou-pro": [
+    "原始南庫希特語",
+    "原始南库希特语",
+    "Proto-Rift"
   ],
   "cut": [
     "特烏蒂拉奎卡特克語",
-    "特乌蒂拉奎卡特克语",
-    "Teutila Cuicatec"
+    "特乌蒂拉奎卡特克语"
   ],
   "cuu": [
     "傣雅語",
-    "傣雅语",
-    "Tai Ya"
+    "傣雅语"
   ],
   "cuv": [
     "Cuvok"
@@ -7144,8 +6585,7 @@
   ],
   "cux": [
     "特佩烏希拉奎卡特克語",
-    "特佩乌希拉奎卡特克语",
-    "Tepeuxila Cuicatec"
+    "特佩乌希拉奎卡特克语"
   ],
   "cuy": [
     "Cuitlatec",
@@ -7160,8 +6600,7 @@
   ],
   "cvn": [
     "國家山谷奇南特克語",
-    "国家山谷奇南特克语",
-    "Valle Nacional Chinantec"
+    "国家山谷奇南特克语"
   ],
   "cwa": [
     "Kabwa"
@@ -7171,8 +6610,7 @@
   ],
   "cwd": [
     "森林克里語",
-    "森林克里语",
-    "Woods Cree"
+    "森林克里语"
   ],
   "cwe": [
     "Kwere"
@@ -7192,8 +6630,7 @@
   ],
   "cya": [
     "諾帕拉查蒂諾語",
-    "诺帕拉查蒂诺语",
-    "Nopala Chatino"
+    "诺帕拉查蒂诺语"
   ],
   "cyb": [
     "Cayubaba",
@@ -7202,15 +6639,11 @@
   ],
   "cyo": [
     "庫約農語",
-    "库约农语",
-    "Cuyunon"
+    "库约农语"
   ],
   "czh": [
     "徽語",
     "徽语",
-    "徽州話",
-    "徽州话",
-    "Huizhou",
     "Huizhou Chinese"
   ],
   "czk": [
@@ -7218,19 +6651,16 @@
   ],
   "czn": [
     "森松特佩克查蒂諾語",
-    "森松特佩克查蒂诺语",
-    "Zenzontepec Chatino"
+    "森松特佩克查蒂诺语"
   ],
   "czo": [
     "閩中語",
     "闽中语",
-    "Min Zhong",
     "Min Zhong Chinese"
   ],
   "czt": [
     "佐通語",
     "佐通语",
-    "Zotung Chin",
     "Zotung"
   ],
   "da": [
@@ -7255,8 +6685,7 @@
   ],
   "dag": [
     "達加巴尼語",
-    "达加巴尼语",
-    "Dagbani"
+    "达加巴尼语"
   ],
   "dah": [
     "Gwahatike"
@@ -7269,8 +6698,7 @@
   ],
   "dak": [
     "達科他語",
-    "达科他语",
-    "Dakota"
+    "达科他语"
   ],
   "dal": [
     "Dahalo"
@@ -7292,7 +6720,6 @@
   "dar": [
     "達爾金語",
     "达尔金语",
-    "Dargwa",
     "Dargin"
   ],
   "das": [
@@ -7315,7 +6742,7 @@
     "Dao"
   ],
   "dba": [
-    "Bangi Me"
+    "Bangime"
   ],
   "dbb": [
     "Deno"
@@ -7329,7 +6756,6 @@
   "dbf": [
     "埃多皮語",
     "埃多皮语",
-    "Edopi",
     "Elopi"
   ],
   "dbg": [
@@ -7340,12 +6766,12 @@
     "Doka"
   ],
   "dbj": [
-    "Ida'an"
+    "Ida'an",
+    "Idahan"
   ],
   "dbl": [
     "迪爾巴爾語",
-    "迪尔巴尔语",
-    "Dyirbal"
+    "迪尔巴尔语"
   ],
   "dbm": [
     "Duguri"
@@ -7384,7 +6810,6 @@
   "dcc": [
     "達金語",
     "达金语",
-    "Deccan",
     "Dakhani",
     "Dakhini",
     "Dakhni",
@@ -7394,6 +6819,7 @@
     "Dakkhani",
     "Dakkhini",
     "Dakkhni",
+    "Deccan",
     "Deccany",
     "Dekhani",
     "Dekhini",
@@ -7407,7 +6833,6 @@
   "dda": [
     "達迪-達迪語",
     "达迪-达迪语",
-    "Dadi Dadi",
     "Dardi Dardi",
     "Tati Tati",
     "Dadi-Dadi",
@@ -7422,23 +6847,19 @@
   ],
   "ddg": [
     "法塔魯庫語",
-    "法塔鲁库语",
-    "Fataluku"
+    "法塔鲁库语"
   ],
   "ddi": [
     "迪奧迪奧語",
-    "迪奥迪奥语",
-    "Diodio"
+    "迪奥迪奥语"
   ],
   "ddj": [
     "賈魯語",
-    "贾鲁语",
-    "Jaru"
+    "贾鲁语"
   ],
   "ddn": [
     "登迪語",
     "登迪语",
-    "Dendi",
     "Dandawa",
     "Dendi (West Africa)",
     "Dendi (Benin)"
@@ -7446,7 +6867,6 @@
   "ddo": [
     "采茲語",
     "采兹语",
-    "Tsez",
     "Tsezi",
     "Dido"
   ],
@@ -7464,8 +6884,7 @@
     "德語",
     "德语",
     "High German",
-    "新高地德語",
-    "新高地德语",
+    "New High German",
     "Deutsch"
   ],
   "dec": [
@@ -7487,8 +6906,7 @@
   ],
   "deh": [
     "德赫瓦里語",
-    "德赫瓦里语",
-    "Dehwari"
+    "德赫瓦里语"
   ],
   "dei": [
     "Demisa"
@@ -7502,14 +6920,12 @@
   "den": [
     "斯拉維語",
     "斯拉维语",
-    "Slavey",
     "Slave",
     "Slavé"
   ],
   "dep": [
     "德拉瓦皮欽語",
-    "德拉瓦皮钦语",
-    "Pidgin Delaware"
+    "德拉瓦皮钦语"
   ],
   "der": [
     "Deori"
@@ -7532,8 +6948,7 @@
   ],
   "dgc": [
     "卡西古蘭杜馬加特阿埃塔語",
-    "卡西古兰杜马加特阿埃塔语",
-    "Casiguran Dumagat Agta"
+    "卡西古兰杜马加特阿埃塔语"
   ],
   "dgd": [
     "Dagaari Dioula"
@@ -7555,18 +6970,15 @@
   ],
   "dgn": [
     "達格曼語",
-    "达格曼语",
-    "Dagoman"
+    "达格曼语"
   ],
   "dgo": [
     "印地多格拉語",
-    "印地多格拉语",
-    "Hindi Dogri"
+    "印地多格拉语"
   ],
   "dgr": [
     "多格里布語",
     "多格里布语",
-    "Dogrib",
     "Tłicho",
     "Tlinchon"
   ],
@@ -7576,13 +6988,11 @@
   "dgt": [
     "恩德拉恩吉特語",
     "恩德拉恩吉特语",
-    "Ntra'ngith",
     "Ndra'ngith"
   ],
   "dgw": [
     "道恩烏隆語",
     "道恩乌隆语",
-    "Daungwurrung",
     "Taungurong",
     "Dhagung-wurrung",
     "Thagungwurrung"
@@ -7601,8 +7011,7 @@
   ],
   "dhl": [
     "達蘭吉語",
-    "达兰吉语",
-    "Dhalandji"
+    "达兰吉语"
   ],
   "dhm": [
     "Zemba",
@@ -7616,18 +7025,15 @@
   ],
   "dhn": [
     "丹基語",
-    "丹基语",
-    "Dhanki"
+    "丹基语"
   ],
   "dho": [
     "多迪亞語",
-    "多迪亚语",
-    "Dhodia"
+    "多迪亚语"
   ],
   "dhr": [
     "達爾加里語",
     "达尔加里语",
-    "Tharrgari",
     "Dhargari"
   ],
   "dhs": [
@@ -7638,21 +7044,18 @@
   ],
   "dhv": [
     "利富語",
-    "利富语",
-    "Drehu"
+    "利富语"
   ],
   "dhw": [
     "達努瓦里語",
     "达努瓦里语",
-    "Danuwar",
     "Danwar",
     "Dhanwar",
     "Rai"
   ],
   "dhx": [
     "敦加羅語",
-    "敦加罗语",
-    "Dhungaloo"
+    "敦加罗语"
   ],
   "dia": [
     "Dia"
@@ -7669,7 +7072,6 @@
   "dif": [
     "迪埃里語",
     "迪埃里语",
-    "Dieri",
     "Diyari",
     "Dirari"
   ],
@@ -7694,8 +7096,7 @@
   ],
   "din": [
     "丁卡語",
-    "丁卡语",
-    "Dinka"
+    "丁卡语"
   ],
   "dio": [
     "Dibo"
@@ -7733,7 +7134,6 @@
   "dja": [
     "賈賈伍龍語",
     "贾贾伍龙语",
-    "Djadjawurrung",
     "Dja dja wurrung"
   ],
   "djb": [
@@ -7745,7 +7145,6 @@
   "djd": [
     "賈明瓊語",
     "贾明琼语",
-    "Jaminjung",
     "Djamindjung"
   ],
   "dje": [
@@ -7754,8 +7153,7 @@
   ],
   "djf": [
     "詹貢語",
-    "詹贡语",
-    "Djangun"
+    "詹贡语"
   ],
   "dji": [
     "Djinang"
@@ -7763,7 +7161,6 @@
   "djj": [
     "恩傑巴納語",
     "恩杰巴纳语",
-    "Ndjébbana",
     "Djeebbana"
   ],
   "djk": [
@@ -7772,8 +7169,7 @@
   ],
   "djl": [
     "吉瓦利語",
-    "吉瓦利语",
-    "Djiwarli"
+    "吉瓦利语"
   ],
   "djm": [
     "Jamsay",
@@ -7782,8 +7178,7 @@
   ],
   "djn": [
     "賈萬語",
-    "贾万语",
-    "Djauan"
+    "贾万语"
   ],
   "djo": [
     "Jangkang"
@@ -7796,8 +7191,7 @@
   ],
   "djw": [
     "賈維語",
-    "贾维语",
-    "Djawi"
+    "贾维语"
   ],
   "dka": [
     "Dakpa",
@@ -7813,24 +7207,22 @@
   ],
   "dks": [
     "東南丁卡語",
-    "东南丁卡语",
-    "Southeastern Dinka"
+    "东南丁卡语"
   ],
   "dkx": [
     "Mazagway"
   ],
   "dlg": [
     "多爾干語",
-    "多尔干语",
-    "Dolgan"
+    "多尔干语"
   ],
   "dlk": [
-    "Dahalik"
+    "Dahalik",
+    "Dahlik"
   ],
   "dlm": [
     "達爾馬提亞語",
     "达尔马提亚语",
-    "Dalmatian",
     "Dalmatic"
   ],
   "dln": [
@@ -7852,7 +7244,6 @@
   "dmd": [
     "馬蒂馬蒂語",
     "马蒂马蒂语",
-    "Madhi Madhi",
     "Madhi-Madhi",
     "Madi Madi",
     "Madi-Madi",
@@ -7867,18 +7258,15 @@
   ],
   "dmg": [
     "上京那巴當岸語",
-    "上京那巴当岸语",
-    "Upper Kinabatangan"
+    "上京那巴当岸语"
   ],
   "dmk": [
     "多馬基語",
-    "多马基语",
-    "Domaaki"
+    "多马基语"
   ],
   "dml": [
     "達梅里語",
-    "达梅里语",
-    "Dameli"
+    "达梅里语"
   ],
   "dmm": [
     "Dama (Nigeria)"
@@ -7887,10 +7275,12 @@
     "Dama (Sierra Leone)"
   ],
   "dmn-mdw-pro": [
-    "Proto-Western Mande"
+    "原始西曼德語",
+    "原始西曼德语"
   ],
   "dmn-pro": [
-    "Proto-Mande"
+    "原始曼德語",
+    "原始曼德语"
   ],
   "dmo": [
     "Kemezung"
@@ -7910,7 +7300,6 @@
   "dmw": [
     "穆德布拉語",
     "穆德布拉语",
-    "Mudburra",
     "Mudbura"
   ],
   "dmx": [
@@ -7930,8 +7319,7 @@
   ],
   "dng": [
     "東干語",
-    "东干语",
-    "Dungan"
+    "东干语"
   ],
   "dni": [
     "Lower Grand Valley Dani"
@@ -7969,8 +7357,7 @@
   ],
   "dny": [
     "丹尼語",
-    "丹尼语",
-    "Dení"
+    "丹尼语"
   ],
   "doa": [
     "Dom"
@@ -7981,7 +7368,6 @@
   "doc": [
     "北侗語",
     "北侗语",
-    "Northern Kam",
     "Northern Gam",
     "Northern Dong"
   ],
@@ -7996,8 +7382,7 @@
   ],
   "doi": [
     "多格拉語",
-    "多格拉语",
-    "Dogri"
+    "多格拉语"
   ],
   "dok": [
     "Dondo"
@@ -8044,8 +7429,7 @@
   ],
   "doz": [
     "多爾澤語",
-    "多尔泽语",
-    "Dorze"
+    "多尔泽语"
   ],
   "dpp": [
     "Papar"
@@ -8053,27 +7437,23 @@
   "dra-mkn": [
     "中古卡納達語",
     "中古卡纳达语",
-    "Middle Kannada",
     "Nadugannada"
   ],
   "dra-okn": [
     "古卡納達語",
     "古卡纳达语",
-    "Old Kannada",
     "Halegannada"
   ],
   "dra-pro": [
     "原始達羅毗荼語",
-    "原始达罗毗荼语",
-    "Proto-Dravidian"
+    "原始达罗毗荼语"
   ],
   "drb": [
     "Dair"
   ],
   "drc": [
     "明德里科語",
-    "明德里科语",
-    "Minderico"
+    "明德里科语"
   ],
   "drd": [
     "Darmiya"
@@ -8090,7 +7470,6 @@
   "drl": [
     "巴阿甘吉語",
     "巴阿甘吉语",
-    "Baagandji",
     "Darling",
     "Bandjigali"
   ],
@@ -8108,9 +7487,7 @@
   ],
   "dru": [
     "魯凱語",
-    "鲁凯语",
-    "Rukai",
-    "Drekay"
+    "鲁凯语"
   ],
   "dru-pro": [
     "原始魯凱語",
@@ -8118,8 +7495,7 @@
   ],
   "dry": [
     "達萊語",
-    "达莱语",
-    "Darai"
+    "达莱语"
   ],
   "dsb": [
     "下索布語",
@@ -8138,24 +7514,21 @@
   ],
   "dsl": [
     "丹麥手語",
-    "丹麦手语",
-    "Danish Sign Language"
+    "丹麦手语"
   ],
   "dsn": [
     "Dusner"
   ],
   "dso": [
     "德西雅語",
-    "德西雅语",
-    "Desiya"
+    "德西雅语"
   ],
   "dsq": [
     "Tadaksahak"
   ],
   "dta": [
     "達斡爾語",
-    "达斡尔语",
-    "Daur"
+    "达斡尔语"
   ],
   "dtb": [
     "Labuk-Kinabatangan Kadazan"
@@ -8166,8 +7539,7 @@
   ],
   "dth": [
     "阿迪廷吉蒂格語",
-    "阿迪廷吉蒂格语",
-    "Adithinngithigh"
+    "阿迪廷吉蒂格语"
   ],
   "dti": [
     "Ana Tinga Dogon"
@@ -8207,7 +7579,6 @@
   "dty": [
     "都特利語",
     "都特利语",
-    "Doteli",
     "Dotyali"
   ],
   "dua": [
@@ -8216,8 +7587,7 @@
   ],
   "dub": [
     "杜布里語",
-    "杜布里语",
-    "Dubli"
+    "杜布里语"
   ],
   "duc": [
     "Duna"
@@ -8234,8 +7604,7 @@
   ],
   "duh": [
     "敦格拉比爾語",
-    "敦格拉比尔语",
-    "Dungra Bhil"
+    "敦格拉比尔语"
   ],
   "dui": [
     "Dumun"
@@ -8249,8 +7618,7 @@
   ],
   "dum": [
     "中古荷蘭語",
-    "中古荷兰语",
-    "Middle Dutch"
+    "中古荷兰语"
   ],
   "dun": [
     "Dusun Deyah"
@@ -8258,7 +7626,6 @@
   "duo": [
     "杜巴尼南阿埃塔語",
     "杜巴尼南阿埃塔语",
-    "Dupaningan Agta",
     "Dupaninan Agta",
     "Dupaningan",
     "Dupaninan"
@@ -8278,7 +7645,6 @@
   "duu": [
     "獨龍語",
     "独龙语",
-    "Drung",
     "Derung",
     "Dulong",
     "Trung"
@@ -8304,10 +7670,8 @@
   "dv": [
     "迪維希語",
     "迪维希语",
-    "迪維西語",
-    "迪维西语",
-    "馬爾代夫語",
-    "马尔代夫语"
+    "Divehi",
+    "Maldivian"
   ],
   "dva": [
     "Duau"
@@ -8321,7 +7685,6 @@
   "dwu": [
     "杜瓦爾語",
     "杜瓦尔语",
-    "Dhuwal",
     "Gumatj",
     "Dual",
     "Duala",
@@ -8344,7 +7707,6 @@
   "dwz": [
     "德維斯萊語",
     "德维斯莱语",
-    "Dewas Rai",
     "Danuwar Rai",
     "Rai Danuwar"
   ],
@@ -8353,13 +7715,11 @@
   ],
   "dyb": [
     "迪亞貝爾迪亞貝爾語",
-    "迪亚贝尔迪亚贝尔语",
-    "Dyaberdyaber"
+    "迪亚贝尔迪亚贝尔语"
   ],
   "dyd": [
     "迪尤貢語",
-    "迪尤贡语",
-    "Dyugun"
+    "迪尤贡语"
   ],
   "dyg": [
     "Villa Viciosa Agta"
@@ -8378,14 +7738,12 @@
   ],
   "dyn": [
     "迪揚加迪語",
-    "迪扬加迪语",
-    "Dyangadi"
+    "迪扬加迪语"
   ],
   "dyo": [
     "Jola-Fonyi",
     "Diola-Fogny",
-    "朱拉語",
-    "朱拉语",
+    "Jola",
     "Joola",
     "Diola"
   ],
@@ -8402,11 +7760,7 @@
   ],
   "dz": [
     "宗喀語",
-    "宗喀语",
-    "宗卡語",
-    "宗卡语",
-    "不丹語",
-    "不丹语"
+    "宗喀语"
   ],
   "dza": [
     "Tunzu",
@@ -8433,7 +7787,6 @@
   "ebk": [
     "東邦圖克語",
     "东邦图克语",
-    "Eastern Bontoc",
     "Eastern Bontok"
   ],
   "ebr": [
@@ -8448,8 +7801,7 @@
   ],
   "ecs": [
     "厄瓜多爾手語",
-    "厄瓜多尔手语",
-    "Ecuadorian Sign Language"
+    "厄瓜多尔手语"
   ],
   "ecy": [
     "Eteocypriot"
@@ -8470,8 +7822,7 @@
   ],
   "efi": [
     "埃菲克語",
-    "埃菲克语",
-    "Efik"
+    "埃菲克语"
   ],
   "ega": [
     "Ega"
@@ -8479,7 +7830,6 @@
   "egl": [
     "艾米利亞語",
     "艾米利亚语",
-    "Emilian",
     "Emiliano"
   ],
   "ego": [
@@ -8488,16 +7838,13 @@
   "egx-dem": [
     "世俗埃及語",
     "世俗埃及语",
-    "Demotic",
     "Demotic Egyptian",
     "Enchorial"
   ],
   "egy": [
     "埃及語",
     "埃及语",
-    "Egyptian",
-    "古埃及語",
-    "古埃及语"
+    "Ancient Egyptian"
   ],
   "ehu": [
     "Ehueun"
@@ -8547,14 +7894,12 @@
   ],
   "eky": [
     "東克耶語",
-    "东克耶语",
-    "Eastern Kayah"
+    "东克耶语"
   ],
   "el": [
     "希臘語",
     "希腊语",
-    "現代希臘語",
-    "现代希腊语",
+    "Modern Greek",
     "Neo-Hellenic"
   ],
   "ele": [
@@ -8588,8 +7933,7 @@
   ],
   "elx": [
     "埃蘭語",
-    "埃兰语",
-    "Elamite"
+    "埃兰语"
   ],
   "ema": [
     "Emai",
@@ -8599,15 +7943,15 @@
   ],
   "emb": [
     "Embaloh",
-    "Palin",
-    "Pari",
-    "Sangau",
-    "Sanggau",
     "Maloh",
     "Malo",
     "Matoh",
     "Mbaloh",
-    "Memaloh"
+    "Memaloh",
+    "Palin",
+    "Pari",
+    "Sangau",
+    "Sanggau"
   ],
   "eme": [
     "Emerillon",
@@ -8620,13 +7964,11 @@
   ],
   "emg": [
     "東梅瓦杭語",
-    "东梅瓦杭语",
-    "Eastern Meohang"
+    "东梅瓦杭语"
   ],
   "emi": [
     "穆紹-埃米勞語",
-    "穆绍-埃米劳语",
-    "Mussau-Emira"
+    "穆绍-埃米劳语"
   ],
   "emk": [
     "Eastern Maninkakan"
@@ -8642,34 +7984,29 @@
   ],
   "ems": [
     "阿魯提克語",
-    "阿鲁提克语",
-    "Alutiiq"
+    "阿鲁提克语"
   ],
   "emu": [
     "東穆里亞語",
-    "东穆里亚语",
-    "Eastern Muria"
+    "东穆里亚语"
   ],
   "emw": [
     "Emplawas"
   ],
   "emx": [
     "巴斯克羅姆語",
-    "巴斯克罗姆语",
-    "Erromintxela"
+    "巴斯克罗姆语"
   ],
   "emy": [
     "古典馬雅語",
     "古典马雅语",
-    "Epigraphic Mayan",
     "Classic Ch'olti'an",
     "Ch'olti'"
   ],
   "en": [
     "英語",
     "英语",
-    "現代英語",
-    "现代英语",
+    "Modern English",
     "New English"
   ],
   "ena": [
@@ -8680,21 +8017,18 @@
   ],
   "enc": [
     "恩語",
-    "恩语",
-    "En"
+    "恩语"
   ],
   "end": [
     "Ende"
   ],
   "enf": [
     "森林埃涅茨語",
-    "森林埃涅茨语",
-    "Forest Enets"
+    "森林埃涅茨语"
   ],
   "enh": [
     "凍原埃涅茨語",
-    "冻原埃涅茨语",
-    "Tundra Enets"
+    "冻原埃涅茨语"
   ],
   "enl": [
     "Enlhet",
@@ -8703,11 +8037,8 @@
   "enm": [
     "中古英語",
     "中古英语",
-    "Middle English",
     "Medieval English",
-    "Mediaeval English",
-    "中世紀英語",
-    "中世纪英语"
+    "Mediaeval English"
   ],
   "enn": [
     "Engenni"
@@ -8762,7 +8093,6 @@
   "erk": [
     "南埃法特語",
     "南埃法特语",
-    "South Efate",
     "Efate",
     "Vate",
     "Vaté"
@@ -8770,7 +8100,6 @@
   "ero": [
     "爾龔語",
     "尔龚语",
-    "Horpa",
     "Ergong",
     "Danba",
     "Stau",
@@ -8800,14 +8129,12 @@
   "ers": [
     "爾蘇語",
     "尔苏语",
-    "Ersu",
     "Duoxu",
     "Erhsu"
   ],
   "ert": [
     "埃里泰語",
-    "埃里泰语",
-    "Eritai"
+    "埃里泰语"
   ],
   "erw": [
     "Erokwanas"
@@ -8823,36 +8150,30 @@
   ],
   "esh": [
     "埃斯特哈爾迪語",
-    "埃斯特哈尔迪语",
-    "Eshtehardi"
+    "埃斯特哈尔迪语"
   ],
   "esi": [
     "北阿拉斯加伊努皮克語",
-    "北阿拉斯加伊努皮克语",
-    "North Alaskan Inupiatun"
+    "北阿拉斯加伊努皮克语"
   ],
   "esk": [
     "西北阿拉斯加伊努皮克語",
-    "西北阿拉斯加伊努皮克语",
-    "Northwest Alaskan Inupiatun"
+    "西北阿拉斯加伊努皮克语"
   ],
   "esl": [
     "埃及手語",
-    "埃及手语",
-    "Egyptian Sign Language"
+    "埃及手语"
   ],
   "esm": [
     "Esuma"
   ],
   "esn": [
     "薩爾瓦多手語",
-    "萨尔瓦多手语",
-    "Salvadoran Sign Language"
+    "萨尔瓦多手语"
   ],
   "eso": [
     "愛沙尼亞手語",
-    "爱沙尼亚手语",
-    "Estonian Sign Language"
+    "爱沙尼亚手语"
   ],
   "esq": [
     "Esselen"
@@ -8860,7 +8181,6 @@
   "ess": [
     "中西伯利亞尤皮克語",
     "中西伯利亚尤皮克语",
-    "Central Siberian Yupik",
     "Central Siberian Yup'ik",
     "St. Lawrence Yupik",
     "St. Lawrence Yup'ik",
@@ -8875,14 +8195,11 @@
   ],
   "esu": [
     "中阿拉斯加尤皮克語",
-    "中阿拉斯加尤皮克语",
-    "Yup'ik",
-    "Central Alaskan Yupik"
+    "中阿拉斯加尤皮克语"
   ],
   "esx-esk-pro": [
     "原始愛斯基摩語",
-    "原始爱斯基摩语",
-    "Proto-Eskimo"
+    "原始爱斯基摩语"
   ],
   "esx-ink": [
     "Inuktun"
@@ -8892,21 +8209,18 @@
   ],
   "esx-inu-pro": [
     "原始因紐特語",
-    "原始因纽特语",
-    "Proto-Inuit"
+    "原始因纽特语"
   ],
   "esx-pro": [
     "原始愛斯基摩-阿留申語",
-    "原始爱斯基摩-阿留申语",
-    "Proto-Eskimo-Aleut"
+    "原始爱斯基摩-阿留申语"
   ],
   "esx-tut": [
     "Tunumiisut"
   ],
   "esy": [
     "埃斯卡亞語",
-    "埃斯卡亚语",
-    "Eskayan"
+    "埃斯卡亚语"
   ],
   "et": [
     "愛沙尼亞語",
@@ -8920,10 +8234,7 @@
   ],
   "eth": [
     "埃塞俄比亞手語",
-    "埃塞俄比亚手语",
-    "Ethiopian Sign Language",
-    "衣索比亞手語",
-    "衣索比亚手语"
+    "埃塞俄比亚手语"
   ],
   "etn": [
     "Eton (Vanuatu)",
@@ -8944,8 +8255,7 @@
   ],
   "ett": [
     "伊特拉斯坎語",
-    "伊特拉斯坎语",
-    "Etruscan"
+    "伊特拉斯坎语"
   ],
   "etu": [
     "Ejagham"
@@ -8964,13 +8274,11 @@
   "euq-pro": [
     "原始巴斯克語",
     "原始巴斯克语",
-    "Proto-Basque",
     "Proto-Vasconic"
   ],
   "eve": [
     "鄂溫語",
-    "鄂温语",
-    "Even"
+    "鄂温语"
   ],
   "evh": [
     "Uvbie"
@@ -8978,7 +8286,7 @@
   "evn": [
     "鄂溫克語",
     "鄂温克语",
-    "Evenki"
+    "Tungus"
   ],
   "ewo": [
     "依汪都語",
@@ -8987,13 +8295,11 @@
   ],
   "ext": [
     "埃斯特雷馬杜拉語",
-    "埃斯特雷马杜拉语",
-    "Extremaduran"
+    "埃斯特雷马杜拉语"
   ],
   "eya": [
     "埃雅克語",
-    "埃雅克语",
-    "Eyak"
+    "埃雅克语"
   ],
   "eyo": [
     "Keiyo"
@@ -9010,10 +8316,8 @@
     "波斯語",
     "波斯语",
     "Farsi",
-    "新波斯語",
-    "新波斯语",
-    "現代波斯語",
-    "现代波斯语"
+    "New Persian",
+    "Modern Persian"
   ],
   "faa": [
     "Fasu",
@@ -9027,7 +8331,6 @@
   "fab": [
     "安諾本語",
     "安诺本语",
-    "Annobonese",
     "Fa d'Ambu"
   ],
   "fad": [
@@ -9064,10 +8367,9 @@
   "fan": [
     "芳語",
     "芳语",
-    "Fang (Bantu)",
-    "Fang (Guinea)",
     "Pahouin",
     "Fang (Equatorial Guinea)",
+    "Fang (Gabon)",
     "Fang"
   ],
   "fap": [
@@ -9083,32 +8385,28 @@
     "Fataleka"
   ],
   "fau": [
-    "Fayu"
+    "法尤語",
+    "法尤语"
   ],
   "fax": [
     "法拉語",
-    "法拉语",
-    "Fala"
+    "法拉语"
   ],
   "fay": [
     "西南法爾斯語",
-    "西南法尔斯语",
-    "Southwestern Fars"
+    "西南法尔斯语"
   ],
   "faz": [
     "西北法爾斯語",
-    "西北法尔斯语",
-    "Northwestern Fars"
+    "西北法尔斯语"
   ],
   "fbl": [
     "西阿爾拜比科爾語",
-    "西阿尔拜比科尔语",
-    "West Albay Bikol"
+    "西阿尔拜比科尔语"
   ],
   "fcs": [
     "魁北克手語",
-    "魁北克手语",
-    "Quebec Sign Language"
+    "魁北克手语"
   ],
   "fer": [
     "Feroge"
@@ -9116,8 +8414,7 @@
   "ff": [
     "富拉語",
     "富拉语",
-    "富拉尼語",
-    "富拉尼语"
+    "Fulani"
   ],
   "ffi": [
     "Foia Foia"
@@ -9131,15 +8428,15 @@
     "Suomi"
   ],
   "fia": [
-    "Nobiin"
+    "努比因語",
+    "努比因语"
   ],
   "fie": [
     "Fyer"
   ],
   "fip": [
     "菲帕語",
-    "菲帕语",
-    "Fipa"
+    "菲帕语"
   ],
   "fir": [
     "Firan"
@@ -9147,7 +8444,7 @@
   "fit": [
     "梅安語",
     "梅安语",
-    "Meänkieli"
+    "Tornedalen Finnish"
   ],
   "fiw": [
     "Fiwaga"
@@ -9167,7 +8464,6 @@
   "fla": [
     "蒙大拿薩利希語",
     "蒙大拿萨利希语",
-    "Montana Salish",
     "Flathead",
     "Salish",
     "Séliš",
@@ -9187,7 +8483,6 @@
   "fln": [
     "費蓮達島語",
     "费莲达岛语",
-    "Flinders Island",
     "Yalgawarra",
     "Wurima",
     "Mutumui"
@@ -9204,13 +8499,11 @@
   ],
   "fmu": [
     "遠西穆里亞語",
-    "远西穆里亚语",
-    "Far Western Muria"
+    "远西穆里亚语"
   ],
   "fng": [
     "凡那伽羅語",
-    "凡那伽罗语",
-    "Fanagalo"
+    "凡那伽罗语"
   ],
   "fni": [
     "Fania"
@@ -9238,14 +8531,11 @@
   ],
   "fos": [
     "西拉雅語",
-    "西拉雅语",
-    "Siraya"
+    "西拉雅语"
   ],
   "fpe": [
     "皮欽利斯語",
-    "皮钦利斯语",
-    "Pichinglis",
-    "Fernando Po Creole English"
+    "皮钦利斯语"
   ],
   "fqs": [
     "Fas"
@@ -9253,16 +8543,14 @@
   "fr": [
     "法語",
     "法语",
-    "現代法語",
-    "现代法语"
+    "Modern French"
   ],
   "frd": [
     "Fordata"
   ],
   "frm": [
     "中古法語",
-    "中古法语",
-    "Middle French"
+    "中古法语"
   ],
   "fro": [
     "古法語",
@@ -9271,7 +8559,6 @@
   "frp": [
     "法蘭克-普羅旺斯語",
     "法兰克-普罗旺斯语",
-    "Franco-Provençal",
     "Arpetan",
     "Arpitan"
   ],
@@ -9280,33 +8567,26 @@
   ],
   "frr": [
     "北弗里斯蘭語",
-    "北弗里斯兰语",
-    "North Frisian",
-    "北弗里西語",
-    "北弗里西语"
+    "北弗里斯兰语"
   ],
   "frt": [
     "Fortsenal"
   ],
   "fse": [
     "芬蘭手語",
-    "芬兰手语",
-    "Finnish Sign Language"
+    "芬兰手语"
   ],
   "fsl": [
     "法國手語",
-    "法国手语",
-    "French Sign Language"
+    "法国手语"
   ],
   "fss": [
     "芬蘭-瑞典手語",
-    "芬兰-瑞典手语",
-    "Finnish-Swedish Sign Language"
+    "芬兰-瑞典手语"
   ],
   "fud": [
     "富圖納語",
     "富图纳语",
-    "East Futuna",
     "Futunan",
     "Futunian",
     "Futuna"
@@ -9322,13 +8602,11 @@
   ],
   "fur": [
     "弗留利語",
-    "弗留利语",
-    "Friulian"
+    "弗留利语"
   ],
   "fut": [
     "富圖納-阿尼瓦語",
-    "富图纳-阿尼瓦语",
-    "Futuna-Aniwa"
+    "富图纳-阿尼瓦语"
   ],
   "fuu": [
     "Furu"
@@ -9348,14 +8626,12 @@
   "fy": [
     "西弗里斯蘭語",
     "西弗里斯兰语",
-    "西弗里西語",
-    "西弗里西语"
+    "Western Frisian"
   ],
   "ga": [
     "愛爾蘭語",
     "爱尔兰语",
-    "愛爾蘭蓋爾語",
-    "爱尔兰盖尔语",
+    "Irish Gaelic",
     "Gaelic"
   ],
   "gaa": [
@@ -9369,7 +8645,6 @@
   "gac": [
     "混合大安達曼語",
     "混合大安达曼语",
-    "Mixed Great Andamanese",
     "Great Andamanese creole",
     "Great Andamanese"
   ],
@@ -9389,13 +8664,11 @@
   ],
   "gag": [
     "加告茲語",
-    "加告兹语",
-    "Gagauz"
+    "加告兹语"
   ],
   "gah": [
     "阿勒卡諾語",
     "阿勒卡诺语",
-    "Alekano",
     "Gahuku"
   ],
   "gai": [
@@ -9418,8 +8691,7 @@
   ],
   "gan": [
     "贛語",
-    "赣语",
-    "Gan"
+    "赣语"
   ],
   "gao": [
     "Gants",
@@ -9510,8 +8782,7 @@
   ],
   "gbm": [
     "加爾華利語",
-    "加尔华利语",
-    "Garhwali"
+    "加尔华利语"
   ],
   "gbn": [
     "Mo'da"
@@ -9575,7 +8846,6 @@
   "gcf": [
     "安地列斯克里奧爾語",
     "安地列斯克里奥尔语",
-    "Antillean Creole",
     "Antillean Creole French",
     "Guadeloupean Creole",
     "Guadeloupean Creole French",
@@ -9584,8 +8854,7 @@
   ],
   "gcl": [
     "格瑞那達克里奧爾英語",
-    "格瑞那达克里奥尔英语",
-    "Grenadian Creole English"
+    "格瑞那达克里奥尔英语"
   ],
   "gcn": [
     "Gaina"
@@ -9593,14 +8862,9 @@
   "gcr": [
     "圭亞那克里奧爾語",
     "圭亚那克里奥尔语",
-    "法屬圭亞那克里奧爾語",
-    "法属圭亚那克里奥尔语",
-    "圭亞那語",
-    "圭亚那语",
-    "Guianese Creole",
-    "Guyanais",
     "French Guianese Creole",
     "Guianese French Creole",
+    "Guyanais",
     "Guyanese French Creole"
   ],
   "gct": [
@@ -9665,13 +8929,11 @@
   "gdo": [
     "戈多貝里語",
     "戈多贝里语",
-    "Godoberi",
     "Ghodoberi"
   ],
   "gdq": [
     "邁赫拉語",
     "迈赫拉语",
-    "Mehri",
     "Mahri"
   ],
   "gdr": [
@@ -9714,8 +8976,7 @@
   ],
   "gej": [
     "格恩語",
-    "格恩语",
-    "Gen"
+    "格恩语"
   ],
   "gek": [
     "Gerka",
@@ -9760,21 +9021,20 @@
   "gem-bur": [
     "古勃艮第語",
     "古勃艮第语",
-    "Burgundian",
     "Burgundish",
     "Burgundic"
   ],
   "gem-pro": [
     "原始日耳曼語",
     "原始日耳曼语",
-    "Proto-Germanic",
     "Common Germanic"
   ],
   "geq": [
     "Geme"
   ],
   "ges": [
-    "Geser-Gorom"
+    "蓋瑟亞語",
+    "盖瑟亚语"
   ],
   "gev": [
     "Viya",
@@ -9792,20 +9052,17 @@
   "gez": [
     "吉茲語",
     "吉兹语",
-    "Ge'ez",
     "Ethiopic",
     "Gi'iz",
     "Geez"
   ],
   "gfk": [
     "帕特帕塔爾語",
-    "帕特帕塔尔语",
-    "Patpatar"
+    "帕特帕塔尔语"
   ],
   "gft": [
     "加法特語",
-    "加法特语",
-    "Gafat"
+    "加法特语"
   ],
   "gga": [
     "Gao"
@@ -9891,14 +9148,13 @@
   "gih": [
     "Githabul"
   ],
+  "gii": [
+    "Girirra",
+    "Gariire"
+  ],
   "gil": [
     "吉伯特語",
     "吉伯特语",
-    "Gilbertese",
-    "基里巴斯語",
-    "基里巴斯语",
-    "吉里巴斯語",
-    "吉里巴斯语",
     "Kiribati",
     "Kiribatese"
   ],
@@ -9911,7 +9167,6 @@
   "gin": [
     "希努赫語",
     "希努赫语",
-    "Hinukh",
     "Hinuq",
     "Hinux",
     "Ginukh",
@@ -9919,8 +9174,7 @@
   ],
   "gio": [
     "仡佬語",
-    "仡佬语",
-    "Gelao"
+    "仡佬语"
   ],
   "gip": [
     "Gimi (Austronesian)",
@@ -9931,14 +9185,12 @@
   "giq": [
     "青仡佬語",
     "青仡佬语",
-    "Green Gelao",
     "Hagei",
     "Hakhi"
   ],
   "gir": [
     "紅仡佬語",
     "红仡佬语",
-    "Red Gelao",
     "Vandu"
   ],
   "gis": [
@@ -9949,13 +9201,11 @@
   ],
   "giu": [
     "木佬語",
-    "木佬语",
-    "Mulao"
+    "木佬语"
   ],
   "giw": [
     "白仡佬語",
     "白仡佬语",
-    "White Gelao",
     "Telue",
     "Doulou",
     "Tolo"
@@ -9984,8 +9234,12 @@
   "gju": [
     "古賈里語",
     "古贾里语",
-    "Gojri",
-    "Gujari"
+    "Gojari",
+    "Gujari",
+    "Gujuri",
+    "Gujjari",
+    "Gujri",
+    "Gurjari"
   ],
   "gka": [
     "Guya"
@@ -10016,13 +9270,8 @@
   "gld": [
     "赫哲語",
     "赫哲语",
-    "Nanai",
-    "那乃語",
-    "那乃语",
     "Goldi",
-    "Hezhen",
-    "赫真語",
-    "赫真语"
+    "Hezhen"
   ],
   "glh": [
     "Northwest Pashayi"
@@ -10061,8 +9310,7 @@
   ],
   "gme-cgo": [
     "克里米亞哥特語",
-    "克里米亚哥特语",
-    "Crimean Gothic"
+    "克里米亚哥特语"
   ],
   "gmg": [
     "Magiyi",
@@ -10070,13 +9318,11 @@
   ],
   "gmh": [
     "中古高地德語",
-    "中古高地德语",
-    "Middle High German"
+    "中古高地德语"
   ],
   "gml": [
     "中古低地德語",
-    "中古低地德语",
-    "Middle Low German"
+    "中古低地德语"
   ],
   "gmm": [
     "Gbaya-Mbodomo"
@@ -10086,39 +9332,32 @@
   ],
   "gmq-bot": [
     "西博滕語",
-    "西博滕语",
-    "Westrobothnian"
+    "西博滕语"
   ],
   "gmq-gut": [
     "哥特蘭語",
-    "哥特兰语",
-    "Gutnish"
+    "哥特兰语"
   ],
   "gmq-jmk": [
     "耶姆特蘭語",
     "耶姆特兰语",
-    "Jamtish",
     "Jamtlandic"
   ],
   "gmq-mno": [
     "中古挪威語",
-    "中古挪威语",
-    "Middle Norwegian"
+    "中古挪威语"
   ],
   "gmq-oda": [
     "古丹麥語",
-    "古丹麦语",
-    "Old Danish"
+    "古丹麦语"
   ],
   "gmq-osw": [
     "古瑞典語",
-    "古瑞典语",
-    "Old Swedish"
+    "古瑞典语"
   ],
   "gmq-pro": [
     "原始諾爾斯語",
     "原始诺尔斯语",
-    "Proto-Norse",
     "Proto-Scandinavian",
     "Primitive Norse",
     "Proto-Nordic",
@@ -10132,8 +9371,7 @@
   ],
   "gmq-scy": [
     "斯堪尼亞語",
-    "斯堪尼亚语",
-    "Scanian"
+    "斯堪尼亚语"
   ],
   "gmu": [
     "Gumalu"
@@ -10142,10 +9380,12 @@
     "Gamo",
     "Gemu"
   ],
+  "gmw-bgh": [
+    "Bergish"
+  ],
   "gmw-cfr": [
     "中部法蘭克尼亞語",
     "中部法兰克尼亚语",
-    "Central Franconian",
     "Mittelfränkisch",
     "Ripuarian",
     "Moselle Franconian",
@@ -10155,19 +9395,16 @@
   "gmw-ecg": [
     "中東部德語",
     "中东部德语",
-    "圖林根語",
-    "图林根语",
+    "Thuringian",
     "Thüringisch",
-    "上薩克森語",
-    "上萨克森语",
-    "西里西亞德語",
-    "西里西亚德语",
+    "Upper Saxon",
+    "Upper Saxon German",
     "Obersächsisch",
     "Lusatian",
     "Erzgebirgisch",
     "Silesian",
-    "高地普魯士語",
-    "高地普鲁士语"
+    "Silesian German",
+    "High Prussian"
   ],
   "gmw-gts": [
     "Gottscheerish",
@@ -10175,18 +9412,15 @@
   ],
   "gmw-jdt": [
     "澤西荷蘭語",
-    "泽西荷兰语",
-    "Jersey Dutch"
+    "泽西荷兰语"
   ],
   "gmw-pro": [
     "原始西日耳曼語",
-    "原始西日耳曼语",
-    "Proto-West Germanic"
+    "原始西日耳曼语"
   ],
   "gmw-rfr": [
     "萊茵法蘭克尼亞語",
     "莱茵法兰克尼亚语",
-    "Rhine Franconian",
     "Rheinfränkisch",
     "Rhenish Franconian",
     "Hessian",
@@ -10199,7 +9433,8 @@
     "Palatinate German"
   ],
   "gmw-stm": [
-    "Sathmar Swabian",
+    "薩圖馬雷施瓦本語",
+    "萨图马雷施瓦本语",
     "Satu Mare Swabian",
     "Sathmarschwäbisch",
     "Sathmarisch"
@@ -10207,13 +9442,11 @@
   "gmw-tsx": [
     "特蘭西瓦尼亞薩克森語",
     "特兰西瓦尼亚萨克森语",
-    "Transylvanian Saxon",
     "Siebenbürger Saxon"
   ],
   "gmw-vog": [
     "伏爾加德語",
-    "伏尔加德语",
-    "Volga German"
+    "伏尔加德语"
   ],
   "gmw-zps": [
     "Zipser German",
@@ -10226,12 +9459,20 @@
   ],
   "gmy": [
     "邁錫尼希臘語",
-    "迈锡尼希腊语",
-    "Mycenaean Greek"
+    "迈锡尼希腊语"
+  ],
+  "gmz": [
+    "Mgbo",
+    "Mgbolizhia"
   ],
   "gn": [
     "瓜拉尼語",
-    "瓜拉尼语"
+    "瓜拉尼语",
+    "Guarani"
+  ],
+  "gn-cls": [
+    "古典瓜拉尼語",
+    "古典瓜拉尼语"
   ],
   "gna": [
     "Kaansa"
@@ -10260,7 +9501,7 @@
   "gni": [
     "古尼揚迪語",
     "古尼扬迪语",
-    "Gooniyandi"
+    "Guniyandi"
   ],
   "gnj": [
     "Ngen",
@@ -10298,7 +9539,6 @@
   "gnw": [
     "西玻利維亞瓜拉尼語",
     "西玻利维亚瓜拉尼语",
-    "Western Bolivian Guaraní",
     "Simba",
     "Simba Guarani"
   ],
@@ -10329,11 +9569,7 @@
   ],
   "goh": [
     "古高地德語",
-    "古高地德语",
-    "Old High German",
-    "Gobosi",
-    "Gebusi",
-    "Bibo"
+    "古高地德语"
   ],
   "goi": [
     "Gobasi",
@@ -10372,8 +9608,7 @@
   ],
   "gor": [
     "哥倫打洛語",
-    "哥伦打洛语",
-    "Gorontalo"
+    "哥伦打洛语"
   ],
   "got": [
     "哥特語",
@@ -10382,6 +9617,9 @@
   "gou": [
     "Gavar",
     "Gawar"
+  ],
+  "gov": [
+    "Goo"
   ],
   "gow": [
     "Gorowa"
@@ -10425,7 +9663,6 @@
   "gqu": [
     "稿語",
     "稿语",
-    "Qau",
     "Gao",
     "Aqao",
     "Qau Gelao"
@@ -10440,7 +9677,7 @@
   "grc": [
     "古希臘語",
     "古希腊语",
-    "Ancient Greek"
+    "Classical Greek"
   ],
   "grd": [
     "Guruntum"
@@ -10464,14 +9701,12 @@
   "grk-cal": [
     "卡拉布里亞希臘語",
     "卡拉布里亚希腊语",
-    "Calabrian Greek",
     "Italian Greek",
     "Bova"
   ],
   "grk-ita": [
     "意大利希臘語",
     "意大利希腊语",
-    "Italiot Greek",
     "Griko",
     "Grico",
     "Grecanic"
@@ -10479,7 +9714,6 @@
   "grk-mar": [
     "馬里烏波爾希臘語",
     "马里乌波尔希腊语",
-    "Mariupol Greek",
     "Mariupolitan Greek",
     "Rumeíka",
     "Rumeika"
@@ -10487,7 +9721,6 @@
   "grk-pro": [
     "原始希臘語",
     "原始希腊语",
-    "Proto-Hellenic",
     "Proto-Greek"
   ],
   "grm": [
@@ -10498,9 +9731,6 @@
   ],
   "grq": [
     "Gorovu"
-  ],
-  "grr": [
-    "Taznatit"
   ],
   "grs": [
     "Gresi"
@@ -10534,15 +9764,11 @@
   ],
   "gse": [
     "加納手語",
-    "加纳手语",
-    "迦納手語",
-    "迦纳手语",
-    "Ghanaian Sign Language"
+    "加纳手语"
   ],
   "gsg": [
     "德國手語",
     "德国手语",
-    "German Sign Language",
     "Deutsche Gebärdensprache"
   ],
   "gsl": [
@@ -10550,10 +9776,7 @@
   ],
   "gsm": [
     "危地馬拉手語",
-    "危地马拉手语",
-    "瓜地馬拉手語",
-    "瓜地马拉手语",
-    "Guatemalan Sign Language"
+    "危地马拉手语"
   ],
   "gsn": [
     "Gusan"
@@ -10566,35 +9789,12 @@
   ],
   "gss": [
     "希臘手語",
-    "希腊手语",
-    "Greek Sign Language"
+    "希腊手语"
   ],
   "gsw": [
     "阿勒曼尼語",
     "阿勒曼尼语",
-    "Alemannic German",
-    "瑞士德語",
-    "瑞士德语",
-    "Swiss German",
-    "Walser German",
-    "Walserdeutsch",
-    "Walser",
-    "Wallisertiitsch",
-    "Italian Walser",
-    "Pomattertitsch",
-    "Formazza",
-    "Kampel",
-    "Remmaljertittschu",
-    "Rimella",
-    "Chalchoufe",
-    "Titzschu",
-    "Alagna",
-    "Greschóneytitsch",
-    "Greschóney",
-    "Greschoney",
-    "Gressoney",
-    "Éischemtöitschu",
-    "Issime"
+    "Swiss German"
   ],
   "gta": [
     "Guató"
@@ -10616,8 +9816,7 @@
   ],
   "gub": [
     "瓜加加拉語",
-    "瓜加加拉语",
-    "Guajajára"
+    "瓜加加拉语"
   ],
   "guc": [
     "瓦尤語",
@@ -10639,8 +9838,7 @@
     "巴拉圭瓜拉尼語",
     "巴拉圭瓜拉尼语",
     "Jopará",
-    "Yopará",
-    "Paraguayan Guaraní"
+    "Yopará"
   ],
   "guh": [
     "Guahibo"
@@ -10648,7 +9846,6 @@
   "gui": [
     "東玻利維亞瓜拉尼語",
     "东玻利维亚瓜拉尼语",
-    "Eastern Bolivian Guaraní",
     "Ava Guaraní",
     "Chiriguanos"
   ],
@@ -10658,7 +9855,6 @@
   "gul": [
     "古拉語",
     "古拉语",
-    "Gullah",
     "Geechee",
     "Sea Island Creole English"
   ],
@@ -10668,7 +9864,6 @@
   "gun": [
     "姆比亞瓜拉尼語",
     "姆比亚瓜拉尼语",
-    "Mbyá Guaraní",
     "Mbyá",
     "Mbya",
     "Mbyhá",
@@ -10714,7 +9909,6 @@
   "gur": [
     "法拉法拉語",
     "法拉法拉语",
-    "Farefare",
     "Frafra",
     "Gurene",
     "Gurenɛ",
@@ -10730,9 +9924,7 @@
   ],
   "gus": [
     "幾內亞手語",
-    "几内亚手语",
-    "Guinean Sign Language",
-    "Guayaki"
+    "几内亚手语"
   ],
   "gut": [
     "Maléku Jaíka"
@@ -10758,12 +9950,7 @@
   "gv": [
     "曼島語",
     "曼岛语",
-    "曼島蓋爾語",
-    "曼岛盖尔语",
-    "馬恩語",
-    "马恩语",
-    "馬恩島語",
-    "马恩岛语"
+    "Manx Gaelic"
   ],
   "gva": [
     "Kaskihá",
@@ -10910,7 +10097,6 @@
   "gyn": [
     "蓋亞那克里奧爾英語",
     "盖亚那克里奥尔英语",
-    "Guyanese Creole English",
     "Guyanese Creole",
     "Creolese",
     "Guyanese"
@@ -10944,13 +10130,11 @@
   ],
   "hab": [
     "河內手語",
-    "河内手语",
-    "Hanoi Sign Language"
+    "河内手语"
   ],
   "hac": [
     "古拉尼語",
     "古拉尼语",
-    "Gurani",
     "Gorani",
     "Avromani",
     "Awroman",
@@ -10967,8 +10151,7 @@
   ],
   "haf": [
     "海防手語",
-    "海防手语",
-    "Haiphong Sign Language"
+    "海防手语"
   ],
   "hag": [
     "Hanga"
@@ -10978,45 +10161,34 @@
   ],
   "hai": [
     "海達語",
-    "海达语",
-    "Haida"
+    "海达语"
   ],
   "haj": [
     "哈瓊語",
-    "哈琼语",
-    "Hajong"
+    "哈琼语"
   ],
   "hak": [
     "客家語",
-    "客家语",
-    "客家話",
-    "客家话",
-    "客語",
-    "客语",
-    "Hakka"
+    "客家语"
   ],
   "hal": [
     "哈朗語",
-    "哈朗语",
-    "Halang"
+    "哈朗语"
   ],
   "ham": [
     "赫瓦語",
-    "赫瓦语",
-    "Hewa"
+    "赫瓦语"
   ],
   "hao": [
     "哈科語",
-    "哈科语",
-    "Hakö"
+    "哈科语"
   ],
   "hap": [
     "Hupla"
   ],
   "har": [
     "哈勒爾語",
-    "哈勒尔语",
-    "Harari"
+    "哈勒尔语"
   ],
   "has": [
     "Haisla"
@@ -11026,21 +10198,18 @@
   ],
   "haw": [
     "夏威夷語",
-    "夏威夷语",
-    "Hawaiian"
+    "夏威夷语"
   ],
   "hax": [
     "南海達語",
-    "南海达语",
-    "Southern Haida"
+    "南海达语"
   ],
   "hay": [
     "Haya"
   ],
   "haz": [
     "哈札拉語",
-    "哈札拉语",
-    "Hazaragi"
+    "哈札拉语"
   ],
   "hba": [
     "Hamba"
@@ -11057,25 +10226,19 @@
   ],
   "hca": [
     "安達曼克里奧爾印地語",
-    "安达曼克里奥尔印地语",
-    "Andaman Creole Hindi"
+    "安达曼克里奥尔印地语"
   ],
   "hch": [
     "惠喬爾語",
-    "惠乔尔语",
-    "Huichol"
+    "惠乔尔语"
   ],
   "hdn": [
     "北海達語",
-    "北海达语",
-    "Northern Haida"
+    "北海达语"
   ],
   "hds": [
     "洪都拉斯手語",
     "洪都拉斯手语",
-    "宏都拉斯手語",
-    "宏都拉斯手语",
-    "Honduras Sign Language",
     "Honduran Sign Language"
   ],
   "hdy": [
@@ -11089,7 +10252,6 @@
   "hea": [
     "北部黔東苗語",
     "北部黔东苗语",
-    "Northern Qiandong Miao",
     "Black Miao"
   ],
   "hed": [
@@ -11103,16 +10265,14 @@
   ],
   "hei": [
     "海爾蘇克語",
-    "海尔苏克语",
-    "Heiltsuk"
+    "海尔苏克语"
   ],
   "hem": [
     "Hemba"
   ],
   "hgm": [
     "海奧姆語",
-    "海奥姆语",
-    "Haiǁom"
+    "海奥姆语"
   ],
   "hgw": [
     "Haigwai"
@@ -11139,13 +10299,11 @@
   ],
   "hid": [
     "希達沙語",
-    "希达沙语",
-    "Hidatsa"
+    "希达沙语"
   ],
   "hif": [
     "斐濟印地語",
-    "斐济印地语",
-    "Fiji Hindi"
+    "斐济印地语"
   ],
   "hig": [
     "Kamwe",
@@ -11157,8 +10315,7 @@
   ],
   "hii": [
     "欣杜里語",
-    "欣杜里语",
-    "Hinduri"
+    "欣杜里语"
   ],
   "hij": [
     "Hijuk"
@@ -11168,8 +10325,7 @@
   ],
   "hil": [
     "希利蓋農語",
-    "希利盖农语",
-    "Hiligaynon"
+    "希利盖农语"
   ],
   "hio": [
     "Tshwa",
@@ -11188,9 +10344,6 @@
   "hit": [
     "赫梯語",
     "赫梯语",
-    "西臺語",
-    "西台语",
-    "Hittite",
     "Hettite",
     "Kanesite",
     "Kaneshite",
@@ -11208,7 +10361,6 @@
   "hix": [
     "希卡利亞納語",
     "希卡利亚纳语",
-    "Hixkaryana",
     "Hixkaryána"
   ],
   "hji": [
@@ -11230,30 +10382,25 @@
   ],
   "hks": [
     "香港手語",
-    "香港手语",
-    "Hong Kong Sign Language"
+    "香港手语"
   ],
   "hla": [
     "哈利亞語",
-    "哈利亚语",
-    "Halia"
+    "哈利亚语"
   ],
   "hlb": [
     "哈爾比語",
-    "哈尔比语",
-    "Halbi"
+    "哈尔比语"
   ],
   "hld": [
     "端語",
     "端语",
-    "Halang Doan",
     "Duan",
     "Doan"
   ],
   "hle": [
     "山蘇語",
     "山苏语",
-    "Hlersu",
     "Sansu"
   ],
   "hlt": [
@@ -11273,15 +10420,11 @@
   "hmc": [
     "中部惠水苗語",
     "中部惠水苗语",
-    "Central Huishui Hmong",
     "Central Huishui Miao"
   ],
   "hmd": [
     "滇東北苗語",
     "滇东北苗语",
-    "大花苗語",
-    "大花苗语",
-    "A-Hmao",
     "A Hmao",
     "Big Flowery Miao",
     "Large Flowery Miao"
@@ -11289,7 +10432,6 @@
   "hme": [
     "東部惠水苗語",
     "东部惠水苗语",
-    "Eastern Huishui Hmong",
     "Eastern Huishui Miao"
   ],
   "hmf": [
@@ -11297,64 +10439,50 @@
   ],
   "hmg": [
     "西南貴陽苗語",
-    "西南贵阳苗语",
-    "Southwestern Guiyang Hmong"
+    "西南贵阳苗语"
   ],
   "hmh": [
     "西南惠水苗語",
     "西南惠水苗语",
-    "Southwestern Huishui Hmong",
     "Southwestern Huishui Miao"
   ],
   "hmi": [
     "北部惠水苗語",
     "北部惠水苗语",
-    "Northern Huishui Hmong",
     "Northern Huishui Miao"
   ],
   "hmj": [
     "𱎼家語",
     "𱎼家语",
-    "⿰亻革家語",
-    "⿰亻革家语",
-    "重安江苗語",
-    "重安江苗语",
-    "Ge",
     "Gedou Miao"
   ],
   "hmk": [
     "濊貊語",
-    "濊貊语",
-    "Maek",
+    "𰛦貊语",
     "Ye-Maek",
     "Yemaek"
   ],
   "hml": [
     "羅泊河苗語",
-    "罗泊河苗语",
-    "Luopohe Hmong"
+    "罗泊河苗语"
   ],
   "hmm": [
     "中部麻山苗語",
     "中部麻山苗语",
-    "Central Mashan Hmong",
     "Central Mashan Miao"
   ],
   "hmn-pro": [
     "原始苗語",
-    "原始苗语",
-    "Proto-Hmong"
+    "原始苗语"
   ],
   "hmp": [
     "北部麻山苗語",
     "北部麻山苗语",
-    "Northern Mashan Hmong",
     "Northern Mashan Miao"
   ],
   "hmq": [
     "東部黔東苗語",
     "东部黔东苗语",
-    "Eastern Qiandong Miao",
     "Black Miao"
   ],
   "hmr": [
@@ -11363,7 +10491,6 @@
   "hms": [
     "南部黔東苗語",
     "南部黔东苗语",
-    "Southern Qiandong Miao",
     "Black Miao"
   ],
   "hmt": [
@@ -11380,28 +10507,23 @@
   "hmw": [
     "西部麻山苗語",
     "西部麻山苗语",
-    "Western Mashan Hmong",
     "Western Mashan Miao"
   ],
   "hmx-mie-pro": [
     "原始瑤語",
-    "原始瑶语",
-    "Proto-Mien"
+    "原始瑶语"
   ],
   "hmx-pro": [
     "原始苗瑤語",
-    "原始苗瑶语",
-    "Proto-Hmong-Mien"
+    "原始苗瑶语"
   ],
   "hmy": [
     "南部貴陽苗語",
-    "南部贵阳苗语",
-    "Southern Guiyang Hmong"
+    "南部贵阳苗语"
   ],
   "hmz": [
     "漢苗語",
     "汉苗语",
-    "Hmong Shua",
     "Hmong Sua"
   ],
   "hna": [
@@ -11412,28 +10534,22 @@
   ],
   "hnd": [
     "南辛德科語",
-    "南辛德科语",
-    "Southern Hindko"
+    "南辛德科语"
   ],
   "hne": [
     "恰蒂斯加爾語",
-    "恰蒂斯加尔语",
-    "Chhattisgarhi"
+    "恰蒂斯加尔语"
   ],
   "hnh": [
     "ǁAni"
   ],
   "hni": [
     "哈尼語",
-    "哈尼语",
-    "Hani",
-    "哈尼話",
-    "哈尼话"
+    "哈尼语"
   ],
   "hnj": [
     "青苗語",
     "青苗语",
-    "Green Hmong",
     "Hmong Njua",
     "Hmong Leng",
     "Mong Leng",
@@ -11448,7 +10564,6 @@
   "hno": [
     "北辛德科語",
     "北辛德科语",
-    "Northern Hindko",
     "Kagani",
     "Hazara Hindko",
     "Hindki of Hazara"
@@ -11456,9 +10571,6 @@
   "hns": [
     "加勒比印度斯坦語",
     "加勒比印度斯坦语",
-    "Caribbean Hindustani",
-    "加勒比博傑普爾語",
-    "加勒比博杰普尔语",
     "Caribbean Bhojpuri"
   ],
   "hnu": [
@@ -11476,14 +10588,12 @@
   "hob": [
     "南島馬里語",
     "南岛马里语",
-    "Austronesian Mari",
     "Mari (Madang Province)",
     "Hop"
   ],
   "hoc": [
     "霍語",
-    "霍语",
-    "Ho"
+    "霍语"
   ],
   "hod": [
     "Holma"
@@ -11513,7 +10623,6 @@
   "hop": [
     "霍皮語",
     "霍皮语",
-    "Hopi",
     "Moqui"
   ],
   "hor": [
@@ -11521,8 +10630,7 @@
   ],
   "hos": [
     "胡志明市手語",
-    "胡志明市手语",
-    "Ho Chi Minh City Sign Language"
+    "胡志明市手语"
   ],
   "hot": [
     "Hote"
@@ -11549,8 +10657,6 @@
   "hps": [
     "夏威夷皮欽手語",
     "夏威夷皮钦手语",
-    "夏威夷手語",
-    "夏威夷手语",
     "Hawaiian Sign Language",
     "Hula",
     "Hawaii Sign Language"
@@ -11565,27 +10671,22 @@
   "hre": [
     "赫耶語",
     "赫耶语",
-    "Hre",
     "Hrê"
   ],
   "hrk": [
     "哈魯庫語",
-    "哈鲁库语",
-    "Haruku"
+    "哈鲁库语"
   ],
   "hrm": [
     "角苗語",
-    "角苗语",
-    "Horned Miao",
-    "Hrê"
+    "角苗语"
   ],
   "hro": [
     "Haroi"
   ],
   "hrp": [
     "恩希爾皮語",
-    "恩希尔皮语",
-    "Nhirrpi"
+    "恩希尔皮语"
   ],
   "hrt": [
     "Hértevin"
@@ -11600,38 +10701,30 @@
   "hrx": [
     "漢斯立克語",
     "汉斯立克语",
-    "Hunsrik",
-    "里奧格蘭德洪斯呂克語",
-    "里奥格兰德洪斯吕克语",
     "Riograndenser Hunsrückisch"
   ],
   "hrz": [
     "哈爾札尼語",
     "哈尔札尼语",
-    "Harzani",
     "Harzandi"
   ],
   "hsb": [
     "上索布語",
     "上索布语",
-    "Upper Sorbian",
     "Upper Lusatian",
     "Upper Wendish"
   ],
   "hsh": [
     "匈牙利手語",
-    "匈牙利手语",
-    "Hungarian Sign Language"
+    "匈牙利手语"
   ],
   "hsl": [
     "豪薩手語",
-    "豪萨手语",
-    "Hausa Sign Language"
+    "豪萨手语"
   ],
   "hsn": [
     "湘語",
-    "湘语",
-    "Xiang"
+    "湘语"
   ],
   "hss": [
     "Harsusi"
@@ -11640,8 +10733,7 @@
     "海地克里奧爾語",
     "海地克里奥尔语",
     "Creole",
-    "海地語",
-    "海地语",
+    "Haitian",
     "Kreyòl"
   ],
   "hti": [
@@ -11654,21 +10746,15 @@
   ],
   "hts": [
     "哈扎語",
-    "哈扎语",
-    "Hadza"
+    "哈扎语"
   ],
   "htu": [
     "Hitu"
   ],
-  "htx": [
-    "中古赫梯語",
-    "中古赫梯语"
-  ],
   "hu": [
     "匈牙利語",
     "匈牙利语",
-    "馬扎爾語",
-    "马扎尔语"
+    "Magyar"
   ],
   "hub": [
     "Huambisa",
@@ -11698,8 +10784,7 @@
   ],
   "huj": [
     "北部貴陽苗語",
-    "北部贵阳苗语",
-    "Northern Guiyang Hmong"
+    "北部贵阳苗语"
   ],
   "huk": [
     "Hulung"
@@ -11720,25 +10805,20 @@
   "huq": [
     "回輝語",
     "回辉语",
-    "海南占語",
-    "海南占语",
-    "回輝話",
-    "回辉话",
-    "三亞回族話",
-    "三亚回族话",
-    "Tsat",
+    "Hainan Cham",
+    "Hui",
+    "Huihui",
+    "Sanya Hui",
     "Utsat",
     "Utset"
   ],
   "hur": [
     "哈爾魁梅林語",
-    "哈尔魁梅林语",
-    "Halkomelem"
+    "哈尔魁梅林语"
   ],
   "hus": [
     "瓦斯特克語",
     "瓦斯特克语",
-    "Wastek",
     "Huastek",
     "Huasteka",
     "Huasteque",
@@ -11773,13 +10853,11 @@
   ],
   "huz": [
     "洪濟布語",
-    "洪济布语",
-    "Hunzib"
+    "洪济布语"
   ],
   "hvc": [
     "海地巫毒文化語",
     "海地巫毒文化语",
-    "Haitian Vodoun Culture Language",
     "Langaj",
     "Langay"
   ],
@@ -11796,13 +10874,6 @@
   "hwc": [
     "夏威夷英語",
     "夏威夷英语",
-    "夏威夷克里奧爾英語",
-    "夏威夷克里奥尔英语",
-    "夏威夷克里奧爾語",
-    "夏威夷克里奥尔语",
-    "夏威夷皮欽語",
-    "夏威夷皮钦语",
-    "Hawaiian Creole",
     "Hawaiian Creole English",
     "Hawai'ian Creole English",
     "Hawaiian Pidgin",
@@ -11814,16 +10885,14 @@
   "hy": [
     "亞美尼亞語",
     "亚美尼亚语",
-    "現代亞美尼亞語",
-    "现代亚美尼亚语"
+    "Modern Armenian"
   ],
   "hya": [
     "Hya"
   ],
   "hyx-pro": [
     "原始亞美尼亞語",
-    "原始亚美尼亚语",
-    "Proto-Armenian"
+    "原始亚美尼亚语"
   ],
   "hz": [
     "赫雷羅語",
@@ -11831,12 +10900,7 @@
   ],
   "ia": [
     "因特語",
-    "因特语",
-    "國際語A",
-    "国际语A",
-    "拉丁國際語",
-    "拉丁国际语",
-    "Interlingua"
+    "因特语"
   ],
   "iai": [
     "Iaai"
@@ -11849,26 +10913,22 @@
   ],
   "iba": [
     "伊班語",
-    "伊班语",
-    "Iban"
+    "伊班语"
   ],
   "ibb": [
     "伊比比奧語",
-    "伊比比奥语",
-    "Ibibio"
+    "伊比比奥语"
   ],
   "ibd": [
     "伊瓦加語",
-    "伊瓦加语",
-    "Iwaidja"
+    "伊瓦加语"
   ],
   "ibe": [
     "Akpes"
   ],
   "ibg": [
     "伊巴納格語",
-    "伊巴纳格语",
-    "Ibanag"
+    "伊巴纳格语"
   ],
   "ibh": [
     "Bih"
@@ -11876,7 +10936,6 @@
   "ibl": [
     "伊巴洛伊語",
     "伊巴洛伊语",
-    "Ibaloi",
     "Ibaloy",
     "Inibaloi",
     "Inibaloy"
@@ -11907,28 +10966,23 @@
   ],
   "icl": [
     "冰島手語",
-    "冰岛手语",
-    "Icelandic Sign Language"
+    "冰岛手语"
   ],
   "icr": [
     "島嶼克里奧爾英語",
     "岛屿克里奥尔英语",
-    "Islander Creole English",
     "San Andrés-Providencia Creole"
   ],
   "id": [
     "印尼語",
-    "印尼语",
-    "印度尼西亞語",
-    "印度尼西亚语"
+    "印尼语"
   ],
   "ida": [
     "Idakho-Isukha-Tiriki"
   ],
   "idb": [
     "印度葡萄牙語",
-    "印度葡萄牙语",
-    "Indo-Portuguese"
+    "印度葡萄牙语"
   ],
   "idc": [
     "Idon"
@@ -11941,8 +10995,7 @@
   ],
   "idi": [
     "伊迪語",
-    "伊迪语",
-    "Idi"
+    "伊迪语"
   ],
   "idr": [
     "Indri"
@@ -11959,9 +11012,6 @@
   "ie": [
     "西方國際語",
     "西方国际语",
-    "國際語B",
-    "国际语B",
-    "Interlingue",
     "Occidental"
   ],
   "ifa": [
@@ -11991,7 +11041,6 @@
   "ifu": [
     "馬尤瑤-伊富高語",
     "马尤瑶-伊富高语",
-    "Mayoyao Ifugao",
     "Mayoyao Ifugaw"
   ],
   "ify": [
@@ -12046,29 +11095,22 @@
   "ii": [
     "彝語",
     "彝语",
-    "諾蘇語",
-    "诺苏语",
-    "四川彝語",
-    "四川彝语",
-    "涼山彝語",
-    "凉山彝语",
-    "北部彝語",
-    "北部彝语"
+    "Nuosu",
+    "Nosu",
+    "Northern Yi",
+    "Liangshan Yi"
   ],
   "iir-nur-pro": [
     "原始努利斯坦語",
-    "原始努利斯坦语",
-    "Proto-Nuristani"
+    "原始努利斯坦语"
   ],
   "iir-pro": [
     "原始印度-伊朗語",
-    "原始印度-伊朗语",
-    "Proto-Indo-Iranian"
+    "原始印度-伊朗语"
   ],
   "ijc": [
     "伊宗語",
     "伊宗语",
-    "Izon",
     "Kolokuma",
     "Ekpetiama",
     "Gbanran",
@@ -12086,7 +11128,6 @@
   "ijo-pro": [
     "原始伊爵語",
     "原始伊爵语",
-    "Proto-Ijoid",
     "Proto-Ijaw"
   ],
   "ijs": [
@@ -12097,16 +11138,13 @@
   "ik": [
     "伊努皮克語",
     "伊努皮克语",
-    "伊努皮雅特語",
-    "伊努皮雅特语",
     "Inupiak",
     "Iñupiaq",
     "Inupiatun"
   ],
   "ike": [
     "東加拿大伊努克提圖特語",
-    "东加拿大伊努克提图特语",
-    "Eastern Canadian Inuktitut"
+    "东加拿大伊努克提图特语"
   ],
   "iki": [
     "Iko"
@@ -12127,14 +11165,12 @@
   "ikr": [
     "伊卡蘭加爾語",
     "伊卡兰加尔语",
-    "Ikaranggal",
     "Ikarranggal",
     "Ikarranggali"
   ],
   "iks": [
     "因紐特手語",
     "因纽特手语",
-    "Inuit Sign Language",
     "Inuit Uukturausingit",
     "ISL",
     "IUR"
@@ -12156,16 +11192,14 @@
   ],
   "ikz": [
     "伊基祖語",
-    "伊基祖语",
-    "Ikizu"
+    "伊基祖语"
   ],
   "ila": [
     "Ile Ape"
   ],
   "ilb": [
     "伊拉語",
-    "伊拉语",
-    "Ila"
+    "伊拉语"
   ],
   "ilg": [
     "Ilgar",
@@ -12176,13 +11210,11 @@
   ],
   "ilk": [
     "伊隆戈語",
-    "伊隆戈语",
-    "Ilongot"
+    "伊隆戈语"
   ],
   "ill": [
     "伊拉努語",
     "伊拉努语",
-    "Iranun",
     "Ilanun",
     "Iranun (Malaysia)",
     "Iranun (Philippines)"
@@ -12191,12 +11223,11 @@
     "伊洛卡諾語",
     "伊洛卡诺语",
     "Ilokano",
-    "Ikokano"
+    "Iloko"
   ],
   "ils": [
     "國際手語",
-    "国际手语",
-    "International Sign"
+    "国际手语"
   ],
   "ilu": [
     "Ili'uun"
@@ -12217,8 +11248,7 @@
   ],
   "imn": [
     "伊蒙達語",
-    "伊蒙达语",
-    "Imonda"
+    "伊蒙达语"
   ],
   "imo": [
     "Imbongu",
@@ -12230,191 +11260,151 @@
   ],
   "ims": [
     "馬爾西語",
-    "马尔西语",
-    "Marsian"
+    "马尔西语"
   ],
   "imy": [
     "彌呂亞語",
-    "弥吕亚语",
-    "Milyan"
+    "弥吕亚语"
   ],
   "inb": [
     "Inga"
   ],
   "inc-ash": [
     "阿輸迦普拉克里特語",
-    "阿输迦普拉克里特语",
-    "Ashokan Prakrit"
+    "阿输迦普拉克里特语"
   ],
   "inc-cen-pro": [
     "原始中印度-雅利安語",
-    "原始中印度-雅利安语",
-    "Proto-Central Indo-Aryan"
-  ],
-  "inc-dar-pro": [
-    "原始達爾德語",
-    "原始达尔德语",
-    "Proto-Dardic",
-    "Proto-Rigvedic"
+    "原始中印度-雅利安语"
   ],
   "inc-gup": [
     "古爾扎爾阿帕布拉姆沙語",
-    "古尔扎尔阿帕布拉姆沙语",
-    "Gurjar Apabhramsa"
+    "古尔扎尔阿帕布拉姆沙语"
   ],
   "inc-kam": [
     "迦摩縷波俗語",
-    "迦摩缕波俗语",
-    "Kamarupi Prakrit"
+    "迦摩缕波俗语"
   ],
   "inc-kha": [
     "卡薩俗語",
-    "卡萨俗语",
-    "Khasa Prakrit"
+    "卡萨俗语"
   ],
   "inc-kho": [
     "科羅斯語",
-    "科罗斯语",
-    "Kholosi"
+    "科罗斯语"
   ],
   "inc-mas": [
     "中古阿薩姆語",
-    "中古阿萨姆语",
-    "Middle Assamese"
+    "中古阿萨姆语"
   ],
   "inc-mbn": [
     "中古孟加拉語",
-    "中古孟加拉语",
-    "Middle Bengali"
+    "中古孟加拉语"
   ],
   "inc-mgd": [
     "摩揭陀俗語",
-    "摩揭陀俗语",
-    "Magadhi Prakrit"
+    "摩揭陀俗语"
   ],
   "inc-mgu": [
     "中古古吉拉特語",
-    "中古古吉拉特语",
-    "Middle Gujarati"
+    "中古古吉拉特语"
   ],
   "inc-mor": [
     "中古奧里亞語",
-    "中古奥里亚语",
-    "Middle Oriya"
+    "中古奥里亚语"
   ],
   "inc-oas": [
     "古阿薩姆語",
-    "古阿萨姆语",
-    "Early Assamese",
-    "Old Assamese"
+    "古阿萨姆语"
   ],
   "inc-obn": [
     "古孟加拉語",
-    "古孟加拉语",
-    "Old Bengali"
+    "古孟加拉语"
   ],
   "inc-ogu": [
     "古古吉拉特語",
     "古古吉拉特语",
-    "Old Gujarati",
     "Old Western Rajasthani"
   ],
   "inc-ohi": [
     "古印地語",
-    "古印地语",
-    "Old Hindi"
+    "古印地语"
   ],
   "inc-oor": [
     "古奧里亞語",
-    "古奥里亚语",
-    "Old Oriya"
+    "古奥里亚语"
   ],
   "inc-opa": [
     "古旁遮普語",
-    "古旁遮普语",
-    "Old Punjabi"
+    "古旁遮普语"
   ],
   "inc-ork": [
     "Old Kamta"
   ],
   "inc-pra": [
     "普拉克里特語",
-    "普拉克里特语",
-    "Prakrit"
+    "普拉克里特语"
   ],
   "inc-pro": [
     "原始印度-雅利安語",
-    "原始印度-雅利安语",
-    "Proto-Indo-Aryan"
+    "原始印度-雅利安语"
   ],
   "inc-psc": [
     "白夏基普拉克里特語",
-    "白夏基普拉克里特语",
-    "Paisaci Prakrit"
+    "白夏基普拉克里特语"
   ],
   "inc-sap": [
     "索拉塞尼阿帕布拉姆沙語",
-    "索拉塞尼阿帕布拉姆沙语",
-    "Sauraseni Apabhramsa"
+    "索拉塞尼阿帕布拉姆沙语"
   ],
   "inc-tak": [
     "磔迦阿帕布拉姆沙語",
-    "磔迦阿帕布拉姆沙语",
-    "Takka Apabhramsa"
+    "磔迦阿帕布拉姆沙语"
   ],
   "inc-vra": [
     "沃拉恰達阿帕布拉姆沙語",
-    "沃拉恰达阿帕布拉姆沙语",
-    "Proto-Anatolian"
+    "沃拉恰达阿帕布拉姆沙语"
   ],
   "ine-ana-pro": [
     "原始安納托利亞語",
-    "原始安纳托利亚语",
-    "Proto-Anatolian"
+    "原始安纳托利亚语"
   ],
   "ine-bsl-pro": [
     "原始波羅的-斯拉夫語",
-    "原始波罗的-斯拉夫语",
-    "Proto-Balto-Slavic"
+    "原始波罗的-斯拉夫语"
   ],
   "ine-pae": [
     "培奧尼亞語",
-    "培奥尼亚语",
-    "Paeonian"
+    "培奥尼亚语"
   ],
   "ine-pro": [
     "原始印歐語",
-    "原始印欧语",
-    "Proto-Indo-European"
+    "原始印欧语"
   ],
   "ine-toc-pro": [
     "原始吐火羅語",
-    "原始吐火罗语",
-    "Proto-Tocharian"
+    "原始吐火罗语"
   ],
   "ing": [
     "Deg Xinag"
   ],
   "inh": [
     "印古什語",
-    "印古什语",
-    "Ingush"
+    "印古什语"
   ],
   "inj": [
     "Jungle Inga"
   ],
   "inl": [
     "印尼手語",
-    "印尼手语",
-    "Indonesian Sign Language"
+    "印尼手语"
   ],
   "inm": [
     "Minaean"
   ],
   "inn": [
     "伊斯奈語",
-    "伊斯奈语",
-    "Isinai"
+    "伊斯奈语"
   ],
   "ino": [
     "Inoke-Yate"
@@ -12424,16 +11414,14 @@
   ],
   "ins": [
     "印度手語",
-    "印度手语",
-    "Indian Sign Language"
+    "印度手语"
   ],
   "int": [
     "Intha"
   ],
   "inz": [
     "伊內塞諾語",
-    "伊内塞诺语",
-    "Ineseño"
+    "伊内塞诺语"
   ],
   "io": [
     "伊多語",
@@ -12446,7 +11434,8 @@
     "Tuma-Irumu"
   ],
   "iow": [
-    "Chiwere",
+    "奇維雷語",
+    "奇维雷语",
     "Iowa",
     "Otoe",
     "Oto",
@@ -12477,48 +11466,39 @@
   ],
   "ira-mny-pro": [
     "原始蒙賈尼伊特格哈語",
-    "原始蒙贾尼伊特格哈语",
-    "Proto-Munji-Yidgha"
+    "原始蒙贾尼伊特格哈语"
   ],
   "ira-mpr-pro": [
     "原始米底-安息語",
-    "原始米底-安息语",
-    "Proto-Medo-Parthian"
+    "原始米底-安息语"
   ],
   "ira-pat-pro": [
     "原始普什圖語",
-    "原始普什图语",
-    "Proto-Pathan"
+    "原始普什图语"
   ],
   "ira-pro": [
     "原始伊朗語",
-    "原始伊朗语",
-    "Proto-Iranian"
+    "原始伊朗语"
   ],
   "ira-sgc-pro": [
     "原始粟特語",
-    "原始粟特语",
-    "Proto-Sogdic"
+    "原始粟特语"
   ],
   "ira-sgi-pro": [
     "原始桑格萊奇伊什卡什米語",
-    "原始桑格莱奇伊什卡什米语",
-    "Proto-Sanglechi-Ishkashimi"
+    "原始桑格莱奇伊什卡什米语"
   ],
   "ira-shr-pro": [
     "原始舒格南羅尚語",
-    "原始舒格南罗尚语",
-    "Proto-Shughni-Roshani"
+    "原始舒格南罗尚语"
   ],
   "ira-shy-pro": [
     "原始舒格南雅茲古拉米語",
-    "原始舒格南雅兹古拉米语",
-    "Proto-Shughni-Yazghulami"
+    "原始舒格南雅兹古拉米语"
   ],
   "ira-sym-pro": [
     "原始舒格南雅茲古拉米蒙賈尼語",
-    "原始舒格南雅兹古拉米蒙贾尼语",
-    "Proto-Shughni-Yazghulami-Munji"
+    "原始舒格南雅兹古拉米蒙贾尼语"
   ],
   "ira-wnj": [
     "Vanji",
@@ -12529,8 +11509,7 @@
   ],
   "ira-zgr-pro": [
     "原始扎扎其古拉尼語",
-    "原始扎扎其古拉尼语",
-    "Proto-Zaza-Gorani"
+    "原始扎扎其古拉尼语"
   ],
   "ire": [
     "Iresim"
@@ -12554,28 +11533,23 @@
   ],
   "iro-min": [
     "明戈語",
-    "明戈语",
-    "Mingo"
+    "明戈语"
   ],
   "iro-nor-pro": [
     "原始北易洛魁語",
-    "原始北易洛魁语",
-    "Proto-North Iroquoian"
+    "原始北易洛魁语"
   ],
   "iro-pro": [
     "原始易洛魁語",
-    "原始易洛魁语",
-    "Proto-Iroquoian"
+    "原始易洛魁语"
   ],
   "irr": [
     "伊爾語",
-    "伊尔语",
-    "Ir"
+    "伊尔语"
   ],
   "iru": [
     "伊魯拉語",
-    "伊鲁拉语",
-    "Irula"
+    "伊鲁拉语"
   ],
   "irx": [
     "Kamberau"
@@ -12597,23 +11571,19 @@
   "isd": [
     "伊斯納格語",
     "伊斯纳格语",
-    "Isnag",
     "Isneg"
   ],
   "ise": [
     "意大利手語",
-    "意大利手语",
-    "Italian Sign Language"
+    "意大利手语"
   ],
   "isg": [
     "愛爾蘭手語",
-    "爱尔兰手语",
-    "Irish Sign Language"
+    "爱尔兰手语"
   ],
   "ish": [
     "埃桑語",
-    "埃桑语",
-    "Esan"
+    "埃桑语"
   ],
   "isi": [
     "Nkem-Nkum",
@@ -12624,8 +11594,7 @@
   ],
   "isk": [
     "伊什卡什米語",
-    "伊什卡什米语",
-    "Ishkashimi"
+    "伊什卡什米语"
   ],
   "ism": [
     "Masimasi"
@@ -12638,13 +11607,11 @@
   ],
   "isr": [
     "以色列手語",
-    "以色列手语",
-    "Israeli Sign Language"
+    "以色列手语"
   ],
   "ist": [
     "伊斯特拉語",
-    "伊斯特拉语",
-    "Istriot"
+    "伊斯特拉语"
   ],
   "isu": [
     "Isu",
@@ -12652,17 +11619,14 @@
   ],
   "it": [
     "意大利語",
-    "意大利语",
-    "義大利語",
-    "义大利语"
+    "意大利语"
   ],
   "itb": [
     "Binongan Itneg"
   ],
   "itc-pro": [
     "原始意大利語",
-    "原始意大利语",
-    "Proto-Italic"
+    "原始意大利语"
   ],
   "itd": [
     "Southern Tidong",
@@ -12680,13 +11644,11 @@
   ],
   "itk": [
     "猶太-意大利語",
-    "犹太-意大利语",
-    "Judeo-Italian"
+    "犹太-意大利语"
   ],
   "itl": [
     "伊捷爾緬語",
     "伊捷尔缅语",
-    "Itelmen",
     "Western Itelmen",
     "Kamchadal"
   ],
@@ -12709,7 +11671,6 @@
   "itv": [
     "伊塔維特語",
     "伊塔维特语",
-    "Itawit",
     "Itawis",
     "Tawit",
     "Malaweg",
@@ -12720,8 +11681,7 @@
   ],
   "itx": [
     "伊蒂克語",
-    "伊蒂克语",
-    "Itik"
+    "伊蒂克语"
   ],
   "ity": [
     "Moyadan Itneg"
@@ -12729,26 +11689,21 @@
   "itz": [
     "伊特扎語",
     "伊特扎语",
-    "Itzá",
     "Itza’",
     "Itza",
     "Itzaj"
   ],
   "iu": [
     "因紐特語",
-    "因纽特语",
-    "伊努克提圖特語",
-    "伊努克提图特语"
+    "因纽特语"
   ],
   "ium": [
     "勉語",
-    "勉语",
-    "Iu Mien"
+    "勉语"
   ],
   "ivb": [
     "伊巴丹語",
     "伊巴丹语",
-    "Ibatan",
     "Ibataan",
     "Itbayat",
     "Itbayaten",
@@ -12759,7 +11714,6 @@
   "ivv": [
     "伊萬特語",
     "伊万特语",
-    "Ivatan",
     "Ivatanen",
     "Basco Ivatan",
     "Ivasayen"
@@ -12778,13 +11732,11 @@
   ],
   "ixc": [
     "伊斯卡特語",
-    "伊斯卡特语",
-    "Ixcatec"
+    "伊斯卡特语"
   ],
   "ixl": [
     "伊克西爾語",
     "伊克西尔语",
-    "Ixil",
     "Ixhil"
   ],
   "iya": [
@@ -12801,11 +11753,6 @@
   "izh": [
     "英格里亞語",
     "英格里亚语",
-    "伊喬里亞語",
-    "伊乔里亚语",
-    "伊喬拉語",
-    "伊乔拉语",
-    "Ingrian",
     "Izhorian"
   ],
   "izi": [
@@ -12822,10 +11769,9 @@
   "ja": [
     "日語",
     "日语",
-    "現代日語",
-    "现代日语",
-    "日本語",
-    "日本语"
+    "Modern Japanese",
+    "Nipponese",
+    "Nihongo"
   ],
   "jaa": [
     "Jamamadí",
@@ -12873,7 +11819,6 @@
   "jam": [
     "牙買加克里奧爾語",
     "牙买加克里奥尔语",
-    "Jamaican Creole",
     "Jamaican",
     "Jamaican Patois",
     "Patois",
@@ -12882,7 +11827,6 @@
   "jan": [
     "詹代語",
     "詹代语",
-    "Janday",
     "Jandai",
     "Djandai",
     "Djendewal",
@@ -12898,16 +11842,14 @@
   ],
   "jao": [
     "揚尤瓦語",
-    "扬尤瓦语",
-    "Yanyuwa"
+    "扬尤瓦语"
   ],
   "jaq": [
     "Yaqay"
   ],
   "jas": [
     "新喀里多尼亞爪哇語",
-    "新喀里多尼亚爪哇语",
-    "New Caledonian Javanese"
+    "新喀里多尼亚爪哇语"
   ],
   "jat": [
     "Jakati"
@@ -12923,11 +11865,6 @@
   ],
   "jaz": [
     "Jawe"
-  ],
-  "jbe": [
-    "猶太-柏柏爾語",
-    "犹太-柏柏尔语",
-    "Judeo-Berber"
   ],
   "jbj": [
     "Arandai"
@@ -12945,8 +11882,7 @@
   ],
   "jbo": [
     "邏輯語",
-    "逻辑语",
-    "Lojban"
+    "逻辑语"
   ],
   "jbr": [
     "Jofotek-Bromnya"
@@ -12970,21 +11906,18 @@
   ],
   "jct": [
     "克里姆查克語",
-    "克里姆查克语",
-    "Krymchak"
+    "克里姆查克语"
   ],
   "jda": [
     "Jad"
   ],
   "jdg": [
     "賈德加里語",
-    "贾德加里语",
-    "Jadgali"
+    "贾德加里语"
   ],
   "jdt": [
     "猶太-塔特語",
     "犹太-塔特语",
-    "Judeo-Tat",
     "Juhuri",
     "Juvuri",
     "Juwuri"
@@ -13002,7 +11935,6 @@
   "jeh": [
     "葉語",
     "叶语",
-    "Jeh",
     "Yaeh"
   ],
   "jei": [
@@ -13029,13 +11961,6 @@
   "jgb": [
     "Ngbee"
   ],
-  "jge": [
-    "猶太-格魯吉亞語",
-    "犹太-格鲁吉亚语",
-    "Judeo-Georgian",
-    "Kivruli",
-    "Gruzinic"
-  ],
   "jgk": [
     "Gwak",
     "Gingwak"
@@ -13045,7 +11970,8 @@
     "恩格姆巴语"
   ],
   "jhi": [
-    "Jehai"
+    "Jehai",
+    "Jahai"
   ],
   "jhs": [
     "Jhankot Sign Language"
@@ -13057,7 +11983,8 @@
     "Jibu"
   ],
   "jic": [
-    "Tol",
+    "希卡克語",
+    "希卡克语",
     "Tolupan",
     "Torupan",
     "Eastern Jicaque"
@@ -13073,8 +12000,7 @@
   ],
   "jih": [
     "上寨語",
-    "上寨语",
-    "Shangzhai"
+    "上寨语"
   ],
   "jii": [
     "Jiiddu"
@@ -13089,11 +12015,15 @@
   ],
   "jio": [
     "加茂語",
-    "加茂语",
-    "Jiamao"
+    "加茂语"
   ],
   "jiq": [
-    "Guanyinqiao"
+    "Khroskyabs",
+    "Guanyinqiao",
+    "Yelong",
+    "Wobzi",
+    "Khrosgyabs",
+    "Lavrung"
   ],
   "jit": [
     "Jita"
@@ -13110,7 +12040,6 @@
   "jje": [
     "濟州語",
     "济州语",
-    "Jeju",
     "Cheju",
     "Jejueo"
   ],
@@ -13135,8 +12064,7 @@
     "Ngile"
   ],
   "jls": [
-    "牙買加手語",
-    "牙买加手语"
+    "Jamaican Sign Language"
   ],
   "jma": [
     "Dima"
@@ -13150,8 +12078,7 @@
   ],
   "jmd": [
     "延德納語",
-    "延德纳语",
-    "Yamdena"
+    "延德纳语"
   ],
   "jmi": [
     "Jimi",
@@ -13159,8 +12086,7 @@
   ],
   "jml": [
     "瓊里語",
-    "琼里语",
-    "Jumli"
+    "琼里语"
   ],
   "jmn": [
     "Makuri Naga"
@@ -13175,8 +12101,7 @@
   ],
   "jmx": [
     "西尤斯特拉瓦卡米斯特克語",
-    "西尤斯特拉瓦卡米斯特克语",
-    "Western Juxtlahuaca Mixtec"
+    "西尤斯特拉瓦卡米斯特克语"
   ],
   "jna": [
     "Jangshung"
@@ -13186,8 +12111,7 @@
   ],
   "jng": [
     "揚曼語",
-    "扬曼语",
-    "Yangman"
+    "扬曼语"
   ],
   "jni": [
     "Janji"
@@ -13207,8 +12131,7 @@
   ],
   "jns": [
     "焦恩沙里語",
-    "焦恩沙里语",
-    "Jaunsari"
+    "焦恩沙里语"
   ],
   "job": [
     "Joba"
@@ -13229,33 +12152,24 @@
   "jpr": [
     "猶太-波斯語",
     "犹太-波斯语",
-    "Judeo-Persian",
     "Jidi",
     "Dzhidi",
     "Djudi"
   ],
   "jpx-pro": [
     "原始日語",
-    "原始日语",
-    "Proto-Japonic"
+    "原始日语"
   ],
   "jpx-ryu-pro": [
     "原始琉球語",
-    "原始琉球语",
-    "Proto-Ryukyuan"
+    "原始琉球语"
   ],
   "jqr": [
     "Jaqaru"
   ],
   "jra": [
     "嘉萊語",
-    "嘉莱语",
-    "Jarai"
-  ],
-  "jrb": [
-    "猶太-阿拉伯語",
-    "犹太-阿拉伯语",
-    "Judeo-Arabic"
+    "嘉莱语"
   ],
   "jrr": [
     "Jiru"
@@ -13265,8 +12179,7 @@
   ],
   "jsl": [
     "日本手語",
-    "日本手语",
-    "Japanese Sign Language"
+    "日本手语"
   ],
   "jua": [
     "Júma"
@@ -13276,8 +12189,7 @@
   ],
   "juc": [
     "女真語",
-    "女真语",
-    "Jurchen"
+    "女真语"
   ],
   "jud": [
     "Worodougou"
@@ -13290,16 +12202,14 @@
   ],
   "jui": [
     "恩加朱里語",
-    "恩加朱里语",
-    "Ngadjuri"
+    "恩加朱里语"
   ],
   "juk": [
     "Wapan"
   ],
   "jul": [
     "幾熱爾語",
-    "几热尔语",
-    "Jirel"
+    "几热尔语"
   ],
   "jum": [
     "Jumjum"
@@ -13326,7 +12236,6 @@
   "jut": [
     "日德蘭語",
     "日德兰语",
-    "Jutish",
     "Jutlandic"
   ],
   "juu": [
@@ -13347,40 +12256,31 @@
   ],
   "jvn": [
     "加勒比爪哇語",
-    "加勒比爪哇语",
-    "Caribbean Javanese"
+    "加勒比爪哇语"
   ],
   "jwi": [
     "Jwira-Pepesa"
-  ],
-  "jye": [
-    "猶太-葉門阿拉伯語",
-    "犹太-叶门阿拉伯语",
-    "Judeo-Yemeni Arabic"
   ],
   "jyy": [
     "Jaya"
   ],
   "ka": [
     "格魯吉亞語",
-    "格鲁吉亚语",
-    "喬治亞語",
-    "乔治亚语"
+    "格鲁吉亚语"
   ],
   "kaa": [
     "卡拉卡爾帕克語",
     "卡拉卡尔帕克语",
-    "Karakalpak"
+    "Qaraqalpaq"
   ],
   "kab": [
     "卡拜爾語",
     "卡拜尔语",
-    "Kabyle"
+    "Kabylian"
   ],
   "kac": [
     "景頗語",
     "景颇语",
-    "Jingpho",
     "Kachin"
   ],
   "kad": [
@@ -13388,11 +12288,7 @@
   ],
   "kae": [
     "凱達格蘭語",
-    "凯达格兰语",
-    "Ketangalan",
-    "Luilang",
-    "雷朗語",
-    "雷朗语"
+    "凯达格兰语"
   ],
   "kaf": [
     "Katso",
@@ -13414,18 +12310,13 @@
   ],
   "kak": [
     "卡亞帕卡拉漢語",
-    "卡亚帕卡拉汉语",
-    "Kayapa Kallahan"
+    "卡亚帕卡拉汉语"
   ],
   "kam": [
     "卡姆巴語",
     "卡姆巴语",
-    "Kamba",
     "Kikamba",
-    "坎巴語",
-    "坎巴语",
-    "康巴語",
-    "康巴语"
+    "Kamba (Kenya)"
   ],
   "kao": [
     "Kassonke",
@@ -13436,7 +12327,6 @@
   "kap": [
     "別日塔語",
     "别日塔语",
-    "Bezhta",
     "Bezheta",
     "Kapucha",
     "Bezhita"
@@ -13447,13 +12337,11 @@
   ],
   "kar-pro": [
     "原始克倫語",
-    "原始克伦语",
-    "Proto-Karen"
+    "原始克伦语"
   ],
   "kaw": [
     "古爪哇語",
     "古爪哇语",
-    "Old Javanese",
     "Kawi"
   ],
   "kax": [
@@ -13464,8 +12352,7 @@
   ],
   "kba": [
     "卡拉爾科語",
-    "卡拉尔科语",
-    "Kalarko"
+    "卡拉尔科语"
   ],
   "kbb": [
     "Kaxuyana",
@@ -13487,13 +12374,11 @@
   "kbd": [
     "卡巴爾達語",
     "卡巴尔达语",
-    "Kabardian",
     "East Circassian"
   ],
   "kbe": [
     "坎朱語",
     "坎朱语",
-    "Kanju",
     "Kaanytju",
     "Kandju",
     "Kaantyu",
@@ -13549,8 +12434,7 @@
   ],
   "kbu": [
     "卡布特拉語",
-    "卡布特拉语",
-    "Kabutra"
+    "卡布特拉语"
   ],
   "kbv": [
     "Kamberataro",
@@ -13568,8 +12452,7 @@
   ],
   "kca": [
     "漢特語",
-    "汉特语",
-    "Khanty"
+    "汉特语"
   ],
   "kcb": [
     "Kawacha"
@@ -13654,7 +12537,6 @@
   "kda": [
     "沃里米語",
     "沃里米语",
-    "Worimi",
     "Gadang",
     "Gadhang",
     "Gadjang",
@@ -13666,8 +12548,7 @@
   ],
   "kdd": [
     "揚昆塔賈拉語",
-    "扬昆塔贾拉语",
-    "Yankunytjatjara"
+    "扬昆塔贾拉语"
   ],
   "kde": [
     "馬孔德語",
@@ -13688,8 +12569,7 @@
   ],
   "kdj": [
     "卡拉莫瓊語",
-    "卡拉莫琼语",
-    "Karamojong"
+    "卡拉莫琼语"
   ],
   "kdk": [
     "Numee"
@@ -13708,18 +12588,15 @@
   ],
   "kdq": [
     "科奇語",
-    "科奇语",
-    "Koch"
+    "科奇语"
   ],
   "kdr": [
     "卡拉伊姆語",
-    "卡拉伊姆语",
-    "Karaim"
+    "卡拉伊姆语"
   ],
   "kdt": [
     "歸語",
-    "归语",
-    "Kuy"
+    "归语"
   ],
   "kdu": [
     "Kadaru",
@@ -13748,7 +12625,6 @@
   "kea": [
     "佛得角克里奧爾語",
     "佛得角克里奥尔语",
-    "Kabuverdianu",
     "Cape Verdean Creole",
     "Kriolu",
     "Creole",
@@ -13784,8 +12660,7 @@
   ],
   "kek": [
     "凱克奇語",
-    "凯克奇语",
-    "Q'eqchi"
+    "凯克奇语"
   ],
   "kel": [
     "Kela-Yela",
@@ -13794,8 +12669,7 @@
   ],
   "kem": [
     "克馬克語",
-    "克马克语",
-    "Kemak"
+    "克马克语"
   ],
   "ken": [
     "肯揚語",
@@ -13809,8 +12683,7 @@
   ],
   "keq": [
     "卡馬爾語",
-    "卡马尔语",
-    "Kamar"
+    "卡马尔语"
   ],
   "ker": [
     "Kera"
@@ -13838,27 +12711,22 @@
   ],
   "kex": [
     "庫克納語",
-    "库克纳语",
-    "Kukna"
+    "库克纳语"
   ],
   "key": [
     "庫皮亞語",
-    "库皮亚语",
-    "Kupia"
+    "库皮亚语"
   ],
   "kez": [
     "Kukele"
   ],
   "kfa": [
     "戈達瓦語",
-    "戈达瓦语",
-    "Kodava",
-    "Kodagu"
+    "戈达瓦语"
   ],
   "kfb": [
     "科拉米語",
-    "科拉米语",
-    "Kolami"
+    "科拉米语"
   ],
   "kfc": [
     "Konda-Dora"
@@ -13884,15 +12752,11 @@
   ],
   "kfj": [
     "克蔑語",
-    "克蔑语",
-    "Kemiehua",
-    "克蔑話",
-    "克蔑话"
+    "克蔑语"
   ],
   "kfk": [
     "金瑙里語",
-    "金瑙里语",
-    "Kinnauri"
+    "金瑙里语"
   ],
   "kfl": [
     "Kung"
@@ -13907,7 +12771,8 @@
     "Koro Jula"
   ],
   "kfp": [
-    "Korwa"
+    "科爾瓦語",
+    "科尔瓦语"
   ],
   "kfq": [
     "Korku"
@@ -13915,7 +12780,6 @@
   "kfr": [
     "喀奇語",
     "喀奇语",
-    "Kachchi",
     "Kutchi",
     "Cutchi",
     "Kachchhi",
@@ -13923,23 +12787,19 @@
   ],
   "kfs": [
     "比拉斯普里語",
-    "比拉斯普里语",
-    "Bilaspuri"
+    "比拉斯普里语"
   ],
   "kft": [
     "坎賈里語",
-    "坎贾里语",
-    "Kanjari"
+    "坎贾里语"
   ],
   "kfu": [
     "卡特卡里語",
-    "卡特卡里语",
-    "Katkari"
+    "卡特卡里语"
   ],
   "kfv": [
     "庫爾穆卡爾語",
-    "库尔穆卡尔语",
-    "Kurmukar"
+    "库尔穆卡尔语"
   ],
   "kfw": [
     "Kharam Naga",
@@ -13948,7 +12808,6 @@
   "kfx": [
     "庫魯帕哈里語",
     "库鲁帕哈里语",
-    "Kullu Pahari",
     "Kullu"
   ],
   "kfy": [
@@ -13979,13 +12838,11 @@
   ],
   "kgg": [
     "庫松達語",
-    "库松达语",
-    "Kusunda"
+    "库松达语"
   ],
   "kgi": [
     "雪蘭莪手語",
-    "雪兰莪手语",
-    "Selangor Sign Language"
+    "雪兰莪手语"
   ],
   "kgj": [
     "Gamale Kham"
@@ -13995,8 +12852,7 @@
   ],
   "kgl": [
     "昆加里語",
-    "昆加里语",
-    "Kunggari"
+    "昆加里语"
   ],
   "kgm": [
     "Karipúna"
@@ -14004,7 +12860,6 @@
   "kgn": [
     "卡林加里語",
     "卡林加里语",
-    "Karingani",
     "Keringani"
   ],
   "kgo": [
@@ -14022,8 +12877,7 @@
   ],
   "kgs": [
     "貢邦加爾語",
-    "贡邦加尔语",
-    "Kumbainggar"
+    "贡邦加尔语"
   ],
   "kgt": [
     "Somyev"
@@ -14045,13 +12899,11 @@
   ],
   "kha": [
     "卡西語",
-    "卡西语",
-    "Khasi"
+    "卡西语"
   ],
   "khb": [
     "傣仂語",
     "傣仂语",
-    "Lü",
     "Lue",
     "Tai Lü",
     "Tai Lue",
@@ -14068,27 +12920,18 @@
   ],
   "khf": [
     "佛教克木語",
-    "佛教克木语",
-    "Khuen",
-    "Khmu Khwen"
-  ],
-  "khg": [
-    "康巴藏語",
-    "康巴藏语",
-    "Khams Tibetan"
+    "佛教克木语"
   ],
   "khh": [
     "Kehu"
   ],
   "khi-kho-pro": [
     "原始科伊語",
-    "原始科伊语",
-    "Proto-Khoe"
+    "原始科伊语"
   ],
   "khi-kun": [
     "亢語",
     "亢语",
-    "ǃKung",
     "ǃOǃKung",
     "ǃ'OǃKung",
     "Kung",
@@ -14101,18 +12944,15 @@
   ],
   "khl": [
     "盧西語",
-    "卢西语",
-    "Lusi"
+    "卢西语"
   ],
   "khn": [
     "堪德斯語",
-    "堪德斯语",
-    "Khandeshi"
+    "堪德斯语"
   ],
   "kho": [
     "和闐語",
-    "和阗语",
-    "Khotanese"
+    "和阗语"
   ],
   "khp": [
     "Kapauri"
@@ -14125,8 +12965,7 @@
   ],
   "khr": [
     "卡里亞語",
-    "卡里亚语",
-    "Kharia"
+    "卡里亚语"
   ],
   "khs": [
     "Kasua"
@@ -14134,7 +12973,6 @@
   "kht": [
     "坎底語",
     "坎底语",
-    "Khamti",
     "Tai Khamti"
   ],
   "khu": [
@@ -14143,15 +12981,16 @@
   "khv": [
     "赫瓦爾什語",
     "赫瓦尔什语",
-    "Khvarshi",
     "Khwarshi",
     "Xvarshi",
     "Inkhokvari"
   ],
   "khw": [
     "科瓦語",
-    "科瓦语",
-    "Khowar"
+    "科瓦语"
+  ],
+  "khx": [
+    "Kanu"
   ],
   "khy": [
     "Ekele",
@@ -14162,8 +13001,7 @@
   ],
   "khz": [
     "凱帕拉語",
-    "凯帕拉语",
-    "Keapara"
+    "凯帕拉语"
   ],
   "ki": [
     "基庫尤語",
@@ -14201,8 +13039,7 @@
   ],
   "kij": [
     "基里維納語",
-    "基里维纳语",
-    "Kilivila"
+    "基里维纳语"
   ],
   "kil": [
     "Kariya"
@@ -14210,7 +13047,6 @@
   "kim": [
     "圖法語",
     "图法语",
-    "Tofa",
     "Tofalar",
     "Karagas"
   ],
@@ -14234,8 +13070,7 @@
   ],
   "kiw": [
     "東北基瓦伊語",
-    "东北基瓦伊语",
-    "Northeast Kiwai"
+    "东北基瓦伊语"
   ],
   "kix": [
     "Khiamniungan Naga"
@@ -14258,33 +13093,27 @@
   ],
   "kjb": [
     "坎霍瓦爾語",
-    "坎霍瓦尔语",
-    "Q'anjob'al"
+    "坎霍瓦尔语"
   ],
   "kjc": [
     "孔喬語",
-    "孔乔语",
-    "Coastal Konjo"
+    "孔乔语"
   ],
   "kjd": [
     "南基瓦伊語",
-    "南基瓦伊语",
-    "Southern Kiwai"
+    "南基瓦伊语"
   ],
   "kje": [
     "基薩爾語",
-    "基萨尔语",
-    "Kisar"
+    "基萨尔语"
   ],
   "kjg": [
     "克木語",
-    "克木语",
-    "Khmu"
+    "克木语"
   ],
   "kjh": [
     "哈卡斯語",
-    "哈卡斯语",
-    "Khakas"
+    "哈卡斯语"
   ],
   "kji": [
     "Zabana"
@@ -14292,7 +13121,6 @@
   "kjj": [
     "奇納魯格語",
     "奇纳鲁格语",
-    "Khinalug",
     "Khinalig",
     "Xinalug",
     "Xinalugh",
@@ -14300,8 +13128,7 @@
   ],
   "kjk": [
     "高地孔喬語",
-    "高地孔乔语",
-    "Highland Konjo"
+    "高地孔乔语"
   ],
   "kjl": [
     "Kham"
@@ -14312,7 +13139,6 @@
   "kjn": [
     "昆堅語",
     "昆坚语",
-    "Kunjen",
     "Uw Oykangand",
     "Uw Olkola",
     "Olkol",
@@ -14329,13 +13155,11 @@
   ],
   "kjo": [
     "哈里詹金瑙里語",
-    "哈里詹金瑙里语",
-    "Harijan Kinnauri"
+    "哈里詹金瑙里语"
   ],
   "kjp": [
     "東波克倫語",
     "东波克伦语",
-    "Eastern Pwo",
     "Phlou",
     "Eastern Pwo Karen"
   ],
@@ -14356,8 +13180,7 @@
   ],
   "kju": [
     "卡沙亞語",
-    "卡沙亚语",
-    "Kashaya"
+    "卡沙亚语"
   ],
   "kjx": [
     "Ramopa",
@@ -14393,13 +13216,11 @@
   ],
   "kkg": [
     "瑪巴佳卡林阿語",
-    "玛巴佳卡林阿语",
-    "Mabaka Valley Kalinga"
+    "玛巴佳卡林阿语"
   ],
   "kkh": [
     "傣艮語",
     "傣艮语",
-    "Khün",
     "Tai Khün",
     "Dai Kun"
   ],
@@ -14413,8 +13234,7 @@
   ],
   "kkk": [
     "科科塔語",
-    "科科塔语",
-    "Kokota"
+    "科科塔语"
   ],
   "kkl": [
     "Kosarek Yale"
@@ -14432,7 +13252,6 @@
   "kkp": [
     "古古-貝拉語",
     "古古-贝拉语",
-    "Koko-Bera",
     "Kok-Kaper",
     "Gugubera",
     "Koko-Pera"
@@ -14465,13 +13284,11 @@
   ],
   "kky": [
     "辜古依密舍語",
-    "辜古依密舍语",
-    "Guugu Yimidhirr"
+    "辜古依密舍语"
   ],
   "kkz": [
     "卡斯卡語",
-    "卡斯卡语",
-    "Kaska"
+    "卡斯卡语"
   ],
   "kl": [
     "格陵蘭語",
@@ -14491,9 +13308,6 @@
   "kld": [
     "卡米拉瑞語",
     "卡米拉瑞语",
-    "加米拉拉埃語",
-    "加米拉拉埃语",
-    "Gamilaraay",
     "Kamilaroi",
     "Kamilarai",
     "Kamalarai",
@@ -14507,8 +13321,7 @@
   ],
   "klg": [
     "達雅高路加拉岸語",
-    "达雅高路加拉岸语",
-    "Tagakaulu Kalagan"
+    "达雅高路加拉岸语"
   ],
   "klh": [
     "Weliki"
@@ -14519,7 +13332,6 @@
   "klj": [
     "哈拉吉語",
     "哈拉吉语",
-    "Khalaj",
     "Turkic Khalaj",
     "Arghu"
   ],
@@ -14536,8 +13348,7 @@
   ],
   "kln": [
     "卡倫金語",
-    "卡伦金语",
-    "Kalenjin"
+    "卡伦金语"
   ],
   "klo": [
     "Kapya"
@@ -14550,13 +13361,11 @@
   ],
   "klr": [
     "喀靈語",
-    "喀灵语",
-    "Khaling"
+    "喀灵语"
   ],
   "kls": [
     "卡拉什語",
-    "卡拉什语",
-    "Kalasha"
+    "卡拉什语"
   ],
   "klt": [
     "Nukna"
@@ -14566,13 +13375,11 @@
   ],
   "klv": [
     "馬斯克林斯語",
-    "马斯克林斯语",
-    "Maskelynes"
+    "马斯克林斯语"
   ],
   "klw": [
     "林杜語",
     "林杜语",
-    "Lindu",
     "Tado"
   ],
   "klx": [
@@ -14587,34 +13394,28 @@
   "km": [
     "高棉語",
     "高棉语",
-    "柬埔寨語",
-    "柬埔寨语"
+    "Cambodian",
+    "Central Khmer",
+    "Modern Khmer"
   ],
   "kma": [
     "孔尼語",
-    "孔尼语",
-    "Konni"
+    "孔尼语"
   ],
   "kmb": [
     "金邦杜語",
     "金邦杜语",
-    "Kimbundu",
     "North Mbundu"
   ],
   "kmc": [
     "南侗語",
     "南侗语",
-    "Southern Kam",
     "Southern Gam",
     "Southern Dong"
   ],
   "kmd": [
     "馬杜卡揚卡林阿語",
-    "马杜卡扬卡林阿语",
-    "Madukayang Kalinga",
-    "Southern Kam",
-    "Southern Gam",
-    "Southern Dong"
+    "马杜卡扬卡林阿语"
   ],
   "kme": [
     "Bakole"
@@ -14642,13 +13443,11 @@
   ],
   "kmk": [
     "利莫斯卡林阿語",
-    "利莫斯卡林阿语",
-    "Limos Kalinga"
+    "利莫斯卡林阿语"
   ],
   "kml": [
     "大努丹卡林阿語",
     "大努丹卡林阿语",
-    "Tanudan Kalinga",
     "Lower Tanudan Kalinga",
     "Upper Tanudan Kalinga"
   ],
@@ -14671,7 +13470,6 @@
   "kmr": [
     "北庫爾德語",
     "北库尔德语",
-    "Northern Kurdish",
     "Kurmanji"
   ],
   "kms": [
@@ -14704,14 +13502,11 @@
   "kmz": [
     "呼羅珊尼土耳其語",
     "呼罗珊尼土耳其语",
-    "Khorasani Turkish",
     "Khorasani Turkic"
   ],
   "kn": [
     "卡納達語",
-    "卡纳达语",
-    "康納達語",
-    "康纳达语"
+    "卡纳达语"
   ],
   "kna": [
     "Kanakuru",
@@ -14720,21 +13515,18 @@
   ],
   "knb": [
     "盧布阿甘卡林阿語",
-    "卢布阿甘卡林阿语",
-    "Lubuagan Kalinga"
+    "卢布阿甘卡林阿语"
   ],
   "knd": [
     "Konda"
   ],
   "kne": [
     "坎卡奈語",
-    "坎卡奈语",
-    "Kankanaey"
+    "坎卡奈语"
   ],
   "knf": [
     "曼卡尼亞語",
-    "曼卡尼亚语",
-    "Mankanya"
+    "曼卡尼亚语"
   ],
   "kni": [
     "Kanufi"
@@ -14811,19 +13603,11 @@
   "ko": [
     "朝鮮語",
     "朝鲜语",
-    "韓語",
-    "韩语",
-    "朝語",
-    "朝语",
-    "現代朝鮮語",
-    "现代朝鲜语",
-    "現代韓語",
-    "现代韩语"
+    "Modern Korean"
   ],
   "ko-ear": [
     "近世朝鮮語",
-    "近世朝鲜语",
-    "Early Modern Korean"
+    "近世朝鲜语"
   ],
   "koa": [
     "Konomala"
@@ -14853,17 +13637,11 @@
   ],
   "koi": [
     "彼爾姆科米語",
-    "彼尔姆科米语",
-    "Komi-Permyak",
-    "科米-彼爾米亞克語",
-    "科米-彼尔米亚克语",
-    "彼爾米亞克語",
-    "彼尔米亚克语"
+    "彼尔姆科米语"
   ],
   "kok": [
     "孔卡尼語",
-    "孔卡尼语",
-    "Konkani"
+    "孔卡尼语"
   ],
   "kol": [
     "Kol (New Guinea)",
@@ -14889,7 +13667,8 @@
     "科斯雷恩语"
   ],
   "kot": [
-    "Lagwan"
+    "Lagwan",
+    "Logone"
   ],
   "kou": [
     "Koke"
@@ -14929,8 +13708,7 @@
   ],
   "kpg": [
     "卡平阿馬朗伊語",
-    "卡平阿马朗伊语",
-    "Kapingamarangi"
+    "卡平阿马朗伊语"
   ],
   "kph": [
     "Kplang"
@@ -14949,8 +13727,7 @@
   ],
   "kpm": [
     "格賀語",
-    "格贺语",
-    "Koho"
+    "格贺语"
   ],
   "kpn": [
     "Kepkiriwát"
@@ -14972,8 +13749,7 @@
   ],
   "kpt": [
     "卡拉塔語",
-    "卡拉塔语",
-    "Karata"
+    "卡拉塔语"
   ],
   "kpu": [
     "Kafoa"
@@ -14981,19 +13757,11 @@
   "kpv": [
     "茲梁科米語",
     "兹梁科米语",
-    "Komi-Zyrian",
-    "Komi",
-    "茲梁語",
-    "兹梁语",
-    "科米-齊良語",
-    "科米-齐良语",
-    "齊良語",
-    "齐良语"
+    "Komi"
   ],
   "kpw": [
     "科邦語",
-    "科邦语",
-    "Kobon"
+    "科邦语"
   ],
   "kpx": [
     "Mountain Koiari",
@@ -15001,8 +13769,7 @@
   ],
   "kpy": [
     "科里亞克語",
-    "科里亚克语",
-    "Koryak"
+    "科里亚克语"
   ],
   "kpz": [
     "Kupsabiny"
@@ -15021,13 +13788,11 @@
   ],
   "kqe": [
     "卡拉甘語",
-    "卡拉甘语",
-    "Kalagan"
+    "卡拉甘语"
   ],
   "kqf": [
     "卡卡拜語",
-    "卡卡拜语",
-    "Kakabai"
+    "卡卡拜语"
   ],
   "kqg": [
     "Khe"
@@ -15053,7 +13818,6 @@
   "kqn": [
     "卡翁德語",
     "卡翁德语",
-    "Kaonde",
     "Chikaonde",
     "Kawonde"
   ],
@@ -15068,8 +13832,7 @@
   ],
   "kqr": [
     "基馬拉岡語",
-    "基马拉冈语",
-    "Kimaragang"
+    "基马拉冈语"
   ],
   "kqs": [
     "Northern Kissi"
@@ -15107,8 +13870,7 @@
   ],
   "krc": [
     "卡拉恰伊-巴爾卡爾語",
-    "卡拉恰伊-巴尔卡尔语",
-    "Karachay-Balkar"
+    "卡拉恰伊-巴尔卡尔语"
   ],
   "krd": [
     "Kairui-Midiki"
@@ -15126,8 +13888,6 @@
   "kri": [
     "塞拉利昂克里奧爾語",
     "塞拉利昂克里奥尔语",
-    "克里奧語",
-    "克里奥语",
     "Sierra Leonean Creole"
   ],
   "krj": [
@@ -15136,13 +13896,11 @@
   ],
   "krk": [
     "克列克語",
-    "克列克语",
-    "Kerek"
+    "克列克语"
   ],
   "krl": [
     "卡累利阿語",
-    "卡累利阿语",
-    "Karelian"
+    "卡累利阿语"
   ],
   "krm": [
     "Krim"
@@ -15152,8 +13910,7 @@
   ],
   "kro-pro": [
     "原始克魯語",
-    "原始克鲁语",
-    "Proto-Kru"
+    "原始克鲁语"
   ],
   "krp": [
     "Korop"
@@ -15171,7 +13928,6 @@
   "kru": [
     "庫魯克語",
     "库鲁克语",
-    "Kurukh",
     "Kurux"
   ],
   "krv": [
@@ -15187,7 +13943,6 @@
   "kry": [
     "克里茨語",
     "克里茨语",
-    "Kryts",
     "Kryc",
     "Kryz"
   ],
@@ -15197,8 +13952,6 @@
   "ks": [
     "克什米爾語",
     "克什米尔语",
-    "喀什米爾語",
-    "喀什米尔语",
     "Koshur"
   ],
   "ksa": [
@@ -15211,13 +13964,11 @@
   ],
   "ksc": [
     "南卡林阿語",
-    "南卡林阿语",
-    "Southern Kalinga"
+    "南卡林阿语"
   ],
   "ksd": [
     "庫阿努阿語",
     "库阿努阿语",
-    "Tolai",
     "Kuanua"
   ],
   "kse": [
@@ -15232,9 +13983,7 @@
   ],
   "ksi": [
     "伊薩卡語",
-    "伊萨卡语",
-    "Krisa",
-    "I'saka"
+    "伊萨卡语"
   ],
   "ksj": [
     "Uare"
@@ -15244,9 +13993,7 @@
   ],
   "ksl": [
     "庫馬爾語",
-    "库马尔语",
-    "Kumalu",
-    "Kumal"
+    "库马尔语"
   ],
   "ksm": [
     "Kumba"
@@ -15265,8 +14012,7 @@
   ],
   "ksr": [
     "博隆語",
-    "博隆语",
-    "Borong"
+    "博隆语"
   ],
   "kss": [
     "Southern Kissi"
@@ -15276,8 +14022,7 @@
   ],
   "ksu": [
     "坎佯語",
-    "坎佯语",
-    "Khamyang"
+    "坎佯语"
   ],
   "ksv": [
     "Kusu"
@@ -15285,9 +14030,9 @@
   "ksw": [
     "斯高克倫語",
     "斯高克伦语",
-    "S'gaw Karen",
     "S'gaw Kayin",
     "S'gaw",
+    "Sgaw",
     "White Karen"
   ],
   "ksx": [
@@ -15295,29 +14040,25 @@
   ],
   "ksy": [
     "卡里亞塔爾語",
-    "卡里亚塔尔语",
-    "Kharia Thar"
+    "卡里亚塔尔语"
   ],
   "ksz": [
     "Kodaku"
   ],
   "kta": [
     "歌須語",
-    "歌须语",
-    "Katua"
+    "歌须语"
   ],
   "ktb": [
     "卡姆巴塔語",
-    "卡姆巴塔语",
-    "Kambaata"
+    "卡姆巴塔语"
   ],
   "ktc": [
     "Kholok"
   ],
   "ktd": [
     "科卡塔語",
-    "科卡塔语",
-    "Kokata"
+    "科卡塔语"
   ],
   "ktf": [
     "Kwami"
@@ -15325,7 +14066,6 @@
   "ktg": [
     "卡爾庫通語",
     "卡尔库通语",
-    "Kalkatungu",
     "Kalkutungu",
     "Galgadungu",
     "Kalkutung",
@@ -15377,7 +14117,6 @@
   "ktu": [
     "吉土巴語",
     "吉土巴语",
-    "Kituba",
     "Munukutuba",
     "Kikongo-Kituba",
     "Kikongo",
@@ -15389,8 +14128,7 @@
   ],
   "ktv": [
     "東戈都語",
-    "东戈都语",
-    "Eastern Katu"
+    "东戈都语"
   ],
   "ktw": [
     "Kato",
@@ -15406,11 +14144,6 @@
   "ktz": [
     "朱洪語",
     "朱洪语",
-    "朱胡亞斯",
-    "朱胡亚斯",
-    "朱胡亞斯語",
-    "朱胡亚斯语",
-    "Juǀ'hoan",
     "Zhuǀ'hoan",
     "ǂKxʼauǁʼein",
     "ǁAuǁei",
@@ -15424,16 +14157,9 @@
     "ǁX'auǁ'e",
     "Juǀ'hoansi"
   ],
-  "ku": [
-    "庫爾德語",
-    "库尔德语",
-    "庫德語",
-    "库德语"
-  ],
   "ku-pro": [
     "原始庫爾德語",
-    "原始库尔德语",
-    "Proto-Kurdish"
+    "原始库尔德语"
   ],
   "kub": [
     "Kutep"
@@ -15444,9 +14170,6 @@
   "kud": [
     "奧赫拉瓦語",
     "奥赫拉瓦语",
-    "庫拉達語",
-    "库拉达语",
-    "Auhelawa",
     "'Auhelawa"
   ],
   "kue": [
@@ -15456,8 +14179,7 @@
   ],
   "kuf": [
     "西戈都語",
-    "西戈都语",
-    "Western Katu"
+    "西戈都语"
   ],
   "kug": [
     "Kupa"
@@ -15488,8 +14210,7 @@
   ],
   "kum": [
     "庫梅克語",
-    "库梅克语",
-    "Kumyk"
+    "库梅克语"
   ],
   "kun": [
     "Kunama"
@@ -15521,23 +14242,19 @@
   ],
   "kux": [
     "庫卡吉語",
-    "库卡吉语",
-    "Kukatja"
+    "库卡吉语"
   ],
   "kuy": [
     "庫庫-亞烏語",
-    "库库-亚乌语",
-    "Kuuku-Ya'u"
+    "库库-亚乌语"
   ],
   "kuz": [
     "坤扎語",
-    "坤扎语",
-    "Kunza"
+    "坤扎语"
   ],
   "kva": [
     "巴格瓦拉爾語",
-    "巴格瓦拉尔语",
-    "Bagvalal"
+    "巴格瓦拉尔语"
   ],
   "kvb": [
     "Kubu"
@@ -15560,8 +14277,7 @@
   ],
   "kvh": [
     "科莫多語",
-    "科莫多语",
-    "Komodo"
+    "科莫多语"
   ],
   "kvi": [
     "Kwang"
@@ -15607,8 +14323,7 @@
   ],
   "kvx": [
     "帕卡里科里語",
-    "帕卡里科里语",
-    "Parkari Koli"
+    "帕卡里科里语"
   ],
   "kvy": [
     "Yintale Karen"
@@ -15618,9 +14333,7 @@
   ],
   "kw": [
     "康沃爾語",
-    "康沃尔语",
-    "康瓦爾語",
-    "康瓦尔语"
+    "康沃尔语"
   ],
   "kwa": [
     "Dâw"
@@ -15640,8 +14353,7 @@
   ],
   "kwf": [
     "夸拉阿埃語",
-    "夸拉阿埃语",
-    "Kwara'ae"
+    "夸拉阿埃语"
   ],
   "kwg": [
     "Sara Kaba Deme"
@@ -15664,8 +14376,7 @@
   ],
   "kwk": [
     "夸克瓦拉語",
-    "夸克瓦拉语",
-    "Kwak'wala"
+    "夸克瓦拉语"
   ],
   "kwl": [
     "Kofyar"
@@ -15684,8 +14395,7 @@
   ],
   "kwq": [
     "克瓦克語",
-    "克瓦克语",
-    "Kwak"
+    "克瓦克语"
   ],
   "kwr": [
     "Kwer"
@@ -15698,8 +14408,7 @@
   ],
   "kwu": [
     "克瓦庫姆語",
-    "克瓦库姆语",
-    "Kwakum"
+    "克瓦库姆语"
   ],
   "kwv": [
     "Sara Kaba Náà",
@@ -15713,16 +14422,14 @@
   ],
   "kwz": [
     "克瓦迪語",
-    "克瓦迪语",
-    "Kwadi"
+    "克瓦迪语"
   ],
   "kxa": [
     "Kairiru"
   ],
   "kxb": [
     "克羅布語",
-    "克罗布语",
-    "Krobu"
+    "克罗布语"
   ],
   "kxc": [
     "Khonso"
@@ -15730,8 +14437,7 @@
   "kxd": [
     "汶萊馬來語",
     "汶莱马来语",
-    "Brunei",
-    "Brunei Malay"
+    "Brunei"
   ],
   "kxe": [
     "Kakihum"
@@ -15755,20 +14461,17 @@
   ],
   "kxl": [
     "尼泊爾庫魯克語",
-    "尼泊尔库鲁克语",
-    "Nepali Kurux"
+    "尼泊尔库鲁克语"
   ],
   "kxm": [
     "北部高棉語",
     "北部高棉语",
-    "Northern Khmer",
     "Thai Khmer",
     "Surin Khmer"
   ],
   "kxn": [
     "加拿逸語",
     "加拿逸语",
-    "Kanowit",
     "Tanjong",
     "Kanowit-Tanjong Melanau"
   ],
@@ -15777,8 +14480,7 @@
   ],
   "kxp": [
     "瓦迪雅拉科里語",
-    "瓦迪雅拉科里语",
-    "Wadiyara Koli"
+    "瓦迪雅拉科里语"
   ],
   "kxq": [
     "Smärky Kanum"
@@ -15789,7 +14491,8 @@
     "Koro"
   ],
   "kxs": [
-    "Kangjia"
+    "康家語",
+    "康家语"
   ],
   "kxt": [
     "Koiwat"
@@ -15810,8 +14513,7 @@
   ],
   "kxy": [
     "歌庸語",
-    "歌庸语",
-    "Kayong"
+    "歌庸语"
   ],
   "kxz": [
     "Kerewo"
@@ -15819,18 +14521,16 @@
   "ky": [
     "吉爾吉斯語",
     "吉尔吉斯语",
-    "柯爾克孜語",
-    "柯尔克孜语"
+    "Kirghiz",
+    "Kirgiz"
   ],
   "kya": [
     "克瓦亞語",
-    "克瓦亚语",
-    "Kwaya"
+    "克瓦亚语"
   ],
   "kyb": [
     "布特布特卡林阿語",
-    "布特布特卡林阿语",
-    "Butbut Kalinga"
+    "布特布特卡林阿语"
   ],
   "kyc": [
     "Kyaka"
@@ -15848,28 +14548,25 @@
     "Keyagana"
   ],
   "kyh": [
-    "Karok",
+    "卡魯克語",
+    "卡鲁克语",
     "Karuk"
   ],
   "kyi": [
     "基普特語",
-    "基普特语",
-    "Kiput"
+    "基普特语"
   ],
   "kyj": [
     "加勞語",
-    "加劳语",
-    "Karao"
+    "加劳语"
   ],
   "kyk": [
     "卡馬尤語",
-    "卡马尤语",
-    "Kamayo"
+    "卡马尤语"
   ],
   "kyl": [
     "卡拉普亞語",
-    "卡拉普亚语",
-    "Kalapuya"
+    "卡拉普亚语"
   ],
   "kym": [
     "Kpatili"
@@ -15900,8 +14597,7 @@
   ],
   "kyu": [
     "西克耶語",
-    "西克耶语",
-    "Western Kayah"
+    "西克耶语"
   ],
   "kyv": [
     "Kayort"
@@ -15909,7 +14605,6 @@
   "kyw": [
     "庫德馬里語",
     "库德马里语",
-    "Kudmali",
     "Kurmali"
   ],
   "kyx": [
@@ -15946,8 +14641,7 @@
   ],
   "kzg": [
     "喜界語",
-    "喜界语",
-    "Kikai"
+    "喜界语"
   ],
   "kzh": [
     "Dongolawi",
@@ -16041,18 +14735,12 @@
   "lac": [
     "拉坎敦語",
     "拉坎敦语",
-    "Lacandon",
     "Jach t’aan",
     "Hach t’an"
   ],
   "lad": [
     "拉蒂諾語",
     "拉蒂诺语",
-    "拉迪諾語",
-    "拉迪诺语",
-    "拉地諾語",
-    "拉地诺语",
-    "Ladino",
     "Judaeo-Spanish",
     "Judæo-Spanish",
     "Judeo-Spanish"
@@ -16070,7 +14758,6 @@
   "lah": [
     "蘭達語",
     "兰达语",
-    "Lahnda",
     "Western Punjabi"
   ],
   "lai": [
@@ -16102,7 +14789,6 @@
   "laq": [
     "普標語",
     "普标语",
-    "Qabiao",
     "Laqua"
   ],
   "lar": [
@@ -16111,7 +14797,6 @@
   "las": [
     "古爾拉瑪語",
     "古尔拉玛语",
-    "Gur Lama",
     "Lama (West Africa)",
     "Lama (Togo)",
     "Lama"
@@ -16125,13 +14810,11 @@
   "lax": [
     "提瓦語",
     "提瓦语",
-    "Tiwa",
     "Lalung"
   ],
   "lay": [
     "拉瑪白語",
     "拉玛白语",
-    "Lama Bai",
     "Lama (Southeast Asia)",
     "Lama (Burma)",
     "Lama (Myanmar)",
@@ -16152,13 +14835,11 @@
   "lbc": [
     "拉珈語",
     "拉珈语",
-    "Lakkia",
     "Lakkja"
   ],
   "lbe": [
     "拉克語",
-    "拉克语",
-    "Lak"
+    "拉克语"
   ],
   "lbf": [
     "Tinani"
@@ -16172,13 +14853,11 @@
   "lbj": [
     "拉達克語",
     "拉达克语",
-    "Ladakhi",
     "Bhoti"
   ],
   "lbk": [
     "中邦托克語",
     "中邦托克语",
-    "Central Bontoc",
     "Central Bontok",
     "Igorot Bontoc",
     "Igorot Bontok",
@@ -16189,13 +14868,11 @@
   ],
   "lbl": [
     "利邦比科爾語",
-    "利邦比科尔语",
-    "Libon Bikol"
+    "利邦比科尔语"
   ],
   "lbm": [
     "洛迪語",
-    "洛迪语",
-    "Lodhi"
+    "洛迪语"
   ],
   "lbn": [
     "Lamet"
@@ -16221,13 +14898,11 @@
   ],
   "lbs": [
     "利比亞手語",
-    "利比亚手语",
-    "Libyan Sign Language"
+    "利比亚手语"
   ],
   "lbt": [
     "拉基語",
-    "拉基语",
-    "Lachi"
+    "拉基语"
   ],
   "lbu": [
     "Labu"
@@ -16250,7 +14925,6 @@
   "lbz": [
     "拉爾迪爾語",
     "拉尔迪尔语",
-    "Lardil",
     "Leerdil",
     "Leertil",
     "Damin",
@@ -16319,8 +14993,7 @@
   ],
   "ldn": [
     "拉丹語",
-    "拉丹语",
-    "Láadan"
+    "拉丹语"
   ],
   "ldo": [
     "Loo"
@@ -16381,8 +15054,7 @@
   ],
   "leh": [
     "倫杰語",
-    "伦杰语",
-    "Lenje"
+    "伦杰语"
   ],
   "lei": [
     "Lemio"
@@ -16414,10 +15086,7 @@
   ],
   "lep": [
     "絨巴語",
-    "绒巴语",
-    "Lepcha",
-    "雷布查語",
-    "雷布查语"
+    "绒巴语"
   ],
   "leq": [
     "Lembena"
@@ -16467,7 +15136,6 @@
   "lez": [
     "列茲金語",
     "列兹金语",
-    "Lezgi",
     "Lezgian",
     "Lezgin"
   ],
@@ -16476,14 +15144,12 @@
   ],
   "lfn": [
     "新共同語言",
-    "新共同语言",
-    "Lingua Franca Nova"
+    "新共同语言"
   ],
   "lg": [
     "盧干達語",
     "卢干达语",
-    "干達語",
-    "干达语",
+    "Ganda",
     "Oluganda"
   ],
   "lga": [
@@ -16506,7 +15172,6 @@
   "lgk": [
     "林加拉克語",
     "林加拉克语",
-    "Neverver",
     "Lingarak"
   ],
   "lgl": [
@@ -16548,6 +15213,9 @@
   "lgr": [
     "Lengo"
   ],
+  "lgs": [
+    "Guinea-Bissau Sign Language"
+  ],
   "lgt": [
     "Pahi"
   ],
@@ -16560,7 +15228,6 @@
   "lha": [
     "拉哈語（越南）",
     "拉哈语（越南）",
-    "Laha (Vietnam)",
     "Laha",
     "La Ha"
   ],
@@ -16570,12 +15237,12 @@
     "Central Ambon"
   ],
   "lhi": [
-    "Lahu Shi"
+    "拉祜西語",
+    "拉祜西语"
   ],
   "lhl": [
     "拉胡爾洛哈爾語",
-    "拉胡尔洛哈尔语",
-    "Lahul Lohar"
+    "拉胡尔洛哈尔语"
   ],
   "lhn": [
     "Lahanan"
@@ -16591,8 +15258,7 @@
   ],
   "lhu": [
     "拉祜語",
-    "拉祜语",
-    "Lahu"
+    "拉祜语"
   ],
   "li": [
     "林堡語",
@@ -16610,7 +15276,6 @@
   "lic": [
     "黎語",
     "黎语",
-    "Hlai",
     "Bouhin",
     "Heitu",
     "Ha Em",
@@ -16637,8 +15302,7 @@
   ],
   "lif": [
     "林布語",
-    "林布语",
-    "Limbu"
+    "林布语"
   ],
   "lig": [
     "Ligbi"
@@ -16651,16 +15315,14 @@
   ],
   "lij": [
     "利古里亞語",
-    "利古里亚语",
-    "Ligurian"
+    "利古里亚语"
   ],
   "lik": [
     "Lika"
   ],
   "lil": [
     "利洛厄特語",
-    "利洛厄特语",
-    "Lillooet"
+    "利洛厄特语"
   ],
   "lio": [
     "Liki"
@@ -16673,23 +15335,18 @@
   ],
   "lir": [
     "利比里亞英語",
-    "利比里亚英语",
-    "賴比瑞亞英語",
-    "赖比瑞亚英语",
-    "Liberian English"
+    "利比里亚英语"
   ],
   "lis": [
     "傈僳語",
-    "傈僳语",
-    "Lisu"
+    "傈僳语"
   ],
   "liu": [
     "Logorik"
   ],
   "liv": [
     "立窩尼亞語",
-    "立窝尼亚语",
-    "Livonian"
+    "立窝尼亚语"
   ],
   "liw": [
     "Col"
@@ -16717,16 +15374,14 @@
   ],
   "ljp": [
     "楠榜阿皮語",
-    "楠榜阿皮语",
-    "Lampung Api"
+    "楠榜阿皮语"
   ],
   "ljw": [
     "Yirandali"
   ],
   "ljx": [
     "尤魯語",
-    "尤鲁语",
-    "Yuru"
+    "尤鲁语"
   ],
   "lka": [
     "Lakalei"
@@ -16735,7 +15390,8 @@
     "Kabras"
   ],
   "lkc": [
-    "Kucong"
+    "苦聰話",
+    "苦聪话"
   ],
   "lkd": [
     "Lakondê"
@@ -16748,8 +15404,7 @@
   ],
   "lki": [
     "拉科語",
-    "拉科语",
-    "Laki"
+    "拉科语"
   ],
   "lkj": [
     "Remun"
@@ -16759,8 +15414,7 @@
   ],
   "lkm": [
     "卡拉馬雅語",
-    "卡拉马雅语",
-    "Kalaamaya"
+    "卡拉马雅语"
   ],
   "lkn": [
     "Lakon"
@@ -16777,13 +15431,11 @@
   "lkt": [
     "拉科塔語",
     "拉科塔语",
-    "Lakota",
     "Lakhota"
   ],
   "lku": [
     "昆卡里語",
-    "昆卡里语",
-    "Kungkari"
+    "昆卡里语"
   ],
   "lky": [
     "Lokoya"
@@ -16800,10 +15452,7 @@
   ],
   "lld": [
     "拉登語",
-    "拉登语",
-    "拉汀語",
-    "拉汀语",
-    "Ladin"
+    "拉登语"
   ],
   "lle": [
     "Lele (New Guinea)",
@@ -16826,7 +15475,6 @@
   "llj": [
     "拉吉拉吉語",
     "拉吉拉吉语",
-    "Ladji-Ladji",
     "Ledji-Ledji"
   ],
   "llk": [
@@ -16848,7 +15496,6 @@
   "llp": [
     "北埃法特語",
     "北埃法特语",
-    "North Efate",
     "Efate",
     "Vate",
     "Vaté",
@@ -16856,18 +15503,15 @@
   ],
   "llq": [
     "洛拉克語",
-    "洛拉克语",
-    "Lolak"
+    "洛拉克语"
   ],
   "lls": [
     "立陶宛手語",
-    "立陶宛手语",
-    "Lithuanian Sign Language"
+    "立陶宛手语"
   ],
   "llu": [
     "勞語",
-    "劳语",
-    "Lau"
+    "劳语"
   ],
   "llx": [
     "Lauan"
@@ -16880,8 +15524,7 @@
   ],
   "lmc": [
     "利米爾甘語",
-    "利米尔甘语",
-    "Limilngan"
+    "利米尔甘语"
   ],
   "lmd": [
     "Lumun"
@@ -16910,7 +15553,6 @@
   "lml": [
     "拉加語",
     "拉加语",
-    "Raga",
     "Hano",
     "Bwatvenua",
     "Lamalanga",
@@ -16920,16 +15562,12 @@
   "lmn": [
     "蘭巴蒂語",
     "兰巴蒂语",
-    "Lambadi",
     "Banjari",
     "Goar-boali"
   ],
   "lmo": [
     "倫巴底語",
-    "伦巴底语",
-    "倫巴第語",
-    "伦巴第语",
-    "Lombard"
+    "伦巴底语"
   ],
   "lmp": [
     "Limbum"
@@ -16955,7 +15593,6 @@
   "lmy": [
     "拉姆博亞語",
     "拉姆博亚语",
-    "Laboya",
     "Lamboya"
   ],
   "lmz": [
@@ -16964,8 +15601,6 @@
   "ln": [
     "林加拉語",
     "林加拉语",
-    "林格拉語",
-    "林格拉语",
     "Ngala"
   ],
   "lna": [
@@ -16976,8 +15611,7 @@
   ],
   "lnd": [
     "弄巴灣語",
-    "弄巴湾语",
-    "Lun Bawang"
+    "弄巴湾语"
   ],
   "lnh": [
     "Lanoh"
@@ -17017,8 +15651,7 @@
   "lo": [
     "老撾語",
     "老挝语",
-    "寮語",
-    "寮语"
+    "Laotian"
   ],
   "loa": [
     "Loloda"
@@ -17028,11 +15661,11 @@
   ],
   "loc": [
     "伊農罕語",
-    "伊农罕语",
-    "Inonhan"
+    "伊农罕语"
   ],
   "lod": [
-    "Berawan",
+    "伯拉萬語",
+    "伯拉万语",
     "Central Berawan",
     "East Berawan",
     "West Berawan",
@@ -17044,8 +15677,7 @@
   ],
   "loe": [
     "薩盧安語",
-    "萨卢安语",
-    "Saluan"
+    "萨卢安语"
   ],
   "lof": [
     "Logol"
@@ -17062,8 +15694,7 @@
   ],
   "loj": [
     "露語",
-    "露语",
-    "Lou"
+    "露语"
   ],
   "lok": [
     "Loko"
@@ -17101,7 +15732,6 @@
     "路易斯安那克里奧爾法語",
     "路易斯安那克里奥尔法语",
     "Louisiana Creole French",
-    "Louisiana Creole",
     "Kréyol"
   ],
   "lov": [
@@ -17115,8 +15745,7 @@
   ],
   "loz": [
     "洛齊語",
-    "洛齐语",
-    "Lozi"
+    "洛齐语"
   ],
   "lpa": [
     "Lelepa"
@@ -17130,7 +15759,6 @@
   "lpo": [
     "里潑語",
     "里泼语",
-    "Lipo",
     "Eastern Lisu"
   ],
   "lpx": [
@@ -17141,8 +15769,7 @@
   ],
   "lrc": [
     "北盧里語",
-    "北卢里语",
-    "Northern Luri"
+    "北卢里语"
   ],
   "lre": [
     "Laurentian",
@@ -17150,8 +15777,7 @@
   ],
   "lrg": [
     "拉拉吉亞語",
-    "拉拉吉亚语",
-    "Laragia"
+    "拉拉吉亚语"
   ],
   "lri": [
     "Marachi"
@@ -17159,14 +15785,14 @@
   "lrk": [
     "洛亞基語",
     "洛亚基语",
-    "Loarki",
     "Gade Lohar"
   ],
   "lrl": [
     "拉里語",
     "拉里语",
+    "Achomi",
     "Lari",
-    "Achomi"
+    "Khodmooni"
   ],
   "lrm": [
     "Marama"
@@ -17195,8 +15821,7 @@
   ],
   "lsa": [
     "拉斯格爾迪語",
-    "拉斯格尔迪语",
-    "Lasgerdi"
+    "拉斯格尔迪语"
   ],
   "lsd": [
     "Lishana Deni",
@@ -17211,15 +15836,13 @@
   "lsi": [
     "勒期語",
     "勒期语",
-    "Lashi",
     "Lacid",
     "Lachik",
     "Leqi"
   ],
   "lsl": [
     "拉脫維亞手語",
-    "拉脱维亚手语",
-    "Latvian Sign Language"
+    "拉脱维亚手语"
   ],
   "lsm": [
     "Saamia"
@@ -17227,15 +15850,11 @@
   "lso": [
     "老撾手語",
     "老挝手语",
-    "寮國手語",
-    "寮国手语",
-    "Laos Sign Language",
     "Laotian Sign Language"
   ],
   "lsp": [
     "巴拿馬手語",
-    "巴拿马手语",
-    "Panamanian Sign Language"
+    "巴拿马手语"
   ],
   "lsr": [
     "Aruop",
@@ -17245,20 +15864,15 @@
   ],
   "lss": [
     "臘斯語",
-    "腊斯语",
-    "Lasi"
+    "腊斯语"
   ],
   "lst": [
     "千里達及托巴哥手語",
-    "千里达及托巴哥手语",
-    "Trinidad and Tobago Sign Language"
+    "千里达及托巴哥手语"
   ],
   "lsy": [
     "毛里求斯手語",
-    "毛里求斯手语",
-    "模里西斯手語",
-    "模里西斯手语",
-    "Mauritian Sign Language"
+    "毛里求斯手语"
   ],
   "lt": [
     "立陶宛語",
@@ -17266,15 +15880,11 @@
   ],
   "ltc": [
     "中古漢語",
-    "中古汉语",
-    "Middle Chinese",
-    "Late Middle Chinese",
-    "Early Middle Chinese"
+    "中古汉语"
   ],
   "ltg": [
     "拉特加萊語",
-    "拉特加莱语",
-    "Latgalian"
+    "拉特加莱语"
   ],
   "lti": [
     "勒蒂語",
@@ -17309,7 +15919,6 @@
   "lud": [
     "盧迪茨語",
     "卢迪茨语",
-    "Ludian",
     "Ludic",
     "Lude"
   ],
@@ -17345,7 +15954,6 @@
   "luo": [
     "盧歐語",
     "卢欧语",
-    "Luo",
     "Dholuo"
   ],
   "lup": [
@@ -17360,32 +15968,27 @@
   "lus": [
     "米佐語",
     "米佐语",
-    "Mizo",
     "Lushai",
     "Lushei"
   ],
   "lut": [
     "盧紹錫德語",
-    "卢绍锡德语",
-    "Lushootseed"
+    "卢绍锡德语"
   ],
   "luu": [
     "Lumba-Yakkha"
   ],
   "luv": [
     "魯瓦蒂語",
-    "鲁瓦蒂语",
-    "Luwati"
+    "鲁瓦蒂语"
   ],
   "luy": [
     "盧希亞語",
-    "卢希亚语",
-    "Luhya"
+    "卢希亚语"
   ],
   "luz": [
     "南盧里語",
-    "南卢里语",
-    "Southern Luri"
+    "南卢里语"
   ],
   "lv": [
     "拉脫維亞語",
@@ -17423,18 +16026,15 @@
   ],
   "lwh": [
     "白拉基語",
-    "白拉基语",
-    "White Lachi"
+    "白拉基语"
   ],
   "lwl": [
     "東拉威語",
-    "东拉威语",
-    "Eastern Lawa"
+    "东拉威语"
   ],
   "lwm": [
     "老緬語",
-    "老缅语",
-    "Laomian"
+    "老缅语"
   ],
   "lwo": [
     "Luwo",
@@ -17443,8 +16043,7 @@
   ],
   "lws": [
     "馬拉威手語",
-    "马拉威手语",
-    "Malawian Sign Language"
+    "马拉威手语"
   ],
   "lwt": [
     "Lewotobi"
@@ -17461,15 +16060,13 @@
   "lyg": [
     "林甘語",
     "林甘语",
-    "Lyngngam"
+    "Lyngam"
   ],
   "lyn": [
     "Luyana"
   ],
   "lzh": [
-    "文言文",
-    "文言",
-    "Literary Chinese"
+    "文言文"
   ],
   "lzl": [
     "Litzlitz"
@@ -17479,23 +16076,19 @@
   ],
   "lzz": [
     "拉茲語",
-    "拉兹语",
-    "Laz"
+    "拉兹语"
   ],
   "maa": [
     "聖赫羅尼莫特科阿特爾馬薩特克語",
-    "圣赫罗尼莫特科阿特尔马萨特克语",
-    "San Jerónimo Tecóatl Mazatec"
+    "圣赫罗尼莫特科阿特尔马萨特克语"
   ],
   "mab": [
     "尤坦杜奇米斯特克語",
-    "尤坦杜奇米斯特克语",
-    "Yutanduchi Mixtec"
+    "尤坦杜奇米斯特克语"
   ],
   "mad": [
     "馬都拉語",
-    "马都拉语",
-    "Madurese"
+    "马都拉语"
   ],
   "mae": [
     "Bo-Rukul"
@@ -17506,30 +16099,23 @@
   ],
   "mag": [
     "馬加希語",
-    "马加希语",
-    "Magahi"
+    "马加希语"
   ],
   "mai": [
     "邁蒂利語",
-    "迈蒂利语",
-    "Maithili",
-    "邁提利語",
-    "迈提利语"
+    "迈蒂利语"
   ],
   "maj": [
     "哈拉佩德迪亞茲馬薩特克語",
-    "哈拉佩德迪亚兹马萨特克语",
-    "Jalapa de Díaz Mazatec"
+    "哈拉佩德迪亚兹马萨特克语"
   ],
   "mak": [
     "望加錫語",
-    "望加锡语",
-    "Makasar"
+    "望加锡语"
   ],
   "mam": [
     "馬姆語",
-    "马姆语",
-    "Mam"
+    "马姆语"
   ],
   "man": [
     "曼丁哥語",
@@ -17537,85 +16123,64 @@
   ],
   "map-ata-pro": [
     "原始泰雅語",
-    "原始泰雅语",
-    "Proto-Atayalic"
+    "原始泰雅语"
   ],
   "map-bms": [
     "班尤馬山語",
-    "班尤马山语",
-    "Banyumasan"
+    "班尤马山语"
   ],
   "map-kxv": [
     "噶哈巫語",
-    "噶哈巫语",
-    "Kaxabu",
-    "Kahabu",
-    "Kahapu"
+    "噶哈巫语"
   ],
   "map-pro": [
     "原始南島語",
-    "原始南岛语",
-    "Proto-Austronesian"
+    "原始南岛语"
   ],
   "map-trv": [
     "太魯閣語",
-    "太鲁阁语",
-    "Truku",
-    "Taroko"
+    "太鲁阁语"
   ],
   "map-twk": [
     "道卡斯語",
-    "道卡斯语",
-    "Taokas",
-    "Taukat",
-    "Taukan"
+    "道卡斯语"
   ],
   "maq": [
     "奇危特蘭馬薩特克語",
-    "奇危特兰马萨特克语",
-    "Chiquihuitlán Mazatec"
+    "奇危特兰马萨特克语"
   ],
   "mas": [
     "馬賽語",
-    "马赛语",
-    "Maasai"
+    "马赛语"
   ],
   "mat": [
     "馬特拉爾辛卡語",
     "马特拉尔辛卡语",
-    "Matlatzinca",
-    "聖弗朗西斯科馬特拉爾辛卡語",
-    "圣弗朗西斯科马特拉尔辛卡语",
     "San Francisco Matlatzinca",
     "San Francisco Oxtotilpa Matlatzinca"
   ],
   "mau": [
     "瓦烏特拉馬薩特克語",
-    "瓦乌特拉马萨特克语",
-    "Huautla Mazatec"
+    "瓦乌特拉马萨特克语"
   ],
   "mav": [
     "Sateré-Mawé"
   ],
   "maw": [
     "曼普魯西語",
-    "曼普鲁西语",
-    "Mampruli"
+    "曼普鲁西语"
   ],
   "max": [
     "北摩鹿加馬來語",
-    "北摩鹿加马来语",
-    "North Moluccan Malay"
+    "北摩鹿加马来语"
   ],
   "maz": [
     "中馬薩瓦語",
-    "中马萨瓦语",
-    "Central Mazahua"
+    "中马萨瓦语"
   ],
   "mba": [
     "希高農語",
-    "希高农语",
-    "Higaonon"
+    "希高农语"
   ],
   "mbb": [
     "西布基農-馬諾博語",
@@ -17632,8 +16197,7 @@
   ],
   "mbd": [
     "迪巴巴旺-馬諾博語",
-    "迪巴巴旺-马诺博语",
-    "Dibabawon Manobo"
+    "迪巴巴旺-马诺博语"
   ],
   "mbe": [
     "Molale",
@@ -17643,8 +16207,7 @@
   ],
   "mbf": [
     "峇峇馬來語",
-    "峇峇马来语",
-    "Baba Malay"
+    "峇峇马来语"
   ],
   "mbh": [
     "Mangseng"
@@ -17703,18 +16266,15 @@
   "mbx": [
     "塞皮克馬里語",
     "塞皮克马里语",
-    "Sepik Mari",
     "Mari (East Sepik Province)"
   ],
   "mby": [
     "梅莫尼語",
-    "梅莫尼语",
-    "Memoni"
+    "梅莫尼语"
   ],
   "mbz": [
     "阿莫爾特佩卡米斯特克語",
-    "阿莫尔特佩卡米斯特克语",
-    "Amoltepec Mixtec"
+    "阿莫尔特佩卡米斯特克语"
   ],
   "mca": [
     "Maca"
@@ -17730,8 +16290,7 @@
   ],
   "mce": [
     "伊通杜希亞米斯特克語",
-    "伊通杜希亚米斯特克语",
-    "Itundujia Mixtec"
+    "伊通杜希亚米斯特克语"
   ],
   "mcf": [
     "Matsés"
@@ -17764,7 +16323,6 @@
   "mcm": [
     "馬六甲克里奧爾葡萄牙語",
     "马六甲克里奥尔葡萄牙语",
-    "Kristang",
     "Malacca Creole Portuguese",
     "Malaccan Creole Portuguese"
   ],
@@ -17775,16 +16333,14 @@
   ],
   "mco": [
     "科阿特蘭米塞語",
-    "科阿特兰米塞语",
-    "Coatlán Mixe"
+    "科阿特兰米塞语"
   ],
   "mcp": [
     "Makaa"
   ],
   "mcq": [
     "埃塞語",
-    "埃塞语",
-    "Ese"
+    "埃塞语"
   ],
   "mcr": [
     "Menya"
@@ -17799,7 +16355,8 @@
     "Minanibai"
   ],
   "mcw": [
-    "Mawa",
+    "馬瓦語",
+    "马瓦语",
     "Mawa (Chad)",
     "Mahwa"
   ],
@@ -17808,8 +16365,7 @@
   ],
   "mcy": [
     "南瓦圖特語",
-    "南瓦图特语",
-    "South Watut"
+    "南瓦图特语"
   ],
   "mcz": [
     "Mawan"
@@ -17834,7 +16390,6 @@
   "mdf": [
     "莫克沙語",
     "莫克沙语",
-    "Moksha",
     "Mordvin"
   ],
   "mdg": [
@@ -17843,7 +16398,7 @@
   "mdh": [
     "馬京達瑙語",
     "马京达瑙语",
-    "Maguindanao"
+    "Maguindanaon"
   ],
   "mdi": [
     "Mamvu"
@@ -17856,8 +16411,7 @@
   ],
   "mdl": [
     "馬爾他手語",
-    "马尔他手语",
-    "Maltese Sign Language"
+    "马尔他手语"
   ],
   "mdm": [
     "Mayogo"
@@ -17873,8 +16427,7 @@
   ],
   "mdr": [
     "曼達爾語",
-    "曼达尔语",
-    "Mandar"
+    "曼达尔语"
   ],
   "mds": [
     "Maria",
@@ -17889,8 +16442,7 @@
   ],
   "mdv": [
     "聖盧西亞蒙泰韋爾米斯特克語",
-    "圣卢西亚蒙泰韦尔米斯特克语",
-    "Santa Lucía Monteverde Mixtec"
+    "圣卢西亚蒙泰韦尔米斯特克语"
   ],
   "mdw": [
     "Mbosi"
@@ -17916,7 +16468,6 @@
   "mec": [
     "瑪拉語",
     "玛拉语",
-    "Mara",
     "Leelawarra",
     "Leelalwarra",
     "Mala",
@@ -17936,8 +16487,7 @@
   ],
   "meh": [
     "西南特拉夏科米斯特克語",
-    "西南特拉夏科米斯特克语",
-    "Southwestern Tlaxiaco Mixtec"
+    "西南特拉夏科米斯特克语"
   ],
   "mei": [
     "Midob"
@@ -17945,19 +16495,16 @@
   "mej": [
     "梅亞赫語",
     "梅亚赫语",
-    "Meyah",
     "Mejah",
     "Meax"
   ],
   "mek": [
     "梅凱奧語",
-    "梅凯奥语",
-    "Mekeo"
+    "梅凯奥语"
   ],
   "mel": [
     "中馬蘭諾語",
-    "中马兰诺语",
-    "Central Melanau"
+    "中马兰诺语"
   ],
   "mem": [
     "Mangala"
@@ -17969,7 +16516,8 @@
   "meo": [
     "吉打馬來語",
     "吉打马来语",
-    "Kedah Malay"
+    "Syburi Malay",
+    "Satun Malay"
   ],
   "mep": [
     "Miriwung"
@@ -17979,8 +16527,7 @@
   ],
   "mer": [
     "梅魯語",
-    "梅鲁语",
-    "Meru"
+    "梅鲁语"
   ],
   "mes": [
     "Masmaje"
@@ -17994,7 +16541,6 @@
   "meu": [
     "莫圖語",
     "莫图语",
-    "Motu",
     "Pure Motu",
     "True Motu"
   ],
@@ -18006,16 +16552,14 @@
   ],
   "mey": [
     "哈桑語",
-    "哈桑语",
-    "Hassaniya"
+    "哈桑语"
   ],
   "mez": [
     "Menominee"
   ],
   "mfa": [
     "北大年馬來語",
-    "北大年马来语",
-    "Pattani Malay"
+    "北大年马来语"
   ],
   "mfb": [
     "Bangka"
@@ -18029,7 +16573,6 @@
   "mfe": [
     "毛里求斯克里奧爾語",
     "毛里求斯克里奥尔语",
-    "Mauritian Creole",
     "Mauritian"
   ],
   "mff": [
@@ -18043,8 +16586,7 @@
   ],
   "mfh": [
     "馬特爾語",
-    "马特尔语",
-    "Matal"
+    "马特尔语"
   ],
   "mfi": [
     "Wandala",
@@ -18070,8 +16612,7 @@
   ],
   "mfp": [
     "望加錫馬來語",
-    "望加锡马来语",
-    "Makassar Malay"
+    "望加锡马来语"
   ],
   "mfq": [
     "Moba"
@@ -18079,7 +16620,6 @@
   "mfr": [
     "馬里蒂爾語",
     "马里蒂尔语",
-    "Marrithiyel",
     "Marrithiyal",
     "Marithiel",
     "Maridhiel",
@@ -18104,8 +16644,7 @@
   ],
   "mfs": [
     "墨西哥手語",
-    "墨西哥手语",
-    "Mexican Sign Language"
+    "墨西哥手语"
   ],
   "mft": [
     "Mokerang"
@@ -18124,24 +16663,18 @@
   ],
   "mfy": [
     "馬約語",
-    "马约语",
-    "Mayo"
+    "马约语"
   ],
   "mfz": [
     "Mabaan"
   ],
   "mg": [
     "馬拉加斯語",
-    "马拉加斯语",
-    "馬達加斯加語",
-    "马达加斯加语",
-    "馬爾加什語",
-    "马尔加什语"
+    "马拉加斯语"
   ],
   "mga": [
     "中古愛爾蘭語",
-    "中古爱尔兰语",
-    "Middle Irish"
+    "中古爱尔兰语"
   ],
   "mgb": [
     "Mararit"
@@ -18192,53 +16725,47 @@
   ],
   "mgp": [
     "東馬嘉爾語",
-    "东马嘉尔语",
-    "Eastern Magar"
+    "东马嘉尔语"
   ],
   "mgq": [
     "Malila"
   ],
   "mgr": [
     "曼布韋-倫古語",
-    "曼布韦-伦古语",
-    "Mambwe-Lungu"
+    "曼布韦-伦古语"
   ],
   "mgs": [
     "曼達語（坦桑尼亞）",
     "曼达语（坦桑尼亚）",
-    "Manda (Tanzania)",
     "Kimanda",
     "Kinyasa",
     "Nyasa"
   ],
   "mgt": [
-    "Mongol"
+    "姆阿凱語",
+    "姆阿凯语"
   ],
   "mgu": [
     "Mailu"
   ],
   "mgv": [
     "馬滕戈語",
-    "马滕戈语",
-    "Matengo"
+    "马滕戈语"
   ],
   "mgw": [
     "馬通比語",
     "马通比语",
-    "Matumbi",
     "Matuumbi",
     "Kimatumbi",
     "Kimatuumbi"
   ],
   "mgy": [
     "姆邦加語",
-    "姆邦加语",
-    "Mbunga"
+    "姆邦加语"
   ],
   "mgz": [
     "姆布圭語",
-    "姆布圭语",
-    "Mbugwe"
+    "姆布圭语"
   ],
   "mh": [
     "馬紹爾語",
@@ -18246,18 +16773,15 @@
   ],
   "mha": [
     "曼達語（印度）",
-    "曼达语（印度）",
-    "Manda (India)"
+    "曼达语（印度）"
   ],
   "mhb": [
     "馬洪圭語",
-    "马洪圭语",
-    "Mahongwe"
+    "马洪圭语"
   ],
   "mhc": [
     "莫喬語",
-    "莫乔语",
-    "Mocho"
+    "莫乔语"
   ],
   "mhd": [
     "Mbugu",
@@ -18266,15 +16790,15 @@
     "Inner Mbugu"
   ],
   "mhe": [
-    "Besisi"
+    "Besisi",
+    "Mah Meri"
   ],
   "mhf": [
     "Mamaa"
   ],
   "mhg": [
     "馬爾古語",
-    "马尔古语",
-    "Margu"
+    "马尔古语"
   ],
   "mhi": [
     "Ma'di"
@@ -18282,7 +16806,6 @@
   "mhj": [
     "蒙戈勒語",
     "蒙戈勒语",
-    "Mogholi",
     "Moghol"
   ],
   "mhk": [
@@ -18296,16 +16819,14 @@
   ],
   "mhn": [
     "默切諾語",
-    "默切诺语",
-    "Mòcheno"
+    "默切诺语"
   ],
   "mho": [
     "Mashi"
   ],
   "mhp": [
     "峇里馬來語",
-    "峇里马来语",
-    "Balinese Malay"
+    "峇里马来语"
   ],
   "mhq": [
     "Mandan"
@@ -18313,7 +16834,13 @@
   "mhr": [
     "東馬里語",
     "东马里语",
-    "Eastern Mari"
+    "Meadow Mari",
+    "Lowland Mari",
+    "Midland Mari",
+    "Standard Mari",
+    "Upo Mari",
+    "Mari",
+    "Mari (Russia)"
   ],
   "mhs": [
     "Buru (Indonesia)",
@@ -18328,7 +16855,8 @@
     "Mandauáka"
   ],
   "mhu": [
-    "Taraon",
+    "達讓語",
+    "达让语",
     "Darang",
     "Digaro-Mishmi",
     "Digaro Mishmi"
@@ -18337,7 +16865,8 @@
     "Mbukushu"
   ],
   "mhx": [
-    "Lhao Vo",
+    "浪速語",
+    "浪速语",
     "Langsu",
     "Maru"
   ],
@@ -18360,23 +16889,19 @@
   ],
   "mib": [
     "阿塔特拉烏卡米斯特克語",
-    "阿塔特拉乌卡米斯特克语",
-    "Atatláhuca Mixtec"
+    "阿塔特拉乌卡米斯特克语"
   ],
   "mic": [
     "密克馬克語",
-    "密克马克语",
-    "Mi'kmaq"
+    "密克马克语"
   ],
   "mid": [
     "曼達安語",
-    "曼达安语",
-    "Mandaic"
+    "曼达安语"
   ],
   "mie": [
     "奧科特佩克米斯特克語",
-    "奥科特佩克米斯特克语",
-    "Ocotepec Mixtec"
+    "奥科特佩克米斯特克语"
   ],
   "mif": [
     "Mofu-Gudur"
@@ -18384,17 +16909,15 @@
   "mig": [
     "大聖米蓋爾米斯特克語",
     "大圣米盖尔米斯特克语",
-    "San Miguel el Grande Mixtec"
+    "Chalcatongo Mixtec"
   ],
   "mih": [
     "查尤科米斯特克語",
-    "查尤科米斯特克语",
-    "Chayuco Mixtec"
+    "查尤科米斯特克语"
   ],
   "mii": [
     "奇格梅卡蒂特蘭米斯特克語",
-    "奇格梅卡蒂特兰米斯特克语",
-    "Chigmecatitlán Mixtec"
+    "奇格梅卡蒂特兰米斯特克语"
   ],
   "mij": [
     "Mungbam",
@@ -18405,76 +16928,59 @@
   ],
   "mik": [
     "密卡蘇奇語",
-    "密卡苏奇语",
-    "Mikasuki"
+    "密卡苏奇语"
   ],
   "mil": [
     "佩諾爾斯米斯特克語",
-    "佩诺尔斯米斯特克语",
-    "Peñoles Mixtec"
+    "佩诺尔斯米斯特克语"
   ],
   "mim": [
     "阿拉卡特拉扎拉米斯特克語",
-    "阿拉卡特拉扎拉米斯特克语",
-    "Alacatlatzala Mixtec"
+    "阿拉卡特拉扎拉米斯特克语"
   ],
   "min": [
     "米南佳保語",
-    "米南佳保语",
-    "米南加保語",
-    "米南加保语",
-    "米南卡保語",
-    "米南卡保语",
-    "Minangkabau"
+    "米南佳保语"
   ],
   "mio": [
     "皮諾特帕納雄耐爾米斯特克語",
-    "皮诺特帕纳雄耐尔米斯特克语",
-    "Pinotepa Nacional Mixtec"
+    "皮诺特帕纳雄耐尔米斯特克语"
   ],
   "mip": [
     "阿帕斯科-阿波亞拉米斯特克語",
-    "阿帕斯科-阿波亚拉米斯特克语",
-    "Apasco-Apoala Mixtec"
+    "阿帕斯科-阿波亚拉米斯特克语"
   ],
   "miq": [
     "米斯基托語",
     "米斯基托语",
-    "Miskito",
     "Miskitu"
   ],
   "mir": [
     "地峽米塞語",
-    "地峡米塞语",
-    "Isthmus Mixe"
+    "地峡米塞语"
   ],
   "mit": [
     "南普埃布拉米斯特克語",
-    "南普埃布拉米斯特克语",
-    "Southern Puebla Mixtec"
+    "南普埃布拉米斯特克语"
   ],
   "miu": [
     "卡卡洛斯特佩克米斯特克語",
-    "卡卡洛斯特佩克米斯特克语",
-    "Cacaloxtepec Mixtec"
+    "卡卡洛斯特佩克米斯特克语"
   ],
   "miw": [
     "Akoye"
   ],
   "mix": [
     "米斯特佩克米斯特克語",
-    "米斯特佩克米斯特克语",
-    "Mixtepec Mixtec"
+    "米斯特佩克米斯特克语"
   ],
   "miy": [
     "阿尤特拉米斯特克語",
-    "阿尤特拉米斯特克语",
-    "Ayutla Mixtec"
+    "阿尤特拉米斯特克语"
   ],
   "miz": [
     "科亞佐斯潘米斯特克語",
-    "科亚佐斯潘米斯特克语",
-    "Coatzospan Mixtec"
+    "科亚佐斯潘米斯特克语"
   ],
   "mjb": [
     "Makalero",
@@ -18482,26 +16988,18 @@
   ],
   "mjc": [
     "聖胡安科羅拉多米斯特克語",
-    "圣胡安科罗拉多米斯特克语",
-    "San Juan Colorado Mixtec"
+    "圣胡安科罗拉多米斯特克语"
   ],
   "mjd": [
     "西北邁杜語",
-    "西北迈杜语",
-    "Northwest Maidu"
+    "西北迈杜语"
   ],
   "mje": [
     "Muskum"
   ],
-  "mjg": [
-    "土族語",
-    "土族语",
-    "Monguor"
-  ],
   "mji": [
     "金門語",
-    "金门语",
-    "Kim Mun"
+    "金门语"
   ],
   "mjj": [
     "Mawak"
@@ -18511,8 +17009,7 @@
   ],
   "mjl": [
     "曼迪阿里語",
-    "曼迪阿里语",
-    "Mandeali"
+    "曼迪阿里语"
   ],
   "mjm": [
     "Medebur"
@@ -18544,7 +17041,7 @@
     "Sawriya Pahariya",
     "Sawriya Malto",
     "Malto",
-    " Malti",
+    "Malti",
     "Maltu",
     "Maler"
   ],
@@ -18564,13 +17061,11 @@
   ],
   "mjy": [
     "莫希干語",
-    "莫希干语",
-    "Mahican"
+    "莫希干语"
   ],
   "mjz": [
     "邁希語",
-    "迈希语",
-    "Majhi"
+    "迈希语"
   ],
   "mk": [
     "馬其頓語",
@@ -18581,16 +17076,14 @@
   ],
   "mkb": [
     "馬爾帕哈里亞語",
-    "马尔帕哈里亚语",
-    "Mal Paharia"
+    "马尔帕哈里亚语"
   ],
   "mkc": [
     "Siliput"
   ],
   "mke": [
     "茂奇語",
-    "茂奇语",
-    "Mawchi"
+    "茂奇语"
   ],
   "mkf": [
     "Miya"
@@ -18598,86 +17091,67 @@
   "mkg": [
     "莫語",
     "莫语",
-    "Mak (China)",
     "Mak"
   ],
   "mkh-asl-pro": [
     "原始亞斯里語",
-    "原始亚斯里语",
-    "Proto-Aslian"
+    "原始亚斯里语"
   ],
   "mkh-ban-pro": [
     "原始巴拿語",
-    "原始巴拿语",
-    "Proto-Bahnaric"
+    "原始巴拿语"
   ],
   "mkh-kat-pro": [
     "原始戈都語",
-    "原始戈都语",
-    "Proto-Katuic"
+    "原始戈都语"
   ],
   "mkh-khm-pro": [
     "原始克木語",
-    "原始克木语",
-    "Proto-Khmuic"
+    "原始克木语"
   ],
   "mkh-kmr-pro": [
     "原始高棉語",
-    "原始高棉语",
-    "Proto-Khmeric"
+    "原始高棉语"
   ],
   "mkh-mmn": [
     "中古孟語",
-    "中古孟语",
-    "Middle Mon"
+    "中古孟语"
   ],
   "mkh-mnc-pro": [
     "原始孟語",
-    "原始孟语",
-    "Proto-Monic"
+    "原始孟语"
   ],
   "mkh-mvi": [
     "中古越南語",
-    "中古越南语",
-    "Middle Vietnamese"
-  ],
-  "mkh-okm": [
-    "古高棉語",
-    "古高棉语",
-    "Old Khmer"
+    "中古越南语"
   ],
   "mkh-pal-pro": [
     "原始佤德昂語",
-    "原始佤德昂语",
-    "Proto-Palaungic"
+    "原始佤德昂语"
   ],
   "mkh-pea-pro": [
     "原始比爾語",
-    "原始比尔语",
-    "Proto-Pearic"
+    "原始比尔语"
   ],
   "mkh-pkn-pro": [
-    "Proto-Pakanic"
+    "原始莽語",
+    "原始莽语"
   ],
   "mkh-pro": [
     "原始孟-高棉語",
-    "原始孟-高棉语",
-    "Proto-Mon-Khmer"
+    "原始孟-高棉语"
   ],
   "mkh-vie-pro": [
     "原始越語",
-    "原始越语",
-    "Proto-Vietic"
+    "原始越语"
   ],
   "mki": [
     "達特基語",
-    "达特基语",
-    "Dhatki"
+    "达特基语"
   ],
   "mkj": [
     "莫基爾語",
-    "莫基尔语",
-    "Mokilese"
+    "莫基尔语"
   ],
   "mkk": [
     "Byep"
@@ -18690,8 +17164,7 @@
   ],
   "mkn": [
     "古邦馬來語",
-    "古邦马来语",
-    "Kupang Malay"
+    "古邦马来语"
   ],
   "mko": [
     "Mingang Doso"
@@ -18704,13 +17177,11 @@
   ],
   "mkr": [
     "馬拉斯語",
-    "马拉斯语",
-    "Malas"
+    "马拉斯语"
   ],
   "mks": [
     "西拉卡約亞潘米斯特克語",
-    "西拉卡约亚潘米斯特克语",
-    "Silacayoapan Mixtec"
+    "西拉卡约亚潘米斯特克语"
   ],
   "mkt": [
     "Vamale"
@@ -18727,23 +17198,19 @@
   ],
   "mky": [
     "東馬基安語",
-    "东马基安语",
-    "East Makian",
-    "Taba"
+    "东马基安语"
   ],
   "mkz": [
-    "Makasae"
+    "馬卡莎語",
+    "马卡莎语"
   ],
   "ml": [
     "馬拉雅拉姆語",
-    "马拉雅拉姆语",
-    "馬拉亞拉姆語",
-    "马拉亚拉姆语"
+    "马拉雅拉姆语"
   ],
   "mla": [
     "塔馬姆博語",
     "塔马姆博语",
-    "Tamambo",
     "Malo",
     "Tamabo",
     "Maloese"
@@ -18754,7 +17221,6 @@
   "mlc": [
     "高欄語",
     "高栏语",
-    "Caolan",
     "Man Cao Lan"
   ],
   "mle": [
@@ -18762,7 +17228,8 @@
   ],
   "mlf": [
     "Mal",
-    "Thin"
+    "Thin",
+    "Prai"
   ],
   "mlh": [
     "Mape"
@@ -18781,8 +17248,7 @@
   ],
   "mlm": [
     "仫佬語",
-    "仫佬语",
-    "Mulam"
+    "仫佬语"
   ],
   "mln": [
     "Malango"
@@ -18806,7 +17272,6 @@
   "mlu": [
     "托阿巴伊塔語",
     "托阿巴伊塔语",
-    "To'abaita",
     "Toqabaqita"
   ],
   "mlv": [
@@ -18831,13 +17296,11 @@
   ],
   "mmc": [
     "米卻肯馬薩瓦語",
-    "米却肯马萨瓦语",
-    "Michoacán Mazahua"
+    "米却肯马萨瓦语"
   ],
   "mmd": [
     "毛南語",
-    "毛南语",
-    "Maonan"
+    "毛南语"
   ],
   "mme": [
     "Mae"
@@ -18865,13 +17328,11 @@
   ],
   "mmm": [
     "邁伊語",
-    "迈伊语",
-    "Maii"
+    "迈伊语"
   ],
   "mmn": [
     "瑪曼瓦語",
-    "玛曼瓦语",
-    "Mamanwa"
+    "玛曼瓦语"
   ],
   "mmo": [
     "Mangga Buang"
@@ -18882,15 +17343,13 @@
   "mmq": [
     "艾西語",
     "艾西语",
-    "Aisi",
     "Musak",
     "Mabɨŋ",
     "Mabing"
   ],
   "mmr": [
     "西部湘西苗語",
-    "西部湘西苗语",
-    "Western Xiangxi Miao"
+    "西部湘西苗语"
   ],
   "mmt": [
     "Malalamai"
@@ -18955,14 +17414,12 @@
   "mni": [
     "曼尼普爾語",
     "曼尼普尔语",
-    "Manipuri",
     "Meitei",
     "Meithei"
   ],
   "mnj": [
     "蒙賈尼語",
     "蒙贾尼语",
-    "Munji",
     "Munjani",
     "Mundzhan",
     "Mundzhani",
@@ -18971,7 +17428,6 @@
   "mnk": [
     "曼丁哥語",
     "曼丁哥语",
-    "Mandinka",
     "Mandingo"
   ],
   "mnl": [
@@ -18986,15 +17442,12 @@
   ],
   "mnp": [
     "閩北語",
-    "闽北语",
-    "Mâing-bă̤-ngṳ̌",
-    "閩北事",
-    "闽北事",
-    "Mâing-bă̤-dī",
-    "Min Bei"
+    "闽北语"
   ],
   "mnq": [
-    "Minriq"
+    "Minriq",
+    "Mendriq",
+    "Menriq"
   ],
   "mnr": [
     "Mono (California)",
@@ -19008,13 +17461,11 @@
   ],
   "mns": [
     "曼西語",
-    "曼西语",
-    "Mansi"
+    "曼西语"
   ],
   "mnt": [
     "馬伊庫蘭語",
     "马伊库兰语",
-    "Maykulan",
     "Mayi-Kulan",
     "Wunumara",
     "Mayi-Yapi",
@@ -19026,18 +17477,20 @@
   "mnv": [
     "拉納爾語",
     "拉纳尔语",
-    "倫內爾語",
-    "伦内尔语",
-    "Rennellese",
     "Rennell-Bellona"
   ],
   "mnw": [
     "孟語",
     "孟语",
-    "Mon",
     "Peguan",
     "Talaing",
     "Raman"
+  ],
+  "mnw-tha": [
+    "Thai Mon",
+    "Raman",
+    "Thai Raman",
+    "Siamese Mon"
   ],
   "mnx": [
     "Manikion",
@@ -19062,23 +17515,19 @@
   ],
   "mod": [
     "莫比爾語",
-    "莫比尔语",
-    "Mobilian"
+    "莫比尔语"
   ],
   "moe": [
     "蒙大拿語",
-    "蒙大拿语",
-    "Montagnais"
+    "蒙大拿语"
   ],
   "mog": [
     "蒙貢多語",
-    "蒙贡多语",
-    "Mongondow"
+    "蒙贡多语"
   ],
   "moh": [
     "莫霍克語",
-    "莫霍克语",
-    "Mohawk"
+    "莫霍克语"
   ],
   "moi": [
     "Mboi"
@@ -19095,14 +17544,12 @@
   "moo": [
     "莫儂語",
     "莫侬语",
-    "Monom",
     "Monam",
     "Bonam"
   ],
   "mop": [
     "莫潘瑪雅語",
     "莫潘玛雅语",
-    "Mopan Maya",
     "Mopan",
     "Mopán Maya",
     "Mopán"
@@ -19153,39 +17600,35 @@
     "Shekkacho"
   ],
   "moz": [
-    "Mukulu"
+    "Mukulu",
+    "Mokulu",
+    "Mokilko"
   ],
   "mpa": [
     "Mpoto"
   ],
   "mpb": [
     "馬拉克馬拉克語",
-    "马拉克马拉克语",
-    "Mullukmulluk",
-    "Malak-Malak"
+    "马拉克马拉克语"
   ],
   "mpc": [
     "曼加拉伊語",
-    "曼加拉伊语",
-    "Mangarayi"
+    "曼加拉伊语"
   ],
   "mpd": [
     "Machinere"
   ],
   "mpe": [
     "馬江語",
-    "马江语",
-    "Majang"
+    "马江语"
   ],
   "mpg": [
     "馬爾巴語",
-    "马尔巴语",
-    "Marba"
+    "马尔巴语"
   ],
   "mph": [
     "毛翁語",
-    "毛翁语",
-    "Maung"
+    "毛翁语"
   ],
   "mpi": [
     "Mpade"
@@ -19193,25 +17636,21 @@
   "mpj": [
     "馬圖汪加語",
     "马图汪加语",
-    "Martu Wangka",
     "Yulparija",
     "Yulparitja"
   ],
   "mpk": [
     "姆巴拉語（乍得）",
     "姆巴拉语（乍得）",
-    "Mbara (Chad)",
     "Mbara"
   ],
   "mpl": [
     "中瓦圖特語",
-    "中瓦图特语",
-    "Middle Watut"
+    "中瓦图特语"
   ],
   "mpm": [
     "約松杜亞米斯特克語",
-    "约松杜亚米斯特克语",
-    "Yosondúa Mixtec"
+    "约松杜亚米斯特克语"
   ],
   "mpn": [
     "Mindiri"
@@ -19277,16 +17716,14 @@
   ],
   "mqh": [
     "特拉索亞爾特佩克米斯特克語",
-    "特拉索亚尔特佩克米斯特克语",
-    "Yosondúa Mixtec"
+    "特拉索亚尔特佩克米斯特克语"
   ],
   "mqi": [
     "Mariri"
   ],
   "mqj": [
     "馬馬薩語",
-    "马马萨语",
-    "Mamasa"
+    "马马萨语"
   ],
   "mqk": [
     "拉賈卡本選-馬諾博語",
@@ -19297,8 +17734,7 @@
   ],
   "mqm": [
     "南馬克薩斯語",
-    "南马克萨斯语",
-    "South Marquesan"
+    "南马克萨斯语"
   ],
   "mqn": [
     "Moronene"
@@ -19317,8 +17753,7 @@
   ],
   "mqs": [
     "西馬基安語",
-    "西马基安语",
-    "West Makian"
+    "西马基安语"
   ],
   "mqt": [
     "Mok"
@@ -19337,8 +17772,7 @@
   ],
   "mqy": [
     "芒加萊語",
-    "芒加莱语",
-    "Manggarai"
+    "芒加莱语"
   ],
   "mqz": [
     "Malasanga",
@@ -19346,9 +17780,7 @@
   ],
   "mr": [
     "馬拉地語",
-    "马拉地语",
-    "馬拉提語",
-    "马拉提语"
+    "马拉地语"
   ],
   "mra": [
     "Mlabri"
@@ -19358,18 +17790,15 @@
   ],
   "mrc": [
     "馬里科帕語",
-    "马里科帕语",
-    "Maricopa"
+    "马里科帕语"
   ],
   "mrd": [
     "西馬嘉爾語",
-    "西马嘉尔语",
-    "Western Magar"
+    "西马嘉尔语"
   ],
   "mre": [
     "瑪莎葡萄園島手語",
-    "玛莎葡萄园岛手语",
-    "Martha's Vineyard Sign Language"
+    "玛莎葡萄园岛手语"
   ],
   "mrf": [
     "Elseng"
@@ -19394,9 +17823,6 @@
   "mrj": [
     "西馬里語",
     "西马里语",
-    "草原馬里語",
-    "草原马里语",
-    "Western Mari",
     "Hill Mari",
     "Mountain Mari",
     "Highland Mari"
@@ -19406,8 +17832,7 @@
   ],
   "mrl": [
     "莫特洛克語",
-    "莫特洛克语",
-    "Mortlockese"
+    "莫特洛克语"
   ],
   "mrm": [
     "Merlav"
@@ -19415,21 +17840,18 @@
   "mrn": [
     "切克霍羅語",
     "切克霍罗语",
-    "Cheke Holo",
     "Maringe"
   ],
   "mro": [
     "姆魯語",
-    "姆鲁语",
-    "Mru"
+    "姆鲁语"
   ],
   "mrp": [
     "Morouas"
   ],
   "mrq": [
     "北馬克薩斯語",
-    "北马克萨斯语",
-    "North Marquesan"
+    "北马克萨斯语"
   ],
   "mrr": [
     "Hill Maria",
@@ -19441,8 +17863,7 @@
   ],
   "mrs": [
     "馬拉古斯語",
-    "马拉古斯语",
-    "Maragus"
+    "马拉古斯语"
   ],
   "mrt": [
     "Margi",
@@ -19455,18 +17876,15 @@
   ],
   "mrv": [
     "曼加瑞瓦語",
-    "曼加瑞瓦语",
-    "Mangarevan"
+    "曼加瑞瓦语"
   ],
   "mrw": [
     "馬拉瑙語",
-    "马拉瑙语",
-    "Maranao"
+    "马拉瑙语"
   ],
   "mrx": [
     "迪內奧爾語",
-    "迪内奥尔语",
-    "Dineor"
+    "迪内奥尔语"
   ],
   "mry": [
     "Karaga Mandaya"
@@ -19478,13 +17896,11 @@
     "馬來語",
     "马来语",
     "Malaysian",
-    "標準馬來語",
-    "标准马来语"
+    "Standard Malay"
   ],
   "msb": [
     "馬斯巴特語",
     "马斯巴特语",
-    "Masbatenyo",
     "Masbateño",
     "Masbateno",
     "Minasbate"
@@ -19494,8 +17910,7 @@
   ],
   "msd": [
     "猶加敦瑪雅手語",
-    "犹加敦玛雅手语",
-    "Yucatec Maya Sign Language"
+    "犹加敦玛雅手语"
   ],
   "mse": [
     "Musey"
@@ -19510,8 +17925,7 @@
   ],
   "msi": [
     "沙巴馬來語",
-    "沙巴马来语",
-    "Sabah Malay"
+    "沙巴马来语"
   ],
   "msj": [
     "Ma",
@@ -19519,8 +17933,7 @@
   ],
   "msk": [
     "曼薩卡語",
-    "曼萨卡语",
-    "Mansaka"
+    "曼萨卡语"
   ],
   "msl": [
     "Molof"
@@ -19531,8 +17944,7 @@
   ],
   "msn": [
     "烏雷斯語",
-    "乌雷斯语",
-    "Vurës"
+    "乌雷斯语"
   ],
   "mso": [
     "Mombum"
@@ -19547,8 +17959,7 @@
   ],
   "msr": [
     "蒙古手語",
-    "蒙古手语",
-    "Mongolian Sign Language"
+    "蒙古手语"
   ],
   "mss": [
     "West Masela"
@@ -19573,9 +17984,7 @@
   ],
   "mt": [
     "馬爾他語",
-    "马尔他语",
-    "馬耳他語",
-    "马耳他语"
+    "马尔他语"
   ],
   "mta": [
     "哥打巴托-馬諾博語",
@@ -19593,7 +18002,6 @@
   "mte": [
     "阿盧語",
     "阿卢语",
-    "Alu",
     "Mono",
     "Mono-Alu"
   ],
@@ -19626,7 +18034,6 @@
   "mtm": [
     "馬托爾語",
     "马托尔语",
-    "Mator",
     "Taygi",
     "Karagas",
     "Mator-Taygi-Karagas"
@@ -19636,16 +18043,14 @@
   ],
   "mto": [
     "特通特佩克米塞語",
-    "特通特佩克米塞语",
-    "Totontepec Mixe"
+    "特通特佩克米塞语"
   ],
   "mtp": [
     "Wichí Lhamtés Nocten"
   ],
   "mtq": [
     "芒語",
-    "芒语",
-    "Muong"
+    "芒语"
   ],
   "mtr": [
     "梅瓦爾語",
@@ -19659,13 +18064,11 @@
   ],
   "mtu": [
     "圖圖特佩克米斯特克語",
-    "图图特佩克米斯特克语",
-    "Tututepec Mixtec"
+    "图图特佩克米斯特克语"
   ],
   "mtv": [
     "阿薩羅奧語",
     "阿萨罗奥语",
-    "Asaro'o",
     "Molet",
     "Molet Kasu",
     "Molet Mur"
@@ -19675,8 +18078,7 @@
   ],
   "mtx": [
     "蒂達亞米斯特克語",
-    "蒂达亚米斯特克语",
-    "Tidaá Mixtec"
+    "蒂达亚米斯特克语"
   ],
   "mty": [
     "Nabi"
@@ -19699,8 +18101,7 @@
   ],
   "mug": [
     "穆斯古語",
-    "穆斯古语",
-    "Musgu"
+    "穆斯古语"
   ],
   "muh": [
     "Mündü",
@@ -19709,9 +18110,6 @@
   "mui": [
     "穆西語",
     "穆西语",
-    "Musi",
-    "巨港馬來語",
-    "巨港马来语",
     "Palembang Malay",
     "Basa Pelembang Sari-sari",
     "Sekayu"
@@ -19721,8 +18119,7 @@
   ],
   "mul": [
     "跨語言",
-    "跨语言",
-    "Translingual"
+    "跨语言"
   ],
   "mum": [
     "Maiwala"
@@ -19730,7 +18127,6 @@
   "mun-pro": [
     "原始蒙達語",
     "原始蒙达语",
-    "Proto-Munda",
     "Proto-Mundan"
   ],
   "muo": [
@@ -19738,13 +18134,11 @@
   ],
   "mup": [
     "馬爾瓦語",
-    "马尔瓦语",
-    "Malvi"
+    "马尔瓦语"
   ],
   "muq": [
     "西部湘西苗語",
-    "西部湘西苗语",
-    "Eastern Xiangxi Miao"
+    "西部湘西苗语"
   ],
   "mur": [
     "Murle"
@@ -19752,13 +18146,11 @@
   "mus": [
     "克里克語",
     "克里克语",
-    "Creek",
     "Muscogee"
   ],
   "mut": [
     "西穆里亞語",
-    "西穆里亚语",
-    "Western Muria"
+    "西穆里亚语"
   ],
   "muu": [
     "Yaaku"
@@ -19777,8 +18169,7 @@
   ],
   "mva": [
     "馬納姆語",
-    "马纳姆语",
-    "Manam"
+    "马纳姆语"
   ],
   "mvb": [
     "Mattole"
@@ -19788,16 +18179,14 @@
   ],
   "mvg": [
     "尤夸涅米斯特克語",
-    "尤夸涅米斯特克语",
-    "Yucuañe Mixtec"
+    "尤夸涅米斯特克语"
   ],
   "mvh": [
     "Mire"
   ],
   "mvi": [
     "宮古語",
-    "宫古语",
-    "Miyako"
+    "宫古语"
   ],
   "mvk": [
     "Mekmek"
@@ -19805,12 +18194,12 @@
   "mvl": [
     "姆巴拉語（澳洲）",
     "姆巴拉语（澳洲）",
-    "Mbara (Australia)",
     "Mbara",
     "Midjamba"
   ],
   "mvm": [
-    "Muya"
+    "木雅語",
+    "木雅语"
   ],
   "mvn": [
     "Minaveha"
@@ -19838,8 +18227,7 @@
   ],
   "mvv": [
     "塔戈爾語",
-    "塔戈尔语",
-    "Tagal Murut"
+    "塔戈尔语"
   ],
   "mvw": [
     "Machinga"
@@ -19849,11 +18237,14 @@
   ],
   "mvy": [
     "印度河科希斯坦語",
-    "印度河科希斯坦语",
-    "Indus Kohistani"
+    "印度河科希斯坦语"
   ],
   "mvz": [
-    "Mesqan"
+    "Mesqan",
+    "Masqan",
+    "Maskan",
+    "Meskan",
+    "Mäsqan"
   ],
   "mwa": [
     "Mwatebu"
@@ -19872,8 +18263,7 @@
   ],
   "mwf": [
     "穆林帕塔語",
-    "穆林帕塔语",
-    "Murrinh-Patha"
+    "穆林帕塔语"
   ],
   "mwg": [
     "Aiklep"
@@ -19889,8 +18279,7 @@
   ],
   "mwl": [
     "米蘭德斯語",
-    "米兰德斯语",
-    "Mirandese"
+    "米兰德斯语"
   ],
   "mwm": [
     "Sar"
@@ -19903,8 +18292,7 @@
   ],
   "mwp": [
     "卡拉拉高雅語",
-    "卡拉拉高雅语",
-    "Kala Lagaw Ya"
+    "卡拉拉高雅语"
   ],
   "mwq": [
     "Mün Chin",
@@ -19914,9 +18302,7 @@
   "mwr": [
     "馬瓦里語",
     "马瓦里语",
-    "Marwari",
     "Merwari",
-    "Mewari",
     "Dhundari",
     "Shekhawati",
     "Harauti",
@@ -19939,30 +18325,25 @@
   "mww": [
     "白苗語",
     "白苗语",
-    "White Hmong",
-    "Hmong Daw",
-    "Hmoob Dawb"
+    "Hmong Daw"
   ],
   "mwz": [
     "Moingi"
   ],
   "mxa": [
     "西北瓦哈卡米斯特克語",
-    "西北瓦哈卡米斯特克语",
-    "Northwest Oaxaca Mixtec"
+    "西北瓦哈卡米斯特克语"
   ],
   "mxb": [
     "特索亞特蘭米斯特克語",
-    "特索亚特兰米斯特克语",
-    "Tezoatlán Mixtec"
+    "特索亚特兰米斯特克语"
   ],
   "mxd": [
     "Modang"
   ],
   "mxe": [
     "梅勒-菲拉語",
-    "梅勒-菲拉语",
-    "Mele-Fila"
+    "梅勒-菲拉语"
   ],
   "mxf": [
     "Malgbe"
@@ -19975,13 +18356,11 @@
   ],
   "mxi": [
     "莫札拉布語",
-    "莫札拉布语",
-    "Mozarabic"
+    "莫札拉布语"
   ],
   "mxj": [
     "格曼語",
     "格曼语",
-    "Miju",
     "Miju Mishmi",
     "Miju-Mishmi",
     "Geman Deng",
@@ -20009,13 +18388,11 @@
   ],
   "mxp": [
     "特拉惠托爾特佩克米塞語",
-    "特拉惠托尔特佩克米塞语",
-    "Tlahuitoltepec Mixe"
+    "特拉惠托尔特佩克米塞语"
   ],
   "mxq": [
     "胡基拉米塞語",
-    "胡基拉米塞语",
-    "Juquila Mixe"
+    "胡基拉米塞语"
   ],
   "mxr": [
     "Murik (Malaysia)",
@@ -20024,13 +18401,11 @@
   ],
   "mxs": [
     "惠特佩克米斯特克語",
-    "惠特佩克米斯特克语",
-    "Huitepec Mixtec"
+    "惠特佩克米斯特克语"
   ],
   "mxt": [
     "哈米爾特佩克米斯特克語",
-    "哈米尔特佩克米斯特克语",
-    "Jamiltepec Mixtec"
+    "哈米尔特佩克米斯特克语"
   ],
   "mxu": [
     "Mada (Cameroon)",
@@ -20038,8 +18413,7 @@
   ],
   "mxv": [
     "梅特拉托諾克米斯特克語",
-    "梅特拉托诺克米斯特克语",
-    "Metlatónoc Mixtec"
+    "梅特拉托诺克米斯特克语"
   ],
   "mxw": [
     "Namo"
@@ -20054,8 +18428,7 @@
   ],
   "mxy": [
     "東南諾奇斯特蘭米斯特克語",
-    "东南诺奇斯特兰米斯特克语",
-    "Southeastern Nochixtlán Mixtec"
+    "东南诺奇斯特兰米斯特克语"
   ],
   "mxz": [
     "Central Masela"
@@ -20105,7 +18478,6 @@
   "myn-pro": [
     "原始瑪雅語",
     "原始玛雅语",
-    "Proto-Mayan",
     "Proto-Maya"
   ],
   "myo": [
@@ -20113,8 +18485,7 @@
   ],
   "myp": [
     "皮拉罕語",
-    "皮拉罕语",
-    "Pirahã"
+    "皮拉罕语"
   ],
   "myr": [
     "Muniche"
@@ -20128,7 +18499,6 @@
   "myv": [
     "埃爾齊亞語",
     "埃尔齐亚语",
-    "Erzya",
     "Mordvin"
   ],
   "myw": [
@@ -20146,23 +18516,20 @@
   ],
   "myz": [
     "古典曼達安語",
-    "古典曼达安语",
-    "Classical Mandaic"
+    "古典曼达安语"
   ],
   "mza": [
     "聖瑪利亞薩卡特佩克米斯特克語",
-    "圣玛利亚萨卡特佩克米斯特克语",
-    "Santa María Zacatepec Mixtec"
+    "圣玛利亚萨卡特佩克米斯特克语"
   ],
   "mzb": [
-    "Tumzabt",
+    "Northern Saharan Berber",
     "Mozabite",
     "Tumẓabt"
   ],
   "mzc": [
     "馬達加斯加手語",
-    "马达加斯加手语",
-    "Madagascar Sign Language"
+    "马达加斯加手语"
   ],
   "mzd": [
     "Malimba"
@@ -20172,29 +18539,25 @@
   ],
   "mzg": [
     "修道院手語",
-    "修道院手语",
-    "Monastic Sign Language"
+    "修道院手语"
   ],
   "mzh": [
     "Wichí Lhamtés Güisnay"
   ],
   "mzi": [
     "伊斯卡特蘭馬薩特克語",
-    "伊斯卡特兰马萨特克语",
-    "Ixcatlán Mazatec"
+    "伊斯卡特兰马萨特克语"
   ],
   "mzj": [
     "Manya"
   ],
   "mzk": [
     "尼日利亞曼比拉語",
-    "尼日利亚曼比拉语",
-    "Nigeria Mambila"
+    "尼日利亚曼比拉语"
   ],
   "mzl": [
     "馬薩特蘭米塞語",
-    "马萨特兰米塞语",
-    "Mazatlán Mixe"
+    "马萨特兰米塞语"
   ],
   "mzm": [
     "Mumuye"
@@ -20202,7 +18565,6 @@
   "mzn": [
     "馬贊德蘭語",
     "马赞德兰语",
-    "Mazanderani",
     "Mazandarani",
     "Tabari"
   ],
@@ -20220,8 +18582,7 @@
   ],
   "mzs": [
     "澳門土生葡語",
-    "澳门土生葡语",
-    "Macanese"
+    "澳门土生葡语"
   ],
   "mzt": [
     "Mintil"
@@ -20240,10 +18601,7 @@
   ],
   "mzy": [
     "莫桑比克手語",
-    "莫桑比克手语",
-    "莫三比克手語",
-    "莫三比克手语",
-    "Mozambican Sign Language"
+    "莫桑比克手语"
   ],
   "mzz": [
     "Maiadomu"
@@ -20251,8 +18609,7 @@
   "na": [
     "瑙魯語",
     "瑙鲁语",
-    "諾魯語",
-    "诺鲁语"
+    "Nauru"
   ],
   "naa": [
     "Namla"
@@ -20279,8 +18636,7 @@
   ],
   "nah": [
     "納瓦特爾語",
-    "纳瓦特尔语",
-    "Nahuatl"
+    "纳瓦特尔语"
   ],
   "nai-ala": [
     "Alazapa",
@@ -20310,14 +18666,16 @@
     "Chiquimulilla"
   ],
   "nai-chu-pro": [
-    "Proto-Chumash",
+    "原始楚馬什語",
+    "原始楚马什语",
     "Proto-Chumashan"
   ],
   "nai-cig": [
     "Ciguayo"
   ],
   "nai-ckn-pro": [
-    "Proto-Chinookan",
+    "原始契努克語",
+    "原始契努克语",
     "Proto-Chinook"
   ],
   "nai-dly": [
@@ -20365,8 +18723,7 @@
   ],
   "nai-klp-pro": [
     "原始卡拉普亞語",
-    "原始卡拉普亚语",
-    "Proto-Kalapuyan"
+    "原始卡拉普亚语"
   ],
   "nai-knm": [
     "Konomihu"
@@ -20403,8 +18760,13 @@
   "nai-miz-pro": [
     "原始米塞-索克語",
     "原始米塞-索克语",
-    "Proto-Mixe-Zoque",
     "Proto-Mixe-Zoquean"
+  ],
+  "nai-mus-pro": [
+    "原始穆斯科格語",
+    "原始穆斯科格语",
+    "Proto-Muskhogean",
+    "Proto-Muskogee"
   ],
   "nai-nao": [
     "Naolan"
@@ -20446,7 +18808,6 @@
   "nai-pom-pro": [
     "原始波莫語",
     "原始波莫语",
-    "Proto-Pomo",
     "Proto-Pomoan"
   ],
   "nai-qng": [
@@ -20454,8 +18815,7 @@
   ],
   "nai-sca-pro": [
     "原始蘇-卡托巴語",
-    "原始苏-卡托巴语",
-    "Proto-Siouan-Catawban"
+    "原始苏-卡托巴语"
   ],
   "nai-sin": [
     "Sinacantán",
@@ -20518,8 +18878,7 @@
   ],
   "nai-tot-pro": [
     "原始托托索克語",
-    "原始托托索克语",
-    "Proto-Totozoquean"
+    "原始托托索克语"
   ],
   "nai-tsi-pro": [
     "Proto-Tsimshianic"
@@ -20533,13 +18892,6 @@
     "Guaycura",
     "Waicura"
   ],
-  "nai-yav": [
-    "Yavapai",
-    "Kwevkepaya",
-    "Wipukpaya",
-    "Tolkepaya",
-    "Yavepe"
-  ],
   "nai-yup": [
     "Yupiltepeque",
     "Jupiltepeque",
@@ -20552,13 +18904,11 @@
   ],
   "nak": [
     "納卡納伊語",
-    "纳卡纳伊语",
-    "Nakanai"
+    "纳卡纳伊语"
   ],
   "nal": [
     "納利克語",
-    "纳利克语",
-    "Nalik"
+    "纳利克语"
   ],
   "nam": [
     "Ngan'gityemerri",
@@ -20568,15 +18918,7 @@
   "nan": [
     "閩南語",
     "闽南语",
-    "福建話",
-    "福建话",
-    "臺灣話",
-    "台湾话",
-    "廈門話",
-    "厦门话",
-    "Hokkien",
-    "Taiwanese",
-    "Amoy (Xiamenese)"
+    "Taiwanese"
   ],
   "nao": [
     "Naaba",
@@ -20585,17 +18927,11 @@
   ],
   "nap": [
     "那不勒斯語",
-    "那不勒斯语",
-    "拿坡里語",
-    "拿坡里语",
-    "Neapolitan"
+    "那不勒斯语"
   ],
   "naq": [
     "科伊科伊語",
     "科伊科伊语",
-    "納馬語",
-    "纳马语",
-    "Khoekhoe",
     "Nama",
     "Hottentot",
     "Khoekhoegowab",
@@ -20621,13 +18957,11 @@
   "nay": [
     "恩加林杰里語",
     "恩加林杰里语",
-    "Ngarrindjeri",
     "Yaraldi"
   ],
   "naz": [
     "科阿特佩克納瓦特爾語",
-    "科阿特佩克纳瓦特尔语",
-    "Coatepec Nahuatl"
+    "科阿特佩克纳瓦特尔语"
   ],
   "nb": [
     "書面挪威語",
@@ -20687,8 +19021,7 @@
   ],
   "nbs": [
     "納米比亞手語",
-    "纳米比亚手语",
-    "Namibian Sign Language"
+    "纳米比亚手语"
   ],
   "nbt": [
     "Na",
@@ -20712,7 +19045,6 @@
   "ncb": [
     "中尼科巴語",
     "中尼科巴语",
-    "Central Nicobarese",
     "Nancowry",
     "Nankwari",
     "Camorta",
@@ -20734,31 +19066,26 @@
   ],
   "ncg": [
     "尼斯加亞語",
-    "尼斯加亚语",
-    "Nisga'a"
+    "尼斯加亚语"
   ],
   "nch": [
     "中瓦斯特卡納瓦特爾語",
-    "中瓦斯特卡纳瓦特尔语",
-    "Central Huasteca Nahuatl"
+    "中瓦斯特卡纳瓦特尔语"
   ],
   "nci": [
     "古典納瓦特爾語",
-    "古典纳瓦特尔语",
-    "Classical Nahuatl"
+    "古典纳瓦特尔语"
   ],
   "ncj": [
     "北普埃布拉納瓦特爾語",
-    "北普埃布拉纳瓦特尔语",
-    "Northern Puebla Nahuatl"
+    "北普埃布拉纳瓦特尔语"
   ],
   "nck": [
     "Nakara"
   ],
   "ncl": [
     "米卻肯納瓦特爾語",
-    "米却肯纳瓦特尔语",
-    "Michoacán Nahuatl"
+    "米却肯纳瓦特尔语"
   ],
   "ncm": [
     "Nambo"
@@ -20774,8 +19101,7 @@
   ],
   "ncs": [
     "尼加拉瓜手語",
-    "尼加拉瓜手语",
-    "Nicaraguan Sign Language"
+    "尼加拉瓜手语"
   ],
   "nct": [
     "Chothe Naga",
@@ -20786,15 +19112,15 @@
   ],
   "ncx": [
     "中普埃布拉納瓦特爾語",
-    "中普埃布拉纳瓦特尔语",
-    "Central Puebla Nahuatl"
+    "中普埃布拉纳瓦特尔语"
   ],
   "ncz": [
     "Natchez"
   ],
   "nd": [
     "北恩德貝勒語",
-    "北恩德贝勒语"
+    "北恩德贝勒语",
+    "North Ndebele"
   ],
   "nda": [
     "Ndasa"
@@ -20849,21 +19175,16 @@
   "nds": [
     "低地德語",
     "低地德语",
-    "Low German",
-    "低地薩克森語",
-    "低地萨克森语",
     "Low Saxon",
     "Modern Low German"
   ],
   "nds-de": [
     "德國低地德語",
-    "德国低地德语",
-    "German Low German"
+    "德国低地德语"
   ],
   "nds-nl": [
     "下薩克森荷蘭語",
-    "下萨克森荷兰语",
-    "Dutch Low Saxon"
+    "下萨克森荷兰语"
   ],
   "ndt": [
     "Ndunga"
@@ -20915,8 +19236,7 @@
   ],
   "neg": [
     "涅吉達爾語",
-    "涅吉达尔语",
-    "Negidal"
+    "涅吉达尔语"
   ],
   "neh": [
     "Nyenkha",
@@ -20950,8 +19270,7 @@
   ],
   "neq": [
     "中北部米塞語",
-    "中北部米塞语",
-    "North Central Mixe"
+    "中北部米塞语"
   ],
   "ner": [
     "Yahadian"
@@ -20971,7 +19290,6 @@
   "new": [
     "尼瓦爾語",
     "尼瓦尔语",
-    "Newar",
     "Newari"
   ],
   "nex": [
@@ -20998,17 +19316,14 @@
   ],
   "nfr": [
     "納凡拉語",
-    "纳凡拉语",
-    "Nafaanra"
+    "纳凡拉语"
   ],
   "nfu": [
     "Mfumte"
   ],
   "ng": [
     "恩敦加語",
-    "恩敦加语",
-    "恩東加語",
-    "恩东加语"
+    "恩敦加语"
   ],
   "nga": [
     "Ngbaka",
@@ -21034,8 +19349,7 @@
   ],
   "ngf-pro": [
     "原始跨新幾內亞語",
-    "原始跨新几内亚语",
-    "Proto-Trans-New Guinea"
+    "原始跨新几内亚语"
   ],
   "ngg": [
     "Ngbaka Manza"
@@ -21043,7 +19357,6 @@
   "ngh": [
     "努語",
     "努语",
-    "Nǀuu",
     "Nǁng"
   ],
   "ngi": [
@@ -21089,8 +19402,7 @@
   ],
   "ngu": [
     "格雷羅納瓦特爾語",
-    "格雷罗纳瓦特尔语",
-    "Guerrero Nahuatl"
+    "格雷罗纳瓦特尔语"
   ],
   "ngv": [
     "Nagumi"
@@ -21115,129 +19427,108 @@
   ],
   "nhc": [
     "塔巴斯科納瓦特爾語",
-    "塔巴斯科纳瓦特尔语",
-    "Tabasco Nahuatl"
+    "塔巴斯科纳瓦特尔语"
   ],
   "nhd": [
     "奇里帕語",
     "奇里帕语",
-    "Chiripá",
     "Ava Guarani",
     "Chiripá Guarani",
     "Nhandéva"
   ],
   "nhe": [
     "東瓦斯特卡納瓦特爾語",
-    "东瓦斯特卡纳瓦特尔语",
-    "Eastern Huasteca Nahuatl"
+    "东瓦斯特卡纳瓦特尔语"
   ],
   "nhf": [
     "Nhuwala"
   ],
   "nhg": [
     "特萊爾辛戈納瓦特爾語",
-    "特莱尔辛戈纳瓦特尔语",
-    "Tetelcingo Nahuatl"
+    "特莱尔辛戈纳瓦特尔语"
   ],
   "nhh": [
     "Nahari"
   ],
   "nhi": [
     "扎卡特蘭-阿華卡特蘭-特佩欽特拉-納瓦特爾語",
-    "扎卡特兰-阿华卡特兰-特佩钦特拉-纳瓦特尔语",
-    "Zacatlán-Ahuacatlán-Tepetzintla Nahuatl"
+    "扎卡特兰-阿华卡特兰-特佩钦特拉-纳瓦特尔语"
   ],
   "nhk": [
     "科索萊阿克納瓦特爾語",
     "科索莱阿克纳瓦特尔语",
-    "Cosoleacaque Nahuatl",
     "Isthmus-Cosoleacaque Nahuatl",
     "Cosoleacaque Isthmus Nahuatl"
   ],
   "nhm": [
     "莫雷洛斯納瓦特爾語",
-    "莫雷洛斯纳瓦特尔语",
-    "Morelos Nahuatl"
+    "莫雷洛斯纳瓦特尔语"
   ],
   "nhn": [
     "中納瓦特爾語",
-    "中纳瓦特尔语",
-    "Central Nahuatl"
+    "中纳瓦特尔语"
   ],
   "nho": [
     "塔庫烏語",
-    "塔库乌语",
-    "Takuu"
+    "塔库乌语"
   ],
   "nhp": [
     "帕哈潘納瓦特爾語",
     "帕哈潘纳瓦特尔语",
-    "Pajapan Nahuatl",
     "Isthmus-Pajapan Nahuatl",
     "Pajapan Isthmus Nahuatl"
   ],
   "nhq": [
     "瓦斯卡勒卡納瓦特爾語",
-    "瓦斯卡勒卡纳瓦特尔语",
-    "Huaxcaleca Nahuatl"
+    "瓦斯卡勒卡纳瓦特尔语"
   ],
   "nhr": [
     "納羅語",
-    "纳罗语",
-    "Naro"
+    "纳罗语"
   ],
   "nht": [
     "奧梅特佩克納瓦特爾語",
-    "奥梅特佩克纳瓦特尔语",
-    "Ometepec Nahuatl"
+    "奥梅特佩克纳瓦特尔语"
   ],
   "nhu": [
     "Noone"
   ],
   "nhv": [
     "特馬斯卡爾特佩克納瓦特爾語",
-    "特马斯卡尔特佩克纳瓦特尔语",
-    "Temascaltepec Nahuatl"
+    "特马斯卡尔特佩克纳瓦特尔语"
   ],
   "nhw": [
     "西瓦斯特卡納瓦特爾語",
-    "西瓦斯特卡纳瓦特尔语",
-    "Western Huasteca Nahuatl"
+    "西瓦斯特卡纳瓦特尔语"
   ],
   "nhx": [
     "梅卡亞潘納瓦特爾語",
     "梅卡亚潘纳瓦特尔语",
-    "Mecayapan Nahuatl",
     "Isthmus-Mecayapan Nahuatl",
     "Mecayapan Isthmus Nahuatl"
   ],
   "nhy": [
     "北瓦哈卡納瓦特爾語",
-    "北瓦哈卡纳瓦特尔语",
-    "Northern Oaxaca Nahuatl"
+    "北瓦哈卡纳瓦特尔语"
   ],
   "nhz": [
     "聖瑪利亞山區納瓦特爾語",
-    "圣玛利亚山区纳瓦特尔语",
-    "Santa María La Alta Nahuatl"
+    "圣玛利亚山区纳瓦特尔语"
   ],
   "nia": [
     "尼亞斯語",
-    "尼亚斯语",
-    "Nias"
+    "尼亚斯语"
   ],
   "nib": [
     "Nakame"
   ],
   "nic-bco-pro": [
     "原始貝努埃-剛果語",
-    "原始贝努埃-刚果语",
-    "Proto-Benue-Congo"
+    "原始贝努埃-刚果语"
   ],
   "nic-bod-pro": [
     "原始類班圖語",
-    "原始类班图语",
-    "Proto-Bantoid"
+    "原始类班图语"
   ],
   "nic-eov-pro": [
     "Proto-Eastern Oti-Volta"
@@ -21268,21 +19559,18 @@
   ],
   "nic-pro": [
     "原始尼日爾-剛果語",
-    "原始尼日尔-刚果语",
-    "Proto-Niger-Congo"
+    "原始尼日尔-刚果语"
   ],
   "nic-ubg-pro": [
     "Proto-Ubangian"
   ],
   "nic-ucr-pro": [
     "原始上克羅斯河語",
-    "原始上克罗斯河语",
-    "Proto-Upper Cross River"
+    "原始上克罗斯河语"
   ],
   "nic-vco-pro": [
     "原始沃爾特-剛果語",
-    "原始沃尔特-刚果语",
-    "Proto-Volta-Congo"
+    "原始沃尔特-刚果语"
   ],
   "nid": [
     "Ngandi"
@@ -21304,18 +19592,15 @@
   ],
   "nij": [
     "恩加朱語",
-    "恩加朱语",
-    "Ngaju"
+    "恩加朱语"
   ],
   "nik": [
     "南尼科巴語",
-    "南尼科巴语",
-    "Southern Nicobarese"
+    "南尼科巴语"
   ],
   "nil": [
     "尼拉語",
-    "尼拉语",
-    "Nila"
+    "尼拉语"
   ],
   "nim": [
     "Nilamba"
@@ -21325,8 +19610,7 @@
   ],
   "nio": [
     "恩加納桑語",
-    "恩加纳桑语",
-    "Nganasan"
+    "恩加纳桑语"
   ],
   "niq": [
     "Nandi"
@@ -21340,18 +19624,15 @@
   "nit": [
     "東南科拉米語",
     "东南科拉米语",
-    "Southeastern Kolami",
     "Naiki"
   ],
   "niu": [
     "紐埃語",
-    "纽埃语",
-    "Niuean"
+    "纽埃语"
   ],
   "niv": [
     "尼夫赫語",
-    "尼夫赫语",
-    "Nivkh"
+    "尼夫赫语"
   ],
   "niw": [
     "Nimo"
@@ -21385,8 +19666,7 @@
   ],
   "njm": [
     "安加米語",
-    "安加米语",
-    "Angami"
+    "安加米语"
   ],
   "njn": [
     "Liangmai Naga"
@@ -21418,7 +19698,6 @@
   "njz": [
     "尼西語",
     "尼西语",
-    "Nyishi",
     "Nishi",
     "Nisi",
     "Nissi",
@@ -21431,8 +19710,7 @@
   ],
   "nka": [
     "恩科亞語",
-    "恩科亚语",
-    "Nkoya"
+    "恩科亚语"
   ],
   "nkb": [
     "Khoibu Naga"
@@ -21475,18 +19753,15 @@
   ],
   "nkp": [
     "紐阿托普塔普語",
-    "纽阿托普塔普语",
-    "Niuatoputapu"
+    "纽阿托普塔普语"
   ],
   "nkq": [
     "恩卡米語",
-    "恩卡米语",
-    "Nkami"
+    "恩卡米语"
   ],
   "nkr": [
     "努庫奧羅語",
-    "努库奥罗语",
-    "Nukuoro"
+    "努库奥罗语"
   ],
   "nks": [
     "North Asmat"
@@ -21529,9 +19804,7 @@
   ],
   "nlg": [
     "恩格拉語",
-    "恩格拉语",
-    "Gela",
-    "Nggela"
+    "恩格拉语"
   ],
   "nli": [
     "Grangali",
@@ -21542,8 +19815,7 @@
   ],
   "nlk": [
     "尼尼亞亞利語",
-    "尼尼亚亚利语",
-    "Ninia Yali"
+    "尼尼亚亚利语"
   ],
   "nll": [
     "Nihali"
@@ -21565,11 +19837,7 @@
   ],
   "nlv": [
     "奧里薩巴納瓦特爾語",
-    "奥里萨巴纳瓦特尔语",
-    "Orizaba Nahuatl",
-    "Tarawara",
-    "Tarawari",
-    "Trawara"
+    "奥里萨巴纳瓦特尔语"
   ],
   "nlw": [
     "Walangama"
@@ -21587,7 +19855,8 @@
     "Maram Naga"
   ],
   "nmb": [
-    "Big Nambas"
+    "大納姆巴斯語",
+    "大纳姆巴斯语"
   ],
   "nmc": [
     "Ngam"
@@ -21637,7 +19906,6 @@
   "nmn": [
     "宏語",
     "宏语",
-    "ǃXóõ",
     "Xoo",
     "Taa"
   ],
@@ -21672,8 +19940,7 @@
   ],
   "nmy": [
     "納木依語",
-    "纳木依语",
-    "Namuyi"
+    "纳木依语"
   ],
   "nmz": [
     "Nawdm"
@@ -21681,6 +19948,7 @@
   "nn": [
     "新挪威語",
     "新挪威语",
+    "New Norwegian",
     "Nynorsk"
   ],
   "nna": [
@@ -21736,13 +20004,11 @@
   ],
   "nnr": [
     "納倫加語",
-    "纳伦加语",
-    "Narungga"
+    "纳伦加语"
   ],
   "nnt": [
     "南蒂科克語",
-    "南蒂科克语",
-    "Nanticoke"
+    "南蒂科克语"
   ],
   "nnu": [
     "Dwang"
@@ -21752,8 +20018,7 @@
   ],
   "nnw": [
     "南努尼語",
-    "南努尼语",
-    "Southern Nuni"
+    "南努尼语"
   ],
   "nnx": [
     "Ngong"
@@ -21777,17 +20042,14 @@
   "nod": [
     "北部泰語",
     "北部泰语",
-    "蘭納語",
-    "兰纳语",
-    "Northern Thai",
+    "Northwestern Thai",
     "Kam Mueang",
     "Kam Muang",
     "Lanna"
   ],
   "noe": [
     "尼馬迪語",
-    "尼马迪语",
-    "Nimadi"
+    "尼马迪语"
   ],
   "nof": [
     "Nomane"
@@ -21795,7 +20057,6 @@
   "nog": [
     "諾蓋語",
     "诺盖语",
-    "Nogai",
     "Nogay"
   ],
   "noh": [
@@ -21819,13 +20080,8 @@
   "non": [
     "古諾爾斯語",
     "古诺尔斯语",
-    "Old Norse",
     "Old Icelandic",
-    "Old Norwegian",
-    "古冰島語",
-    "古冰岛语",
-    "古挪威語",
-    "古挪威语"
+    "Old Norwegian"
   ],
   "nop": [
     "Numanggang"
@@ -21844,8 +20100,7 @@
   ],
   "nov": [
     "諾維亞語",
-    "诺维亚语",
-    "Novial"
+    "诺维亚语"
   ],
   "now": [
     "Nyambo"
@@ -21872,8 +20127,7 @@
   ],
   "npl": [
     "東南普埃布拉納瓦特爾語",
-    "东南普埃布拉纳瓦特尔语",
-    "Southeastern Puebla Nahuatl"
+    "东南普埃布拉纳瓦特尔语"
   ],
   "npn": [
     "Mondropolon"
@@ -21917,7 +20171,8 @@
   ],
   "nr": [
     "南恩德貝勒語",
-    "南恩德贝勒语"
+    "南恩德贝勒语",
+    "South Ndebele"
   ],
   "nra": [
     "Ngom"
@@ -21934,7 +20189,6 @@
   "nrf": [
     "諾曼語",
     "诺曼语",
-    "Norman",
     "Cauchois",
     "Jèrriais",
     "Jersiais",
@@ -21970,23 +20224,19 @@
   ],
   "nrn": [
     "諾恩語",
-    "诺恩语",
-    "Norn"
+    "诺恩语"
   ],
   "nrp": [
     "北皮賽恩語",
-    "北皮赛恩语",
-    "North Picene"
+    "北皮赛恩语"
   ],
   "nrr": [
     "諾拉語",
-    "诺拉语",
-    "Norra"
+    "诺拉语"
   ],
   "nrt": [
     "北卡拉普亞語",
-    "北卡拉普亚语",
-    "Northern Kalapuya"
+    "北卡拉普亚语"
   ],
   "nru": [
     "Narua"
@@ -21996,8 +20246,7 @@
   ],
   "nrz": [
     "拉拉語（新幾內亞）",
-    "拉拉语（新几内亚）",
-    "Lala (New Guinea)"
+    "拉拉语（新几内亚）"
   ],
   "nsa": [
     "Sangtam Naga"
@@ -22022,18 +20271,14 @@
   ],
   "nsi": [
     "尼日利亞手語",
-    "尼日利亚手语",
-    "奈及利亞手語",
-    "奈及利亚手语",
-    "Nigerian Sign Language"
+    "尼日利亚手语"
   ],
   "nsk": [
     "Naskapi"
   ],
   "nsl": [
     "挪威手語",
-    "挪威手语",
-    "Norwegian Sign Language"
+    "挪威手语"
   ],
   "nsm": [
     "Sema"
@@ -22043,21 +20288,18 @@
   ],
   "nso": [
     "北索托語",
-    "北索托语",
-    "Northern Sotho"
+    "北索托语"
   ],
   "nsp": [
     "尼泊爾手語",
-    "尼泊尔手语",
-    "Nepalese Sign Language"
+    "尼泊尔手语"
   ],
   "nsq": [
     "Northern Sierra Miwok"
   ],
   "nsr": [
     "海事手語",
-    "海事手语",
-    "Maritime Sign Language"
+    "海事手语"
   ],
   "nss": [
     "Nali"
@@ -22067,8 +20309,7 @@
   ],
   "nsu": [
     "內格拉山區納瓦特爾語",
-    "内格拉山区纳瓦特尔语",
-    "Sierra Negra Nahuatl"
+    "内格拉山区纳瓦特尔语"
   ],
   "nsv": [
     "Southwestern Nisu"
@@ -22115,8 +20356,7 @@
   ],
   "ntp": [
     "北特佩瓦語",
-    "北特佩瓦语",
-    "Northern Tepehuan"
+    "北特佩瓦语"
   ],
   "ntr": [
     "Delo"
@@ -22148,8 +20388,7 @@
   ],
   "nub-pro": [
     "原始努比亞語",
-    "原始努比亚语",
-    "Proto-Nubian"
+    "原始努比亚语"
   ],
   "nuc": [
     "Nukuini"
@@ -22183,7 +20422,6 @@
   "nuk": [
     "努特卡語",
     "努特卡语",
-    "Nootka",
     "Nuu-chah-nulth",
     "Nuuchahnulth",
     "T'aat'aaqsapa"
@@ -22193,8 +20431,7 @@
   ],
   "num": [
     "紐阿富語",
-    "纽阿富语",
-    "Niuafo'ou"
+    "纽阿富语"
   ],
   "nun": [
     "Anong",
@@ -22206,9 +20443,6 @@
   "nup": [
     "努佩語",
     "努佩语",
-    "努培語",
-    "努培语",
-    "Nupe",
     "Nupe-Nupe-Tako"
   ],
   "nuq": [
@@ -22217,7 +20451,6 @@
   "nur": [
     "努古里亞語",
     "努古里亚语",
-    "Nuguria",
     "Nukuria"
   ],
   "nus": [
@@ -22226,16 +20459,14 @@
   ],
   "nut": [
     "儂語",
-    "侬语",
-    "Nung"
+    "侬语"
   ],
   "nuu": [
     "Ngbundu"
   ],
   "nuv": [
     "北努尼語",
-    "北努尼语",
-    "Northern Nuni"
+    "北努尼语"
   ],
   "nuw": [
     "Nguluwan"
@@ -22249,8 +20480,7 @@
   ],
   "nuz": [
     "特拉馬卡薩帕納瓦特爾語",
-    "特拉马卡萨帕纳瓦特尔语",
-    "Tlamacazapa Nahuatl"
+    "特拉马卡萨帕纳瓦特尔语"
   ],
   "nv": [
     "納瓦霍語",
@@ -22276,7 +20506,6 @@
   "nwc": [
     "古典尼瓦爾語",
     "古典尼瓦尔语",
-    "Classical Newar",
     "Classical Newari"
   ],
   "nwe": [
@@ -22299,7 +20528,6 @@
   "nwx": [
     "中古尼瓦爾語",
     "中古尼瓦尔语",
-    "Middle Newar",
     "Middle Newari"
   ],
   "nwy": [
@@ -22337,8 +20565,7 @@
   ],
   "nxq": [
     "納西語",
-    "纳西语",
-    "Naxi"
+    "纳西语"
   ],
   "nxr": [
     "Ninggerum"
@@ -22354,8 +20581,7 @@
     "齐切瓦语",
     "Chicheŵa",
     "Chinyanja",
-    "尼揚加語",
-    "尼扬加语",
+    "Nyanja",
     "Chewa",
     "Cicewa",
     "Cewa",
@@ -22432,7 +20658,6 @@
   "nys": [
     "尼揚加語",
     "尼扬加语",
-    "Nyunga",
     "Noongar",
     "Nyuunga"
   ],
@@ -22447,10 +20672,7 @@
   ],
   "nyw": [
     "僥語",
-    "侥语",
-    "Nyaw",
-    "Tai Mene",
-    "Tai Yo"
+    "侥语"
   ],
   "nyx": [
     "Nganyaywana"
@@ -22458,14 +20680,12 @@
   "nyy": [
     "尼亞庫薩語",
     "尼亚库萨语",
-    "Nyakyusa",
     "Kinyakyusa",
     "Nyakyusa-Ngonde"
   ],
   "nza": [
     "梯貢-姆本貝語",
-    "梯贡-姆本贝语",
-    "Tigon Mbembe"
+    "梯贡-姆本贝语"
   ],
   "nzb": [
     "Njebi"
@@ -22473,7 +20693,6 @@
   "nzd": [
     "恩扎迪語",
     "恩扎迪语",
-    "Nzadi",
     "Ngiemba",
     "Lensibun",
     "Ndzé Ntaa"
@@ -22491,10 +20710,7 @@
   ],
   "nzs": [
     "新西蘭手語",
-    "新西兰手语",
-    "紐西蘭手語",
-    "纽西兰手语",
-    "New Zealand Sign Language"
+    "新西兰手语"
   ],
   "nzu": [
     "Central Teke"
@@ -22507,13 +20723,11 @@
   ],
   "oaa": [
     "鄂羅克語",
-    "鄂罗克语",
-    "Orok"
+    "鄂罗克语"
   ],
   "oac": [
     "奧羅奇語",
-    "奥罗奇语",
-    "Oroch"
+    "奥罗奇语"
   ],
   "oav": [
     "古阿瓦爾語",
@@ -22531,8 +20745,7 @@
   ],
   "obm": [
     "摩押語",
-    "摩押语",
-    "Moabite"
+    "摩押语"
   ],
   "obo": [
     "歐波-馬諾博語",
@@ -22541,34 +20754,29 @@
   ],
   "obr": [
     "上古緬甸語",
-    "上古缅甸语",
-    "Old Burmese"
+    "上古缅甸语"
   ],
   "obt": [
     "上古布列塔尼語",
-    "上古布列塔尼语",
-    "Old Breton"
+    "上古布列塔尼语"
   ],
   "obu": [
     "Obulom"
   ],
   "oc": [
     "奧克語",
-    "奥克语",
-    "奥克西唐语"
+    "奥克语"
   ],
   "oca": [
     "Ocaina"
   ],
   "och": [
     "上古漢語",
-    "上古汉语",
-    "Old Chinese"
+    "上古汉语"
   ],
   "oco": [
     "上古康沃爾語",
-    "上古康沃尔语",
-    "Old Cornish"
+    "上古康沃尔语"
   ],
   "ocu": [
     "Tlahuica",
@@ -22580,13 +20788,11 @@
   ],
   "odk": [
     "奧德語",
-    "奥德语",
-    "Od"
+    "奥德语"
   ],
   "odt": [
     "古荷蘭語",
-    "古荷兰语",
-    "Old Dutch"
+    "古荷兰语"
   ],
   "odu": [
     "Odual"
@@ -22596,10 +20802,7 @@
   ],
   "ofs": [
     "古弗里斯蘭語",
-    "古弗里斯兰语",
-    "Old Frisian",
-    "上古菲士蘭語",
-    "上古菲士兰语"
+    "古弗里斯兰语"
   ],
   "ofu": [
     "Efutop"
@@ -22612,8 +20815,7 @@
   ],
   "oge": [
     "上古格魯吉亞語",
-    "上古格鲁吉亚语",
-    "Old Georgian"
+    "上古格鲁吉亚语"
   ],
   "ogg": [
     "Ogbogolo"
@@ -22626,8 +20828,7 @@
   ],
   "ohu": [
     "上古匈牙利語",
-    "上古匈牙利语",
-    "Old Hungarian"
+    "上古匈牙利语"
   ],
   "oia": [
     "Oirata"
@@ -22638,47 +20839,39 @@
   "oj": [
     "奧吉布瓦語",
     "奥吉布瓦语",
-    "歐及布威語",
-    "欧及布威语",
+    "Ojibway",
     "Ojibwa"
   ],
   "ojb": [
     "西北奧吉布瓦語",
-    "西北奥吉布瓦语",
-    "Northwestern Ojibwa"
+    "西北奥吉布瓦语"
   ],
   "ojc": [
     "中奧吉布瓦語",
-    "中奥吉布瓦语",
-    "Central Ojibwa"
+    "中奥吉布瓦语"
   ],
   "ojg": [
     "東奧吉布瓦語",
-    "东奥吉布瓦语",
-    "Eastern Ojibwa"
+    "东奥吉布瓦语"
   ],
   "ojp": [
     "古典日語",
-    "古典日语",
-    "Old Japanese"
+    "古典日语"
   ],
   "ojs": [
     "塞文奧吉布瓦語",
-    "塞文奥吉布瓦语",
-    "Severn Ojibwa"
+    "塞文奥吉布瓦语"
   ],
   "ojv": [
     "Ontong Java"
   ],
   "ojw": [
     "西奧吉布瓦語",
-    "西奥吉布瓦语",
-    "Western Ojibwa"
+    "西奥吉布瓦语"
   ],
   "oka": [
     "歐肯納根語",
     "欧肯纳根语",
-    "Okanagan",
     "Okanagan Salish",
     "Okanagan-Colville",
     "Colville-Okanagan"
@@ -22702,8 +20895,7 @@
   ],
   "okh": [
     "科雷斯埃羅斯塔姆語",
-    "科雷斯埃罗斯塔姆语",
-    "Koresh-e Rostam"
+    "科雷斯埃罗斯塔姆语"
   ],
   "oki": [
     "Okiek",
@@ -22726,25 +20918,22 @@
   ],
   "okl": [
     "古肯特手語",
-    "古肯特手语",
-    "Old Kentish Sign Language"
+    "古肯特手语"
   ],
   "okm": [
     "中古朝鮮語",
-    "中古朝鲜语",
-    "Middle Korean"
+    "中古朝鲜语"
   ],
   "okn": [
     "沖永良部語",
     "冲永良部语",
-    "Oki-No-Erabu",
     "Okino-Erabu",
-    "Okinoerabu"
+    "Okinoerabu",
+    "Oki-no-Erabu"
   ],
   "oko": [
     "上古朝鮮語",
-    "上古朝鲜语",
-    "Old Korean"
+    "上古朝鲜语"
   ],
   "okr": [
     "Kirike"
@@ -22765,8 +20954,7 @@
   ],
   "okz": [
     "古高棉語",
-    "古高棉语",
-    "Old Khmer"
+    "古高棉语"
   ],
   "old": [
     "Mochi"
@@ -22780,7 +20968,6 @@
   "olo": [
     "利維卡累利阿語",
     "利维卡累利阿语",
-    "Livvi",
     "Livvi-Karelian",
     "Livvikovian",
     "Olonets",
@@ -22791,8 +20978,7 @@
   ],
   "olt": [
     "古立陶宛語",
-    "古立陶宛语",
-    "Old Lithuanian"
+    "古立陶宛语"
   ],
   "olu": [
     "Kuvale"
@@ -22832,87 +21018,72 @@
   ],
   "omk": [
     "奧莫克語",
-    "奥莫克语",
-    "Omok"
+    "奥莫克语"
   ],
   "oml": [
     "Ombo"
   ],
   "omn": [
     "米諾斯語",
-    "米诺斯语",
-    "Minoan"
+    "米诺斯语"
   ],
   "omo": [
     "Utarmbung"
   ],
   "omp": [
     "上古曼尼普爾語",
-    "上古曼尼普尔语",
-    "Old Manipuri"
+    "上古曼尼普尔语"
   ],
   "omq-cha-pro": [
     "原始查蒂諾語",
-    "原始查蒂诺语",
-    "Proto-Chatino"
+    "原始查蒂诺语"
   ],
   "omq-maz-pro": [
     "原始馬薩特克語",
     "原始马萨特克语",
-    "Proto-Mazatec",
     "Proto-Mazatecan"
   ],
   "omq-mix-pro": [
     "原始類米斯特克語",
-    "原始类米斯特克语",
-    "Proto-Mixtecan"
+    "原始类米斯特克语"
   ],
   "omq-mxt-pro": [
     "原始米斯特克語",
-    "原始米斯特克语",
-    "Proto-Mixtec"
+    "原始米斯特克语"
   ],
   "omq-otp-pro": [
     "原始歐托-帕梅語",
-    "原始欧托-帕梅语",
-    "Proto-Oto-Pamean"
+    "原始欧托-帕梅语"
   ],
   "omq-pro": [
     "原始歐托-曼格語",
     "原始欧托-曼格语",
-    "Proto-Oto-Manguean",
     "Proto-Otomanguean",
     "Proto-Oto-Mangue"
   ],
   "omq-tel": [
     "特波斯科盧拉米斯特克語",
-    "特波斯科卢拉米斯特克语",
-    "Teposcolula Mixtec"
+    "特波斯科卢拉米斯特克语"
   ],
   "omq-teo": [
     "特奧霍姆爾科查蒂諾語",
-    "特奥霍姆尔科查蒂诺语",
-    "Teojomulco Chatino"
+    "特奥霍姆尔科查蒂诺语"
   ],
   "omq-tri-pro": [
     "原始特里基語",
-    "原始特里基语",
-    "Proto-Trique"
+    "原始特里基语"
   ],
   "omq-zap-pro": [
     "原始類薩波特克語",
-    "原始类萨波特克语",
-    "Proto-Zapotecan"
+    "原始类萨波特克语"
   ],
   "omq-zpc-pro": [
     "原始薩波特克語",
-    "原始萨波特克语",
-    "Proto-Zapotec"
+    "原始萨波特克语"
   ],
   "omr": [
     "上古馬拉地語",
-    "上古马拉地语",
-    "Old Marathi"
+    "上古马拉地语"
   ],
   "omt": [
     "Omotik"
@@ -22935,8 +21106,7 @@
   ],
   "omx": [
     "上古孟語",
-    "上古孟语",
-    "Old Mon"
+    "上古孟语"
   ],
   "ona": [
     "Selk'nam",
@@ -22954,8 +21124,7 @@
   ],
   "one": [
     "歐內達語",
-    "欧内达语",
-    "Oneida"
+    "欧内达语"
   ],
   "ong": [
     "Olo"
@@ -22993,8 +21162,7 @@
   ],
   "onw": [
     "上古努比亞語",
-    "上古努比亚语",
-    "Old Nubian"
+    "上古努比亚语"
   ],
   "onx": [
     "Pidgin Onin"
@@ -23002,7 +21170,6 @@
   "ood": [
     "歐罕語",
     "欧罕语",
-    "O'odham",
     "Papago"
   ],
   "oog": [
@@ -23010,8 +21177,7 @@
   ],
   "oon": [
     "翁奇語",
-    "翁奇语",
-    "Önge"
+    "翁奇语"
   ],
   "oor": [
     "Oorlams"
@@ -23019,7 +21185,6 @@
   "oos": [
     "上古奧塞提亞語",
     "上古奥塞提亚语",
-    "Old Ossetic",
     "Old Ossetian",
     "Alanic",
     "Sarmatian"
@@ -23051,11 +21216,6 @@
   "or": [
     "奧利亞語",
     "奥利亚语",
-    "奧里亞語",
-    "奥里亚语",
-    "歐利亞語",
-    "欧利亚语",
-    "奥里雅语",
     "Odia",
     "Oorya"
   ],
@@ -23070,8 +21230,10 @@
   ],
   "orh": [
     "鄂倫春語",
-    "鄂伦春语",
-    "Oroqen"
+    "鄂伦春语"
+  ],
+  "oro": [
+    "Orokolo"
   ],
   "orr": [
     "Oruma"
@@ -23081,15 +21243,11 @@
   ],
   "oru": [
     "奧爾穆里語",
-    "奥尔穆里语",
-    "Ormuri"
+    "奥尔穆里语"
   ],
   "orv": [
     "古東斯拉夫語",
     "古东斯拉夫语",
-    "Old East Slavic",
-    "古俄羅斯語",
-    "古俄罗斯语",
     "Old Russian"
   ],
   "orw": [
@@ -23104,40 +21262,34 @@
   "os": [
     "奧塞梯語",
     "奥塞梯语",
-    "奧塞提亞語",
-    "奥塞提亚语",
+    "Ossete",
     "Ossetic"
   ],
   "os-pro": [
     "原始奧塞提亞語",
     "原始奥塞提亚语",
-    "Proto-Ossetic",
     "Sarmatian"
   ],
   "osa": [
     "奧沙格語",
-    "奥沙格语",
-    "Osage"
+    "奥沙格语"
   ],
   "osc": [
     "奧斯坎語",
-    "奥斯坎语",
-    "Oscan"
+    "奥斯坎语"
   ],
   "osi": [
     "Osing"
+  ],
+  "osn": [
+    "Old Sundanese"
   ],
   "oso": [
     "Ososo"
   ],
   "osp": [
     "中世紀西班牙語",
-    "中世纪西班牙语",
-    "Old Spanish",
-    "古西班牙語",
-    "古西班牙语",
-    "古卡斯蒂利亞語",
-    "古卡斯蒂利亚语"
+    "中世纪西班牙语"
   ],
   "ost": [
     "Osatu"
@@ -23148,20 +21300,16 @@
   "osx": [
     "古撒克遜語",
     "古撒克逊语",
-    "Old Saxon",
-    "Old Low German",
-    "古低地德語",
-    "古低地德语",
-    "古低地日耳曼語",
-    "古低地日耳曼语"
+    "Old Low German"
   ],
   "ota": [
     "鄂圖曼土耳其語",
     "鄂图曼土耳其语",
-    "Ottoman Turkish",
-    "Ottoman",
-    "鄂圖曼語",
-    "鄂图曼语"
+    "Ottoman"
+  ],
+  "otb": [
+    "Old Tibetan",
+    "Imperial Old Tibetan"
   ],
   "otd": [
     "Ot Danum",
@@ -23169,8 +21317,7 @@
   ],
   "ote": [
     "梅斯基塔爾奧托米語",
-    "梅斯基塔尔奥托米语",
-    "Mezquital Otomi"
+    "梅斯基塔尔奥托米语"
   ],
   "oti": [
     "Oti"
@@ -23178,83 +21325,62 @@
   "otk": [
     "古突厥語",
     "古突厥语",
-    "Old Turkic",
     "Orkhon Turkic",
-    "Orkhon",
-    "古代突厥語",
-    "古代突厥语"
+    "Orkhon"
   ],
   "otl": [
     "蒂拉帕奧托米語",
-    "蒂拉帕奥托米语",
-    "Tilapa Otomi"
+    "蒂拉帕奥托米语"
   ],
   "otm": [
     "東部高地奧托米語",
-    "东部高地奥托米语",
-    "Eastern Highland Otomi"
+    "东部高地奥托米语"
   ],
   "otn": [
     "特南戈奧托米語",
-    "特南戈奥托米语",
-    "Tenango Otomi"
+    "特南戈奥托米语"
   ],
   "oto-otm-pro": [
     "原始奧托米語",
-    "原始奥托米语",
-    "Proto-Otomi"
+    "原始奥托米语"
   ],
   "oto-pro": [
     "原始類奧托米語",
-    "原始类奥托米语",
-    "Proto-Otomian"
+    "原始类奥托米语"
   ],
   "otq": [
     "克雷塔羅奧托米語",
-    "克雷塔罗奥托米语",
-    "Querétaro Otomi"
+    "克雷塔罗奥托米语"
   ],
   "otr": [
     "Otoro"
   ],
   "ots": [
     "墨西哥州奧托米語",
-    "墨西哥州奥托米语",
-    "Estado de México Otomi"
+    "墨西哥州奥托米语"
   ],
   "ott": [
     "特莫亞雅奧托米語",
-    "特莫亚雅奥托米语",
-    "Temoaya Otomi"
+    "特莫亚雅奥托米语"
   ],
   "otu": [
     "Otuke"
   ],
   "otw": [
     "渥太華語",
-    "渥太华语",
-    "Ottawa"
+    "渥太华语"
   ],
   "otx": [
     "特斯卡特佩克奧托米語",
-    "特斯卡特佩克奥托米语",
-    "Texcatepec Otomi"
+    "特斯卡特佩克奥托米语"
   ],
   "oty": [
     "上古泰米爾語",
-    "上古泰米尔语",
-    "Old Tamil"
+    "上古泰米尔语"
   ],
   "otz": [
     "伊斯坦科奧托米語",
-    "伊斯坦科奥托米语",
-    "Old Tamil"
-  ],
-  "oua": [
-    "Tagargrent",
-    "Ouargli",
-    "Wargli",
-    "Teggargrent"
+    "伊斯坦科奥托米语"
   ],
   "oub": [
     "Glio-Oubi"
@@ -23265,7 +21391,6 @@
   "oui": [
     "古回鶻語",
     "古回鹘语",
-    "Old Uyghur",
     "Old Uighur"
   ],
   "oum": [
@@ -23274,7 +21399,6 @@
   "ovd": [
     "埃爾夫達利安語",
     "埃尔夫达利安语",
-    "Elfdalian",
     "Övdalian"
   ],
   "owi": [
@@ -23282,8 +21406,7 @@
   ],
   "owl": [
     "古威爾士語",
-    "古威尔士语",
-    "Old Welsh"
+    "古威尔士语"
   ],
   "oyb": [
     "Oy",
@@ -23322,8 +21445,7 @@
   ],
   "paa-nha-pro": [
     "原始北哈馬黑拉語",
-    "原始北哈马黑拉语",
-    "Proto-North Halmahera"
+    "原始北哈马黑拉语"
   ],
   "paa-nun": [
     "Nungon"
@@ -23337,8 +21459,7 @@
   ],
   "pac": [
     "帕戈語",
-    "帕戈语",
-    "Pacoh"
+    "帕戈语"
   ],
   "pad": [
     "Paumarí"
@@ -23351,8 +21472,7 @@
   ],
   "pag": [
     "班詩蘭語",
-    "班诗兰语",
-    "Pangasinan"
+    "班诗兰语"
   ],
   "pah": [
     "Tenharim",
@@ -23368,14 +21488,12 @@
   "pal": [
     "中古波斯語",
     "中古波斯语",
-    "Middle Persian",
     "Pahlavi",
     "Manichaean Middle Persian"
   ],
   "pam": [
     "卡片片甘語",
     "卡片片甘语",
-    "Kapampangan",
     "Pampango"
   ],
   "pao": [
@@ -23391,7 +21509,6 @@
   "pap": [
     "帕皮阿門托語",
     "帕皮阿门托语",
-    "Papiamentu",
     "Papiamento"
   ],
   "paq": [
@@ -23400,8 +21517,7 @@
   "par": [
     "帕納明特語",
     "帕纳明特语",
-    "帕納明特休休尼語",
-    "帕纳明特休休尼语",
+    "Panamint Shoshone",
     "Timbisha",
     "Tümpisha",
     "Koso"
@@ -23414,8 +21530,7 @@
   ],
   "pau": [
     "帕勞語",
-    "帕劳语",
-    "Palauan"
+    "帕劳语"
   ],
   "pav": [
     "Wari'"
@@ -23453,13 +21568,11 @@
   ],
   "pbe": [
     "梅松特拉波波洛卡語",
-    "梅松特拉波波洛卡语",
-    "Mezontla Popoloca"
+    "梅松特拉波波洛卡语"
   ],
   "pbf": [
     "科約特佩克波波洛卡語",
-    "科约特佩克波波洛卡语",
-    "Coyotepec Popoloca"
+    "科约特佩克波波洛卡语"
   ],
   "pbg": [
     "Paraujano"
@@ -23481,7 +21594,6 @@
   "pbm": [
     "普埃布拉馬薩特克語",
     "普埃布拉马萨特克语",
-    "Puebla Mazatec",
     "Mazateco de Puebla y del Noroeste"
   ],
   "pbn": [
@@ -23498,13 +21610,11 @@
   ],
   "pbs": [
     "中帕梅語",
-    "中帕梅语",
-    "Central Pame"
+    "中帕梅语"
   ],
   "pbv": [
     "布那語",
-    "布那语",
-    "Pnar"
+    "布那语"
   ],
   "pby": [
     "Pyu",
@@ -23514,18 +21624,15 @@
   ],
   "pca": [
     "聖伊內斯阿瓦特姆潘波波洛卡語",
-    "圣伊内斯阿瓦特姆潘波波洛卡语",
-    "Santa Inés Ahuatempan Popoloca"
+    "圣伊内斯阿瓦特姆潘波波洛卡语"
   ],
   "pcb": [
     "比爾語",
-    "比尔语",
-    "Pear"
+    "比尔语"
   ],
   "pcc": [
     "布依語",
     "布依语",
-    "Bouyei",
     "Buyi",
     "Buyei",
     "Puyi",
@@ -23535,7 +21642,6 @@
   "pcd": [
     "皮卡第語",
     "皮卡第语",
-    "Picard",
     "Chti",
     "Ch'ti",
     "Rouchi",
@@ -23543,8 +21649,7 @@
   ],
   "pce": [
     "布雷德昂語",
-    "布雷德昂语",
-    "Ruching Palaung"
+    "布雷德昂语"
   ],
   "pcf": [
     "Paliyan"
@@ -23570,8 +21675,7 @@
   ],
   "pcm": [
     "尼日利亞皮欽語",
-    "尼日利亚皮钦语",
-    "Nigerian Pidgin"
+    "尼日利亚皮钦语"
   ],
   "pcn": [
     "Piti"
@@ -23588,9 +21692,6 @@
   "pdc": [
     "賓夕法尼亞德語",
     "宾夕法尼亚德语",
-    "賓州德語",
-    "宾州德语",
-    "Pennsylvania German",
     "Pennsylvania Dutch"
   ],
   "pdi": [
@@ -23605,7 +21706,6 @@
   "pdt": [
     "門諾低地德語",
     "门诺低地德语",
-    "Plautdietsch",
     "Mennonite Low German",
     "Russian Mennonite Low German",
     "Chortitza",
@@ -23614,7 +21714,9 @@
     "Molotcha"
   ],
   "pdu": [
-    "Kayan"
+    "Kayan",
+    "Padaung",
+    "Padaung Karen"
   ],
   "pea": [
     "Peranakan Indonesian"
@@ -23642,8 +21744,7 @@
   ],
   "pei": [
     "奇奇梅克-喬納斯語",
-    "奇奇梅克-乔纳斯语",
-    "Chichimeca-Jonaz"
+    "奇奇梅克-乔纳斯语"
   ],
   "pej": [
     "Northern Pomo"
@@ -23659,8 +21760,7 @@
   ],
   "peo": [
     "古波斯語",
-    "古波斯语",
-    "Old Persian"
+    "古波斯语"
   ],
   "pep": [
     "Kunja"
@@ -23679,8 +21779,7 @@
   ],
   "pez": [
     "東珀南語",
-    "东珀南语",
-    "Eastern Penan"
+    "东珀南语"
   ],
   "pfa": [
     "Pááfang"
@@ -23691,8 +21790,7 @@
   ],
   "pga": [
     "朱巴阿拉伯語",
-    "朱巴阿拉伯语",
-    "Juba Arabic"
+    "朱巴阿拉伯语"
   ],
   "pgd": [
     "Gandhari",
@@ -23710,48 +21808,36 @@
   ],
   "pgl": [
     "原始愛爾蘭語",
-    "原始爱尔兰语",
-    "Primitive Irish"
+    "原始爱尔兰语"
   ],
   "pgn": [
     "帕埃利尼語",
-    "帕埃利尼语",
-    "Paelignian"
+    "帕埃利尼语"
   ],
   "pgs": [
     "Pangseng"
   ],
   "pgu": [
     "帕古語",
-    "帕古语",
-    "Pagu",
-    "Pago",
-    "Pagoe"
+    "帕古语"
   ],
   "pgz": [
     "巴布亞紐幾內亞手語",
     "巴布亚纽几内亚手语",
-    "Papua New Guinean Sign Language",
     "Papua New Guinea Sign Language",
     "Melanesian Sign Language",
-    "PNGSL",
-    "",
-    "巴布亚新几内亚手语",
-    "巴布亞新畿內亞手語",
-    "巴布亚新畿内亚手语"
+    "PNGSL"
   ],
   "pha": [
     "巴哼語",
-    "巴哼语",
-    "Pa-Hng"
+    "巴哼语"
   ],
   "phd": [
     "Phudagi"
   ],
   "phg": [
     "方語",
-    "方语",
-    "Phuong"
+    "方语"
   ],
   "phh": [
     "Phukha"
@@ -23768,18 +21854,16 @@
   ],
   "phi-pro": [
     "原始菲律賓語",
-    "原始菲律宾语",
-    "Proto-Philippine"
+    "原始菲律宾语"
   ],
   "phk": [
     "帕克傣語",
     "帕克傣语",
-    "Phake"
+    "Tai Phake"
   ],
   "phl": [
     "帕盧拉語",
     "帕卢拉语",
-    "Phalura",
     "Palula",
     "Palola",
     "Phalulo",
@@ -23790,8 +21874,7 @@
   ],
   "phn": [
     "腓尼基語",
-    "腓尼基语",
-    "Phoenician"
+    "腓尼基语"
   ],
   "pho": [
     "Phunoi"
@@ -23806,8 +21889,7 @@
   ],
   "pht": [
     "普泰語",
-    "普泰语",
-    "Phu Thai"
+    "普泰语"
   ],
   "phu": [
     "Phuan"
@@ -23824,8 +21906,7 @@
   ],
   "pia": [
     "皮馬巴霍語",
-    "皮马巴霍语",
-    "Pima Bajo"
+    "皮马巴霍语"
   ],
   "pib": [
     "Yine",
@@ -23845,13 +21926,11 @@
   ],
   "pie": [
     "皮羅語",
-    "皮罗语",
-    "Piro"
+    "皮罗语"
   ],
   "pif": [
     "平格拉普語",
-    "平格拉普语",
-    "Pingelapese"
+    "平格拉普语"
   ],
   "pig": [
     "Pisabo"
@@ -23859,7 +21938,6 @@
   "pih": [
     "皮特凱恩語",
     "皮特凯恩语",
-    "Pitcairn-Norfolk",
     "Pitkern-Norfuk",
     "Pitcairn",
     "Pitkern",
@@ -23877,8 +21955,7 @@
   ],
   "pim": [
     "波瓦坦語",
-    "波瓦坦语",
-    "Powhatan"
+    "波瓦坦语"
   ],
   "pin": [
     "Piame"
@@ -23893,7 +21970,8 @@
     "Piratapuyo"
   ],
   "pis": [
-    "Pijin",
+    "皮京語",
+    "皮京语",
     "Kanaka",
     "Neo-Solomonic",
     "Solomons Pidgin"
@@ -23908,7 +21986,6 @@
   "piv": [
     "皮勒尼語",
     "皮勒尼语",
-    "Pileni",
     "Vaeakau-Taumako"
   ],
   "piw": [
@@ -23925,21 +22002,18 @@
   ],
   "pjt": [
     "皮詹加加拉語",
-    "皮詹加加拉语",
-    "Pitjantjatjara"
+    "皮詹加加拉语"
   ],
   "pka": [
     "半摩揭陀俗語",
-    "半摩揭陀俗语",
-    "Ardhamagadhi Prakrit"
+    "半摩揭陀俗语"
   ],
   "pkb": [
     "Kipfokomo"
   ],
   "pkc": [
     "百濟語",
-    "百济语",
-    "Baekje"
+    "百济语"
   ],
   "pkg": [
     "Pak-Tong"
@@ -23968,13 +22042,11 @@
   "pks": [
     "巴基斯坦手語",
     "巴基斯坦手语",
-    "Pakistan Sign Language",
     "Pakistani Sign Language"
   ],
   "pkt": [
     "麻楞語",
-    "麻楞语",
-    "Maleng"
+    "麻楞语"
   ],
   "pku": [
     "Paku"
@@ -23995,8 +22067,7 @@
   ],
   "ple": [
     "帕盧厄語",
-    "帕卢厄语",
-    "Palu'e"
+    "帕卢厄语"
   ],
   "plg": [
     "Pilagá",
@@ -24004,30 +22075,25 @@
   ],
   "plh": [
     "保洛希語",
-    "保洛希语",
-    "Paulohi"
+    "保洛希语"
   ],
   "plj": [
     "Polci"
   ],
   "plk": [
-    "Kohistani Shina"
+    "科希斯坦希納語",
+    "科希斯坦希纳语"
   ],
   "pll": [
     "納盎德昂語",
-    "纳盎德昂语",
-    "Shwe Palaung"
+    "纳盎德昂语"
   ],
   "pln": [
     "Palenquero"
   ],
   "plo": [
     "奧魯塔波波魯卡語",
-    "奥鲁塔波波鲁卡语",
-    "Oluta Popoluca"
-  ],
-  "plp": [
-    "Palpa"
+    "奥鲁塔波波鲁卡语"
   ],
   "plq": [
     "Palaic"
@@ -24037,8 +22103,7 @@
   ],
   "pls": [
     "聖馬科斯特拉爾科亞爾科波波洛卡語",
-    "圣马科斯特拉尔科亚尔科波波洛卡语",
-    "San Marcos Tlalcoyalco Popoloca"
+    "圣马科斯特拉尔科亚尔科波波洛卡语"
   ],
   "plu": [
     "Palikur",
@@ -24050,21 +22115,18 @@
   ],
   "plw": [
     "布魯克波因特巴拉望語",
-    "布鲁克波因特巴拉望语",
-    "Brooke's Point Palawano"
+    "布鲁克波因特巴拉望语"
   ],
   "ply": [
     "巴琉語",
-    "巴琉语",
-    "Bolyu"
+    "巴琉语"
   ],
   "plz": [
     "Paluan"
   ],
   "pma": [
     "帕馬語",
-    "帕马语",
-    "Paama"
+    "帕马语"
   ],
   "pmb": [
     "Pambia"
@@ -24078,13 +22140,11 @@
   "pmf": [
     "帕莫納語",
     "帕莫纳语",
-    "Pamona",
     "Bare'e"
   ],
   "pmh": [
     "馬哈拉施特拉俗語",
     "马哈拉施特拉俗语",
-    "Maharastri Prakrit",
     "Maharashtri Prakrit",
     "Maharastri",
     "Maharashtri"
@@ -24092,14 +22152,12 @@
   "pmi": [
     "北普米語",
     "北普米语",
-    "Northern Pumi",
     "Northern Prinmi",
     "Northern Pimi"
   ],
   "pmj": [
     "南普米語",
     "南普米语",
-    "Southern Pumi",
     "Southern Prinmi",
     "Southern Pimi"
   ],
@@ -24124,21 +22182,18 @@
   ],
   "pmq": [
     "北帕梅語",
-    "北帕梅语",
-    "Northern Pame"
+    "北帕梅语"
   ],
   "pmr": [
     "Paynamar"
   ],
   "pms": [
     "皮埃蒙特語",
-    "皮埃蒙特语",
-    "Piedmontese"
+    "皮埃蒙特语"
   ],
   "pmt": [
     "土阿莫土語",
-    "土阿莫土语",
-    "Tuamotuan"
+    "土阿莫土语"
   ],
   "pmu": [
     "Mirpur Panjabi"
@@ -24151,21 +22206,18 @@
   ],
   "pmy": [
     "巴布亞馬來語",
-    "巴布亚马来语",
-    "Papuan Malay"
+    "巴布亚马来语"
   ],
   "pmz": [
     "南帕梅語",
-    "南帕梅语",
-    "Southern Pame"
+    "南帕梅语"
   ],
   "pna": [
     "Punan Bah-Biau"
   ],
   "pnb": [
     "西旁遮普語",
-    "西旁遮普语",
-    "Western Panjabi"
+    "西旁遮普语"
   ],
   "pnc": [
     "Pannei"
@@ -24175,8 +22227,7 @@
   ],
   "pne": [
     "西珀南語",
-    "西珀南语",
-    "Western Penan"
+    "西珀南语"
   ],
   "png": [
     "Pongu"
@@ -24184,7 +22235,6 @@
   "pnh": [
     "彭林語",
     "彭林语",
-    "Penrhyn",
     "Tongareva",
     "Tongarewa"
   ],
@@ -24228,13 +22278,11 @@
   "pnt": [
     "旁狄希臘語",
     "旁狄希腊语",
-    "Pontic Greek",
     "Pontic"
   ],
   "pnu": [
     "炯奈語",
     "炯奈语",
-    "Jiongnai Bunu",
     "Kiong Nai"
   ],
   "pnv": [
@@ -24245,8 +22293,7 @@
   ],
   "pnx": [
     "克年語",
-    "克年语",
-    "Phong-Kniang"
+    "克年语"
   ],
   "pny": [
     "Pinyin"
@@ -24261,8 +22308,7 @@
   ],
   "poe": [
     "聖胡安阿欽戈波波洛卡語",
-    "圣胡安阿钦戈波波洛卡语",
-    "San Juan Atzingo Popoloca"
+    "圣胡安阿钦戈波波洛卡语"
   ],
   "pof": [
     "Poke"
@@ -24275,8 +22321,7 @@
   ],
   "poi": [
     "高地波波魯卡語",
-    "高地波波鲁卡语",
-    "Highland Popoluca"
+    "高地波波鲁卡语"
   ],
   "pok": [
     "Pokangá"
@@ -24286,8 +22331,7 @@
   ],
   "pon": [
     "波納佩語",
-    "波纳佩语",
-    "Pohnpeian"
+    "波纳佩语"
   ],
   "poo": [
     "Central Pomo"
@@ -24297,24 +22341,20 @@
   ],
   "poq": [
     "特西斯特佩克波波魯卡語",
-    "特西斯特佩克波波鲁卡语",
-    "Texistepec Popoluca"
+    "特西斯特佩克波波鲁卡语"
   ],
   "pos": [
     "薩約拉波波魯卡語",
-    "萨约拉波波鲁卡语",
-    "Sayula Popoluca"
+    "萨约拉波波鲁卡语"
   ],
   "pot": [
     "珀塔瓦托米語",
     "珀塔瓦托米语",
-    "Potawatomi",
     "Pottawatomie"
   ],
   "pov": [
     "幾內亞比紹克里奧爾語",
     "几内亚比绍克里奥尔语",
-    "Guinea-Bissau Creole",
     "Upper Guinea Creole",
     "Upper Guinea Crioulo",
     "Kriol",
@@ -24325,8 +22365,7 @@
   ],
   "pow": [
     "聖費利佩奧特拉特佩克波波洛卡語",
-    "圣费利佩奥特拉特佩克波波洛卡语",
-    "San Felipe Otlaltepec Popoloca"
+    "圣费利佩奥特拉特佩克波波洛卡语"
   ],
   "pox": [
     "波拉布語",
@@ -24338,7 +22377,6 @@
   "poz-abi": [
     "阿拜語",
     "阿拜语",
-    "Abai",
     "Sembuak",
     "Tubu"
   ],
@@ -24350,8 +22388,7 @@
   ],
   "poz-cet-pro": [
     "原始中-東部馬來-波利尼西亞語",
-    "原始中-东部马来-波利尼西亚语",
-    "Proto-Central-Eastern Malayo-Polynesian"
+    "原始中-东部马来-波利尼西亚语"
   ],
   "poz-hce-pro": [
     "Proto-Halmahera-Cenderawasih",
@@ -24359,67 +22396,55 @@
   ],
   "poz-lgx-pro": [
     "原始楠榜語",
-    "原始楠榜语",
-    "Proto-Lampungic"
+    "原始楠榜语"
   ],
   "poz-mcm-pro": [
     "原始馬來-占語",
-    "原始马来-占语",
-    "Proto-Malayo-Chamic"
+    "原始马来-占语"
   ],
   "poz-mly-pro": [
     "原始馬來語",
-    "原始马来语",
-    "Proto-Malayic"
+    "原始马来语"
   ],
   "poz-msa-pro": [
     "原始馬來-松巴哇語",
-    "原始马来-松巴哇语",
-    "Proto-Malayo-Sumbawan"
+    "原始马来-松巴哇语"
   ],
   "poz-oce-pro": [
     "原始大洋洲語",
-    "原始大洋洲语",
-    "Proto-Oceanic"
+    "原始大洋洲语"
   ],
   "poz-pep-pro": [
     "原始東部波利尼西亞語",
     "原始东部波利尼西亚语",
-    "Proto-Eastern Polynesian",
     "Proto-Eastern-Polynesian",
     "Proto-East Polynesian",
     "Proto-East-Polynesian"
   ],
   "poz-pnp-pro": [
     "原始核心波利尼西亞語",
-    "原始核心波利尼西亚语",
-    "Proto-Nuclear Polynesian"
+    "原始核心波利尼西亚语"
   ],
   "poz-pol-pro": [
     "原始波利尼西亞語",
-    "原始波利尼西亚语",
-    "Proto-Polynesian"
+    "原始波利尼西亚语"
   ],
   "poz-pro": [
     "原始馬來-波利尼西亞語",
     "原始马来-波利尼西亚语",
-    "Proto-Malayo-Polynesian",
     "Proto-Western Malayo-Polynesian"
   ],
   "poz-ssw-pro": [
     "原始南蘇拉威西語",
-    "原始南苏拉威西语",
-    "Proto-South Sulawesi"
+    "原始南苏拉威西语"
   ],
   "poz-sus-pro": [
     "原始巽他-蘇拉威西語",
-    "原始巽他-苏拉威西语",
-    "Proto-Sunda-Sulawesi"
+    "原始巽他-苏拉威西语"
   ],
   "poz-swa-pro": [
     "原始北沙撈越語",
-    "原始北沙捞越语",
-    "Proto-North Sarawak"
+    "原始北沙捞越语"
   ],
   "ppa": [
     "Pao"
@@ -24430,19 +22455,15 @@
   "ppi": [
     "帕伊帕伊語",
     "帕伊帕伊语",
-    "Paipai",
     "Akwa'ala"
   ],
   "ppk": [
     "烏馬語",
-    "乌马语",
-    "Uma",
-    "Pipikoro"
+    "乌马语"
   ],
   "ppl": [
     "皮皮爾語",
     "皮皮尔语",
-    "Pipil",
     "Nahuat",
     "Náhuat",
     "Nawat",
@@ -24465,16 +22486,12 @@
     "Suri",
     "Sopese"
   ],
-  "ppp": [
-    "Pelende"
-  ],
   "ppq": [
     "Pei"
   ],
   "pps": [
     "聖路易特馬拉卡約卡波波洛卡語",
-    "圣路易特马拉卡约卡波波洛卡语",
-    "San Luís Temalacayuca Popoloca"
+    "圣路易特马拉卡约卡波波洛卡语"
   ],
   "ppt": [
     "Pa",
@@ -24485,31 +22502,19 @@
   "ppu": [
     "拍瀑拉語",
     "拍瀑拉语",
-    "Papora",
     "Hoanya",
     "Papola",
     "Paporan",
     "Bupuran",
     "Vupuran",
-    "Hinapavosa",
-    "巴布拉語",
-    "巴布拉语",
-    "干仔轄語",
-    "干仔辖语",
-    "洪雅語",
-    "洪雅语",
-    "洪安雅語",
-    "洪安雅语",
-    "和安雅語",
-    "和安雅语"
+    "Hinapavosa"
   ],
   "pqa": [
     "Pa'a"
   ],
   "pqe-pro": [
     "原始東部馬來-波利尼西亞語",
-    "原始东部马来-波利尼西亚语",
-    "Proto-Eastern Malayo-Polynesian"
+    "原始东部马来-波利尼西亚语"
   ],
   "pqm": [
     "Malecite-Passamaquoddy",
@@ -24525,8 +22530,7 @@
   ],
   "pre": [
     "普林西比語",
-    "普林西比语",
-    "Principense"
+    "普林西比语"
   ],
   "prf": [
     "Paranan"
@@ -24534,9 +22538,6 @@
   "prg": [
     "古普魯士語",
     "古普鲁士语",
-    "普魯士語",
-    "普鲁士语",
-    "Old Prussian",
     "Prussian"
   ],
   "prh": [
@@ -24547,17 +22548,10 @@
   ],
   "prk": [
     "巴饒克語",
-    "巴饶克语",
-    "Parauk",
-    "巴饒克方言",
-    "巴饶克方言"
+    "巴饶克语"
   ],
   "prl": [
     "秘魯手語",
-    "秘鲁手语",
-    "Peruvian Sign Language",
-    "祕魯手語",
-    "秘鲁手语",
     "秘鲁手语"
   ],
   "prm": [
@@ -24569,14 +22563,12 @@
   "pro": [
     "古奧克語",
     "古奥克语",
-    "Old Occitan",
     "Old Provençal",
     "Old Provencal"
   ],
   "prq": [
     "佩勒內阿舍寧卡語",
-    "佩勒内阿舍宁卡语",
-    "Ashéninka Perené"
+    "佩勒内阿舍宁卡语"
   ],
   "prr": [
     "Puri"
@@ -24584,7 +22576,6 @@
   "prt": [
     "派語",
     "派语",
-    "Phai",
     "Prai",
     "Pray",
     "Phray"
@@ -24601,7 +22592,6 @@
   "prz": [
     "普羅維登西亞手語",
     "普罗维登西亚手语",
-    "Providencia Sign Language",
     "Providence Island Sign Language"
   ],
   "ps": [
@@ -24610,8 +22600,7 @@
     "Pashtun",
     "Pushto",
     "Pashtu",
-    "阿富汗語",
-    "阿富汗语"
+    "Afghani"
   ],
   "psa": [
     "Asue Awyu",
@@ -24619,41 +22608,34 @@
   ],
   "psc": [
     "波斯手語",
-    "波斯手语",
-    "Persian Sign Language"
+    "波斯手语"
   ],
   "psd": [
     "平原印第安手語",
-    "平原印第安手语",
-    "Plains Indian Sign Language"
+    "平原印第安手语"
   ],
   "pse": [
     "中馬來語",
-    "中马来语",
-    "Central Malay"
+    "中马来语"
   ],
   "psg": [
     "檳城手語",
-    "槟城手语",
-    "Penang Sign Language"
+    "槟城手语"
   ],
   "psh": [
     "西南帕沙伊語",
-    "西南帕沙伊语",
-    "Southwest Pashayi"
+    "西南帕沙伊语"
   ],
   "psi": [
     "東南帕沙伊語",
     "东南帕沙伊语",
-    "Southeast Pashayi",
     "Southeastern Pashayi",
     "Southeastern Pashai",
     "Southeast Pashai"
   ],
   "psl": [
     "波多黎各手語",
-    "波多黎各手语",
-    "Puerto Rican Sign Language"
+    "波多黎各手语"
   ],
   "psm": [
     "Pauserna",
@@ -24664,21 +22646,18 @@
   ],
   "pso": [
     "波蘭手語",
-    "波兰手语",
-    "Polish Sign Language"
+    "波兰手语"
   ],
   "psp": [
     "菲律賓手語",
-    "菲律宾手语",
-    "Philippine Sign Language"
+    "菲律宾手语"
   ],
   "psq": [
     "Pasi"
   ],
   "psr": [
     "葡萄牙手語",
-    "葡萄牙手语",
-    "Portuguese Sign Language"
+    "葡萄牙手语"
   ],
   "pss": [
     "Kaulong"
@@ -24698,8 +22677,7 @@
   "pt": [
     "葡萄牙語",
     "葡萄牙语",
-    "現代葡萄牙語",
-    "现代葡萄牙语"
+    "Modern Portuguese"
   ],
   "pta": [
     "Pai Tavytera"
@@ -24744,7 +22722,6 @@
   "pua": [
     "普雷佩查語",
     "普雷佩查语",
-    "Purepecha",
     "Tarascan",
     "Tarasco",
     "P'urhepecha",
@@ -24752,9 +22729,7 @@
     "P'urhépecha",
     "Phorhépecha",
     "Phorhé",
-    "Porhé",
-    "塔拉斯卡語",
-    "塔拉斯卡语"
+    "Porhé"
   ],
   "pub": [
     "Purum",
@@ -24792,8 +22767,7 @@
   ],
   "puo": [
     "欣門語",
-    "欣门语",
-    "Puoc"
+    "欣门语"
   ],
   "pup": [
     "Pulabu"
@@ -24834,8 +22808,7 @@
   ],
   "pwb": [
     "帕納瓦語",
-    "帕纳瓦语",
-    "Panawa"
+    "帕纳瓦语"
   ],
   "pwg": [
     "Gapapaiwa"
@@ -24853,15 +22826,13 @@
   ],
   "pwn": [
     "排灣語",
-    "排湾语",
-    "Paiwan"
+    "排湾语"
   ],
   "pwo": [
     "西波克倫語",
     "西波克伦语",
-    "Western Pwo",
     "Delta Pwo",
-    "Pwo Western Karen"
+    "Western Pwo Karen"
   ],
   "pwr": [
     "Powari"
@@ -24869,14 +22840,12 @@
   "pww": [
     "北波克倫語",
     "北波克伦语",
-    "Northern Pwo",
     "Phlong",
-    "Pwo Northern Karen"
+    "Northern Pwo Karen"
   ],
   "pxm": [
     "科扎爾特佩克米塞語",
-    "科扎尔特佩克米塞语",
-    "Quetzaltepec Mixe"
+    "科扎尔特佩克米塞语"
   ],
   "pye": [
     "Pye Krumen"
@@ -24892,14 +22861,11 @@
   ],
   "pys": [
     "巴拉圭手語",
-    "巴拉圭手语",
-    "Paraguayan Sign Language"
+    "巴拉圭手语"
   ],
   "pyu": [
     "卑南語",
-    "卑南语",
-    "Puyuma",
-    "Pinuyumayan"
+    "卑南语"
   ],
   "pyx": [
     "驃語",
@@ -24913,90 +22879,77 @@
   ],
   "pzh": [
     "巴宰語",
-    "巴宰语",
-    "Pazeh"
+    "巴宰语"
   ],
   "pzn": [
     "Para Naga"
   ],
   "qfa-adm-pro": [
     "原始大安達曼語",
-    "原始大安达曼语",
-    "Proto-Great Andamanese"
+    "原始大安达曼语"
   ],
   "qfa-bet-pro": [
     "原始貝台語",
     "原始贝台语",
-    "Proto-Be-Tai",
     "Proto-Tai-Be"
   ],
   "qfa-cka-pro": [
     "原始楚科奇-堪察加語",
-    "原始楚科奇-堪察加语",
-    "Proto-Chukotko-Kamchatkan"
+    "原始楚科奇-堪察加语"
   ],
   "qfa-hur-pro": [
     "原始胡里安-烏拉爾圖語",
-    "原始胡里安-乌拉尔图语",
-    "Proto-Hurro-Urartian"
+    "原始胡里安-乌拉尔图语"
   ],
   "qfa-kad-pro": [
     "Proto-Kadu"
   ],
   "qfa-kms-pro": [
     "原始侗水語",
-    "原始侗水语",
-    "Proto-Kam-Sui"
+    "原始侗水语"
   ],
   "qfa-kor-pro": [
     "原始朝鮮語",
-    "原始朝鲜语",
-    "Proto-Korean"
+    "原始朝鲜语"
   ],
   "qfa-kra-pro": [
     "原始仡佬語",
-    "原始仡佬语",
-    "Proto-Kra"
+    "原始仡佬语"
   ],
   "qfa-lic-pro": [
     "原始黎語",
-    "原始黎语",
-    "Proto-Hlai"
+    "原始黎语"
   ],
   "qfa-onb-pro": [
     "原始貝語",
     "原始贝语",
-    "Proto-Be",
     "Proto-Ong-Be",
     "Proto-Bê"
   ],
   "qfa-ong-pro": [
-    "Proto-Ongan"
+    "原始翁奇語",
+    "原始翁奇语"
   ],
   "qfa-tak-pro": [
     "原始侗台語",
     "原始侗台语",
-    "Proto-Kra-Dai",
     "Proto-Tai-Kadai"
   ],
   "qfa-yen-pro": [
     "原始葉尼塞語",
-    "原始叶尼塞语",
-    "Proto-Yeniseian"
+    "原始叶尼塞语"
   ],
   "qfa-yuk-pro": [
     "原始尤卡吉爾語",
-    "原始尤卡吉尔语",
-    "Proto-Yukaghir"
+    "原始尤卡吉尔语"
   ],
   "qu": [
     "克丘亞語",
-    "克丘亚语",
-    "奇楚瓦語",
-    "奇楚瓦语"
+    "克丘亚语"
   ],
   "qua": [
-    "Quapaw",
+    "夸保語",
+    "夸保语",
     "Arkansas"
   ],
   "quc": [
@@ -25029,8 +22982,7 @@
   ],
   "qwc": [
     "古典克丘亞語",
-    "古典克丘亚语",
-    "Classical Quechua"
+    "古典克丘亚语"
   ],
   "qwe-kch": [
     "Kichwa",
@@ -25048,11 +23000,6 @@
   "qwm": [
     "欽察語",
     "钦察语",
-    "克普恰克語",
-    "克普恰克语",
-    "奇普恰克語",
-    "奇普恰克语",
-    "Kipchak",
     "Kypchak",
     "Qypchaq",
     "Armeno-Kipchak",
@@ -25068,11 +23015,11 @@
   ],
   "qxs": [
     "南羌語",
-    "南羌语",
-    "Southern Qiang"
+    "南羌语"
   ],
   "qya": [
-    "Quenya"
+    "昆雅語",
+    "昆雅语"
   ],
   "qyp": [
     "Quiripi",
@@ -25098,13 +23045,11 @@
   "rad": [
     "埃地語",
     "埃地语",
-    "Rade",
     "Rhade"
   ],
   "raf": [
     "西梅瓦杭語",
-    "西梅瓦杭语",
-    "Western Meohang"
+    "西梅瓦杭语"
   ],
   "rag": [
     "Logooli",
@@ -25114,7 +23059,6 @@
   "rah": [
     "拉巴語",
     "拉巴语",
-    "Rabha",
     "Maituri",
     "Rongdani",
     "Rava"
@@ -25132,8 +23076,7 @@
   ],
   "raj": [
     "拉賈斯坦語",
-    "拉贾斯坦语",
-    "Rajasthani"
+    "拉贾斯坦语"
   ],
   "rak": [
     "Tulu-Bohuai",
@@ -25146,7 +23089,6 @@
   "ram": [
     "卡內拉語",
     "卡内拉语",
-    "Canela",
     "Krahô",
     "Canela-Krahô"
   ],
@@ -25160,7 +23102,6 @@
   "rap": [
     "拉帕努伊語",
     "拉帕努伊语",
-    "Rapa Nui",
     "Rapanui",
     "Pascuense"
   ],
@@ -25170,7 +23111,6 @@
   "rar": [
     "拉羅湯加語",
     "拉罗汤加语",
-    "Rarotongan",
     "Cook Islands Maori",
     "Cook Islands Māori"
   ],
@@ -25196,40 +23136,34 @@
   ],
   "raw": [
     "日旺語",
-    "日旺语",
-    "Rawang"
+    "日旺语"
   ],
   "rax": [
     "Rang"
   ],
   "ray": [
     "拉帕語",
-    "拉帕语",
-    "Rapa"
+    "拉帕语"
   ],
   "raz": [
     "Rahambuu"
   ],
   "rbb": [
     "若買德昂語",
-    "若买德昂语",
-    "Rumai Palaung"
+    "若买德昂语"
   ],
   "rbk": [
     "北邦托克語",
     "北邦托克语",
-    "Northern Bontoc",
     "Northern Bontok"
   ],
   "rbl": [
     "米拉亞比科爾語",
-    "米拉亚比科尔语",
-    "Miraya Bikol"
+    "米拉亚比科尔语"
   ],
   "rcf": [
     "留尼旺克里奧爾法語",
-    "留尼旺克里奥尔法语",
-    "Réunion Creole French"
+    "留尼旺克里奥尔法语"
   ],
   "rdb": [
     "Rudbari"
@@ -25239,8 +23173,7 @@
   ],
   "reb": [
     "勒姆邦語",
-    "勒姆邦语",
-    "Rembong"
+    "勒姆邦语"
   ],
   "ree": [
     "Rejang Kayan",
@@ -25264,7 +23197,6 @@
   "rej": [
     "勒姜語",
     "勒姜语",
-    "Rejang",
     "Rejangese"
   ],
   "rel": [
@@ -25275,8 +23207,7 @@
   ],
   "ren": [
     "盧敖語",
-    "卢敖语",
-    "Rengao"
+    "卢敖语"
   ],
   "rer": [
     "Rer Bare"
@@ -25293,13 +23224,11 @@
   ],
   "rga": [
     "羅里亞語",
-    "罗里亚语",
-    "Roria"
+    "罗里亚语"
   ],
   "rge": [
     "羅姆希臘語",
     "罗姆希腊语",
-    "Romani Greek",
     "Romano-Greek",
     "Hellenoromani"
   ],
@@ -25309,7 +23238,6 @@
   "rgn": [
     "羅馬涅語",
     "罗马涅语",
-    "Romagnol",
     "Romagnolo"
   ],
   "rgr": [
@@ -25323,8 +23251,7 @@
   ],
   "rhg": [
     "羅興亞語",
-    "罗兴亚语",
-    "Rohingya"
+    "罗兴亚语"
   ],
   "rhp": [
     "Yahang"
@@ -25336,22 +23263,15 @@
   "rif": [
     "里菲安語",
     "里菲安语",
-    "Tarifit",
-    "Rifain",
-    "里菲亞語",
-    "里菲亚语",
-    "里夫語",
-    "里夫语"
+    "Rifain"
   ],
   "ril": [
     "日昂語",
-    "日昂语",
-    "Riang"
+    "日昂语"
   ],
   "rim": [
     "尼亞圖魯語",
-    "尼亚图鲁语",
-    "Nyaturu"
+    "尼亚图鲁语"
   ],
   "rin": [
     "Nungu"
@@ -25378,8 +23298,7 @@
   ],
   "rka": [
     "克勞爾語",
-    "克劳尔语",
-    "Kraol"
+    "克劳尔语"
   ],
   "rkb": [
     "Rikbaktsa",
@@ -25389,13 +23308,11 @@
   ],
   "rkh": [
     "拉卡漢加-曼尼希基語",
-    "拉卡汉加-曼尼希基语",
-    "Rakahanga-Manihiki"
+    "拉卡汉加-曼尼希基语"
   ],
   "rki": [
     "若開語",
     "若开语",
-    "Rakhine",
     "Arakanese",
     "Ramree",
     "Yangbye",
@@ -25411,8 +23328,7 @@
   ],
   "rkw": [
     "阿拉瓜爾語",
-    "阿拉瓜尔语",
-    "Arakwal"
+    "阿拉瓜尔语"
   ],
   "rm": [
     "羅曼什語",
@@ -25429,57 +23345,48 @@
   ],
   "rmc": [
     "喀爾巴阡羅姆語",
-    "喀尔巴阡罗姆语",
-    "Carpathian Romani"
+    "喀尔巴阡罗姆语"
   ],
   "rmd": [
     "旅行者丹麥語",
-    "旅行者丹麦语",
-    "Traveller Danish"
+    "旅行者丹麦语"
   ],
   "rme": [
     "盎格魯羅姆語",
-    "盎格鲁罗姆语",
-    "Angloromani"
+    "盎格鲁罗姆语"
   ],
   "rmf": [
     "芬蘭羅姆語",
-    "芬兰罗姆语",
-    "Kalo Finnish Romani"
+    "芬兰罗姆语"
   ],
   "rmg": [
     "旅行者挪威語",
-    "旅行者挪威语",
-    "Traveller Norwegian"
+    "旅行者挪威语"
   ],
   "rmh": [
     "Murkim"
   ],
   "rmi": [
     "洛馬夫倫語",
-    "洛马夫伦语",
-    "Lomavren"
+    "洛马夫伦语"
   ],
   "rmk": [
     "Romkun"
   ],
   "rml": [
     "波羅的羅姆語",
-    "波罗的罗姆语",
-    "Baltic Romani"
+    "波罗的罗姆语"
   ],
   "rmm": [
     "Roma"
   ],
   "rmn": [
     "巴爾幹羅姆語",
-    "巴尔干罗姆语",
-    "Balkan Romani"
+    "巴尔干罗姆语"
   ],
   "rmo": [
     "辛特羅姆語",
     "辛特罗姆语",
-    "Sinte Romani",
     "Sinti Romani",
     "Sinti-Manouche",
     "Sinti"
@@ -25489,23 +23396,19 @@
   ],
   "rmq": [
     "伊比利吉普賽語",
-    "伊比利吉普赛语",
-    "Caló"
+    "伊比利吉普赛语"
   ],
   "rms": [
     "羅馬尼亞手語",
-    "罗马尼亚手语",
-    "Romanian Sign Language"
+    "罗马尼亚手语"
   ],
   "rmt": [
     "多姆語",
-    "多姆语",
-    "Domari"
+    "多姆语"
   ],
   "rmu": [
     "斯堪地羅姆語",
-    "斯堪地罗姆语",
-    "Tavringer Romani"
+    "斯堪地罗姆语"
   ],
   "rmv": [
     "Romanova"
@@ -25513,32 +23416,20 @@
   "rmw": [
     "威爾士羅姆語",
     "威尔士罗姆语",
-    "Welsh Romani",
     "Welsh Romany",
     "Kååle"
   ],
   "rmx": [
     "盧曼語",
-    "卢曼语",
-    "Romam",
-    "盧曼卡喬語",
-    "卢曼卡乔语"
+    "卢曼语"
   ],
   "rmy": [
     "弗拉赫羅姆語",
-    "弗拉赫罗姆语",
-    "Vlax Romani"
+    "弗拉赫罗姆语"
   ],
   "rmz": [
     "馬爾馬語",
-    "马尔马语",
-    "Marma"
-  ],
-  "rn": [
-    "克倫地語",
-    "克伦地语",
-    "基隆迪語",
-    "基隆迪语"
+    "马尔马语"
   ],
   "rnd": [
     "Ruwund",
@@ -25549,7 +23440,6 @@
   "rng": [
     "龍加語",
     "龙加语",
-    "Ronga",
     "Xironga"
   ],
   "rnl": [
@@ -25563,18 +23453,18 @@
   ],
   "rnw": [
     "龍瓦語",
-    "龙瓦语",
-    "Rungwa"
+    "龙瓦语"
   ],
   "ro": [
     "羅馬尼亞語",
     "罗马尼亚语",
-    "Daco-Romanian"
+    "Daco-Romanian",
+    "Roumanian",
+    "Rumanian"
   ],
   "roa-ang": [
     "安茹語",
     "安茹语",
-    "Angevin",
     "Craonnais",
     "Baugeois",
     "Saumurois"
@@ -25592,7 +23482,6 @@
   "roa-brg": [
     "勃艮第語",
     "勃艮第语",
-    "Bourguignon",
     "Burgundian",
     "Bregognon",
     "Dijonnais",
@@ -25613,7 +23502,6 @@
   "roa-cha": [
     "香檳語",
     "香槟语",
-    "Champenois",
     "Bassignot",
     "Langrois",
     "Sennonais",
@@ -25631,7 +23519,6 @@
   "roa-fcm": [
     "弗朗什-孔泰語",
     "弗朗什-孔泰语",
-    "Franc-Comtois",
     "Frainc-Comtou",
     "Comtois",
     "Jurassien",
@@ -25643,18 +23530,15 @@
   ],
   "roa-gal": [
     "加羅語",
-    "加罗语",
-    "Gallo"
+    "加罗语"
   ],
   "roa-leo": [
     "萊昂語",
-    "莱昂语",
-    "Leonese"
+    "莱昂语"
   ],
   "roa-lor": [
     "洛林語",
     "洛林语",
-    "Lorrain",
     "Gaumais",
     "Vosgien",
     "Welche",
@@ -25668,31 +23552,29 @@
   "roa-oan": [
     "納瓦拉-阿拉貢語",
     "纳瓦拉-阿拉贡语",
-    "Navarro-Aragonese",
     "Old Aragonese"
   ],
   "roa-oca": [
     "古加泰羅尼亞語",
-    "古加泰罗尼亚语",
-    "Old Catalan"
+    "古加泰罗尼亚语"
   ],
   "roa-ole": [
     "古萊昂語",
-    "古莱昂语",
-    "Old Leonese"
+    "古莱昂语"
   ],
   "roa-opt": [
     "古葡萄牙語",
     "古葡萄牙语",
-    "Old Portuguese",
     "Galician-Portuguese",
     "Galician Portuguese",
-    "Medieval Galician"
+    "Medieval Galician",
+    "Medieval Portuguese",
+    "Old Galician",
+    "Old Portuguese"
   ],
   "roa-orl": [
     "奧爾良語",
     "奥尔良语",
-    "Orléanais",
     "Beauceron",
     "Solognot",
     "Gâtinais",
@@ -25707,20 +23589,17 @@
   ],
   "roa-tar": [
     "塔倫蒂諾語",
-    "塔伦蒂诺语",
-    "Tarantino"
+    "塔伦蒂诺语"
   ],
   "roa-tou": [
     "圖蘭格語",
     "图兰格语",
-    "Tourangeau",
     "Tourangian",
     "Tourangean"
   ],
   "rob": [
     "塔埃語",
-    "塔埃语",
-    "Tae'"
+    "塔埃语"
   ],
   "roc": [
     "Cacgia Roglai"
@@ -25740,24 +23619,20 @@
   ],
   "rol": [
     "朗布隆語",
-    "朗布隆语",
-    "Romblomanon"
+    "朗布隆语"
   ],
   "rom": [
     "羅姆語",
     "罗姆语",
-    "Romani",
     "Gypsy"
   ],
   "roo": [
     "羅托卡特語",
-    "罗托卡特语",
-    "Rotokas"
+    "罗托卡特语"
   ],
   "rop": [
     "澳洲克里奧爾語",
     "澳洲克里奥尔语",
-    "Kriol",
     "Australian Kriol"
   ],
   "ror": [
@@ -25789,8 +23664,7 @@
   ],
   "rsl": [
     "俄羅斯手語",
-    "俄罗斯手语",
-    "Russian Sign Language"
+    "俄罗斯手语"
   ],
   "rsm": [
     "Miriwoong Sign Language"
@@ -25802,24 +23676,18 @@
   ],
   "rth": [
     "拉塔罕語",
-    "拉塔罕语",
-    "Ratahan"
+    "拉塔罕语"
   ],
   "rtm": [
     "羅圖馬語",
-    "罗图马语",
-    "Rotuman",
-    "洛圖馬語",
-    "洛图马语"
+    "罗图马语"
   ],
   "rtw": [
     "Rathawi"
   ],
   "ru": [
     "俄語",
-    "俄语",
-    "俄羅斯語",
-    "俄罗斯语"
+    "俄语"
   ],
   "rub": [
     "Gungu"
@@ -25829,8 +23697,7 @@
   ],
   "rue": [
     "盧森尼亞語",
-    "卢森尼亚语",
-    "Rusyn"
+    "卢森尼亚语"
   ],
   "ruf": [
     "Luguru"
@@ -25850,27 +23717,19 @@
   ],
   "ruo": [
     "伊斯特羅-羅馬尼亞語",
-    "伊斯特罗-罗马尼亚语",
-    "伊斯特拉-羅馬尼亞語",
-    "伊斯特拉-罗马尼亚语",
-    "Istro-Romanian"
+    "伊斯特罗-罗马尼亚语"
   ],
   "rup": [
     "阿羅馬尼亞語",
-    "阿罗马尼亚语",
-    "Aromanian"
+    "阿罗马尼亚语"
   ],
   "ruq": [
     "梅戈來諾-羅馬尼亞語",
-    "梅戈来诺-罗马尼亚语",
-    "Megleno-Romanian"
+    "梅戈来诺-罗马尼亚语"
   ],
   "rut": [
     "魯圖爾語",
-    "鲁图尔语",
-    "Rutul",
-    "塔特語",
-    "塔特语"
+    "鲁图尔语"
   ],
   "ruu": [
     "Lanas Lobu"
@@ -25907,20 +23766,15 @@
   ],
   "ryn": [
     "北奄美大島語",
-    "北奄美大岛语",
-    "Northern Amami-Oshima"
+    "北奄美大岛语"
   ],
   "rys": [
     "八重山語",
-    "八重山语",
-    "Yaeyama"
+    "八重山语"
   ],
   "ryu": [
     "沖繩語",
-    "冲绳语",
-    "琉球語",
-    "琉球语",
-    "Okinawan"
+    "冲绳语"
   ],
   "rzh": [
     "Razihi",
@@ -25933,8 +23787,7 @@
   ],
   "saa": [
     "薩巴語",
-    "萨巴语",
-    "Saba"
+    "萨巴语"
   ],
   "sab": [
     "Buglere",
@@ -25966,7 +23819,6 @@
   "sah": [
     "雅庫特語",
     "雅库特语",
-    "Yakut",
     "Sakha"
   ],
   "sai-ajg": [
@@ -26052,7 +23904,6 @@
   "sai-cer-pro": [
     "原始塞拉多語",
     "原始塞拉多语",
-    "Proto-Cerrado",
     "Proto-Amazonian Jê"
   ],
   "sai-chi": [
@@ -26084,7 +23935,6 @@
   "sai-cje-pro": [
     "原始中熱語",
     "原始中热语",
-    "Proto-Central Jê",
     "Proto-Akuwẽ"
   ],
   "sai-cmg": [
@@ -26175,7 +24025,6 @@
   "sai-jee-pro": [
     "原始熱語",
     "原始热语",
-    "Proto-Jê",
     "Proto-Gê",
     "Proto-Jean",
     "Proto-Gean",
@@ -26212,18 +24061,15 @@
   "sai-mal": [
     "馬拉利語",
     "马拉利语",
-    "Malalí",
     "Malali"
   ],
   "sai-mar": [
     "馬拉蒂諾語",
-    "马拉蒂诺语",
-    "Maratino"
+    "马拉蒂诺语"
   ],
   "sai-mat": [
     "馬塔納維語",
     "马塔纳维语",
-    "Matanawi",
     "Matanauí",
     "Matanaui",
     "Matanawü",
@@ -26233,7 +24079,6 @@
   "sai-mcn": [
     "莫卡納語",
     "莫卡纳语",
-    "Mocana",
     "Mokana"
   ],
   "sai-men": [
@@ -26287,7 +24132,6 @@
   "sai-nje-pro": [
     "原始北熱語",
     "原始北热语",
-    "Proto-Northern Jê",
     "Proto-Core Jê"
   ],
   "sai-opo": [
@@ -26301,7 +24145,6 @@
   "sai-oto": [
     "奧托馬科語",
     "奥托马科语",
-    "Otomaco",
     "Otomako",
     "Otomacan",
     "Otomac",
@@ -26393,7 +24236,6 @@
   "sai-sin": [
     "西努法納語",
     "西努法纳语",
-    "Sinúfana",
     "Cenúfana",
     "Zenúfana",
     "Cinifaná",
@@ -26408,19 +24250,16 @@
   ],
   "sai-sje-pro": [
     "原始南熱語",
-    "原始南热语",
-    "Proto-Southern Jê"
+    "原始南热语"
   ],
   "sai-tab": [
     "塔班卡萊語",
     "塔班卡莱语",
-    "Tabancale",
     "Aconipa"
   ],
   "sai-tal": [
     "塔良語",
     "塔良语",
-    "Tallán",
     "Atalán",
     "Tallan",
     "Tallanca",
@@ -26430,9 +24269,11 @@
   "sai-tap": [
     "塔帕尤納語",
     "塔帕尤纳语",
-    "Tapayuna",
     "Tapayúna",
     "Kajkwakhrattxi"
+  ],
+  "sai-tar-pro": [
+    "Proto-Taranoan"
   ],
   "sai-teu": [
     "Teushen",
@@ -26447,7 +24288,6 @@
   "sai-tpr": [
     "塔帕里塔語",
     "塔帕里塔语",
-    "Taparita",
     "Taparito"
   ],
   "sai-trr": [
@@ -26555,8 +24395,7 @@
   ],
   "saj": [
     "薩胡語",
-    "萨胡语",
-    "Sahu"
+    "萨胡语"
   ],
   "sak": [
     "Sake",
@@ -26565,15 +24404,11 @@
   "sal-pro": [
     "原始薩利希語",
     "原始萨利希语",
-    "Proto-Salish",
     "Proto-Salishan"
   ],
   "sam": [
     "撒馬利亞亞拉姆語",
     "撒马利亚亚拉姆语",
-    "撒馬利亞語",
-    "撒马利亚语",
-    "Samaritan Aramaic",
     "Samaritan"
   ],
   "sao": [
@@ -26595,16 +24430,14 @@
   ],
   "sat": [
     "桑塔利語",
-    "桑塔利语",
-    "Santali"
+    "桑塔利语"
   ],
   "sau": [
     "Saleman"
   ],
   "sav": [
     "薩菲薩菲語",
-    "萨菲萨菲语",
-    "Saafi-Saafi"
+    "萨菲萨菲语"
   ],
   "saw": [
     "Sawi"
@@ -26618,8 +24451,7 @@
   ],
   "saz": [
     "索拉什特拉語",
-    "索拉什特拉语",
-    "Saurashtra"
+    "索拉什特拉语"
   ],
   "sba": [
     "甘拜語",
@@ -26653,7 +24485,6 @@
   "sbh": [
     "索里-哈林甘語",
     "索里-哈林甘语",
-    "Sori-Harengan",
     "Sori",
     "Harengan"
   ],
@@ -26675,8 +24506,7 @@
   ],
   "sbn": [
     "信德比爾語",
-    "信德比尔语",
-    "Sindhi Bhil"
+    "信德比尔语"
   ],
   "sbo": [
     "Sabüm"
@@ -26690,8 +24520,7 @@
   ],
   "sbr": [
     "森巴孔穆魯特語",
-    "森巴孔穆鲁特语",
-    "Sembakung Murut"
+    "森巴孔穆鲁特语"
   ],
   "sbs": [
     "Subiya"
@@ -26704,8 +24533,7 @@
   ],
   "sbv": [
     "薩比尼語",
-    "萨比尼语",
-    "Sabine"
+    "萨比尼语"
   ],
   "sbw": [
     "Simba"
@@ -26721,23 +24549,20 @@
   ],
   "sc": [
     "撒丁語",
-    "撒丁语",
-    "薩丁語",
-    "萨丁语"
+    "撒丁语"
   ],
   "scb": [
-    "Chut"
+    "哲語",
+    "哲语"
   ],
   "sce": [
     "東鄉語",
     "东乡语",
-    "Dongxiang",
     "Santa"
   ],
   "scf": [
     "聖米格爾克里奧爾法語",
-    "圣米格尔克里奥尔法语",
-    "San Miguel Creole French"
+    "圣米格尔克里奥尔法语"
   ],
   "scg": [
     "Sanggau"
@@ -26745,44 +24570,35 @@
   "sch": [
     "薩卡車普語",
     "萨卡车普语",
-    "Sakachep",
     "Khelma"
   ],
   "sci": [
     "斯里蘭卡克里奧爾馬來語",
-    "斯里兰卡克里奥尔马来语",
-    "Sri Lankan Creole Malay"
+    "斯里兰卡克里奥尔马来语"
   ],
   "sck": [
     "薩達里語",
-    "萨达里语",
-    "Sadri"
+    "萨达里语"
   ],
   "scl": [
     "希納語",
     "希纳语",
-    "Shina",
     "Gilgiti",
     "Astori",
     "Chilasi"
   ],
   "scn": [
     "西西里語",
-    "西西里语",
-    "Sicilian"
+    "西西里语"
   ],
   "sco": [
     "低地蘇格蘭語",
     "低地苏格兰语",
-    "蘇格蘭語",
-    "苏格兰语",
-    "Scots",
     "Lowland Scots"
   ],
   "scp": [
     "約爾莫語",
     "约尔莫语",
-    "Yolmo",
     "Hyolmo",
     "Yohlmo",
     "Helambu Sherpa"
@@ -26793,8 +24609,7 @@
   ],
   "scs": [
     "北斯拉維語",
-    "北斯拉维语",
-    "North Slavey"
+    "北斯拉维语"
   ],
   "scu": [
     "Shumcho"
@@ -26814,19 +24629,16 @@
   ],
   "sda": [
     "托拉查-薩達語",
-    "托拉查-萨达语",
-    "Toraja-Sa'dan"
+    "托拉查-萨达语"
   ],
   "sdb": [
     "沙巴克語",
     "沙巴克语",
-    "Shabak",
     "Shabaki"
   ],
   "sdc": [
     "薩薩里語",
-    "萨萨里语",
-    "Sassarese"
+    "萨萨里语"
   ],
   "sde": [
     "Surubu"
@@ -26834,18 +24646,15 @@
   "sdf": [
     "薩爾里語",
     "萨尔里语",
-    "Sarli",
     "Sarliya"
   ],
   "sdg": [
     "沙維語",
-    "沙维语",
-    "Savi"
+    "沙维语"
   ],
   "sdh": [
     "南庫爾德語",
     "南库尔德语",
-    "Southern Kurdish",
     "Kermanshani",
     "Kermanshahi",
     "Kermanshahi Kurdish",
@@ -26859,37 +24668,33 @@
   ],
   "sdl": [
     "沙烏地阿拉伯手語",
-    "沙乌地阿拉伯手语",
-    "Saudi Arabian Sign Language"
+    "沙乌地阿拉伯手语"
   ],
   "sdm": [
     "Semandang"
   ],
   "sdn": [
     "加盧拉語",
-    "加卢拉语",
-    "Gallurese"
+    "加卢拉语"
   ],
   "sdo": [
-    "Bukar-Sadung Bidayuh"
+    "Bukar-Sadung Bidayuh",
+    "Bukar-Sadong"
   ],
   "sdp": [
     "舍朱奔語",
-    "舍朱奔语",
-    "Sherdukpen"
+    "舍朱奔语"
   ],
   "sdr": [
     "奧拉昂薩達里語",
-    "奥拉昂萨达里语",
-    "Oraon Sadri"
+    "奥拉昂萨达里语"
   ],
   "sds": [
-    "Sened"
+    "Tunisian Berber"
   ],
   "sdu": [
     "薩魯杜語",
-    "萨鲁杜语",
-    "Sarudu"
+    "萨鲁杜语"
   ],
   "sdv-daj-pro": [
     "Proto-Daju"
@@ -26912,21 +24717,20 @@
   "se": [
     "北薩米語",
     "北萨米语",
-    "北方薩米語",
-    "北方萨米语"
+    "North Sami",
+    "Northern Saami",
+    "North Saami"
   ],
   "sea": [
     "塞邁語",
-    "塞迈语",
-    "Semai"
+    "塞迈语"
   ],
   "sec": [
     "Sechelt"
   ],
   "sed": [
     "色當語",
-    "色当语",
-    "Sedang"
+    "色当语"
   ],
   "see": [
     "塞訥卡語",
@@ -26958,15 +24762,11 @@
   ],
   "sel": [
     "塞爾庫普語",
-    "塞尔库普语",
-    "Selkup",
-    "謝爾庫普語",
-    "谢尔库普语"
+    "塞尔库普语"
   ],
   "sem-amm": [
     "亞捫語",
-    "亚扪语",
-    "Ammonite"
+    "亚扪语"
   ],
   "sem-amo": [
     "Amorite",
@@ -26974,7 +24774,9 @@
   ],
   "sem-cha": [
     "Chaha",
-    "Cheha"
+    "Cheha",
+    "Čäha",
+    "Čäxa"
   ],
   "sem-dad": [
     "Dadanitic",
@@ -27002,20 +24804,21 @@
   "sem-mhr": [
     "Muher",
     "Muher Gurage",
-    "Muxar"
+    "Muxar",
+    "Muxər",
+    "Muhər",
+    "Muḫər"
   ],
   "sem-pro": [
     "原始閃米特語",
-    "原始闪米特语",
-    "Proto-Semitic"
+    "原始闪米特语"
   ],
   "sem-saf": [
     "Safaitic"
   ],
   "sem-srb": [
     "古南阿拉伯語",
-    "古南阿拉伯语",
-    "Old South Arabian"
+    "古南阿拉伯语"
   ],
   "sem-tay": [
     "Taymanitic",
@@ -27027,8 +24830,7 @@
   ],
   "sem-wes-pro": [
     "原始西閃米特語",
-    "原始西闪米特语",
-    "Proto-West Semitic"
+    "原始西闪米特语"
   ],
   "sen": [
     "Nanerigé Sénoufo"
@@ -27075,18 +24877,15 @@
   ],
   "sfb": [
     "法國比利時手語",
-    "法国比利时手语",
-    "French Belgian Sign Language"
+    "法国比利时手语"
   ],
   "sfm": [
     "小花苗語",
-    "小花苗语",
-    "Small Flowery Miao"
+    "小花苗语"
   ],
   "sfs": [
     "南非手語",
-    "南非手语",
-    "South African Sign Language"
+    "南非手语"
   ],
   "sfw": [
     "Sehwi"
@@ -27097,8 +24896,7 @@
   ],
   "sga": [
     "古愛爾蘭語",
-    "古爱尔兰语",
-    "Old Irish"
+    "古爱尔兰语"
   ],
   "sgb": [
     "麥安契埃塔語",
@@ -27109,24 +24907,20 @@
   ],
   "sgd": [
     "蘇里高農語",
-    "苏里高农语",
-    "Surigaonon"
+    "苏里高农语"
   ],
   "sge": [
     "色蓋語",
-    "色盖语",
-    "Segai"
+    "色盖语"
   ],
   "sgg": [
     "瑞士德語手語",
     "瑞士德语手语",
-    "Swiss-German Sign Language",
     "Swiss German Sign Language"
   ],
   "sgh": [
     "舒格南語",
-    "舒格南语",
-    "Shughni"
+    "舒格南语"
   ],
   "sgi": [
     "Suga"
@@ -27143,13 +24937,11 @@
   "sgr": [
     "桑加薩爾語",
     "桑加萨尔语",
-    "Sangisari",
     "Sangsari"
   ],
   "sgs": [
     "薩莫吉提亞語",
-    "萨莫吉提亚语",
-    "Samogitian"
+    "萨莫吉提亚语"
   ],
   "sgt": [
     "Brokpake",
@@ -27163,52 +24955,42 @@
   ],
   "sgx": [
     "塞拉利昂手語",
-    "塞拉利昂手语",
-    "Sierra Leone Sign Language"
+    "塞拉利昂手语"
   ],
   "sgy": [
     "桑格萊奇語",
     "桑格莱奇语",
-    "Sanglechi",
     "Sanglich",
     "Warduji"
   ],
   "sgz": [
     "蘇爾蘇隆嘉語",
-    "苏尔苏隆嘉语",
-    "Sursurunga"
+    "苏尔苏隆嘉语"
   ],
   "sh": [
     "塞爾維亞-克羅地亞語",
     "塞尔维亚-克罗地亚语",
-    "塞爾維亞-克羅埃西亞語",
-    "塞尔维亚-克罗埃西亚语",
     "BCS",
-    "克羅地亞-塞爾維亞語",
-    "克罗地亚-塞尔维亚语",
-    "塞-克語",
-    "塞-克语"
+    "Croato-Serbian",
+    "Serbocroatian"
   ],
   "sha": [
     "Shall-Zwall"
   ],
   "shb": [
     "尼納姆語",
-    "尼纳姆语",
-    "Ninam"
+    "尼纳姆语"
   ],
   "shc": [
     "Sonde"
   ],
   "shd": [
     "昆達爾-沙希語",
-    "昆达尔-沙希语",
-    "Kundal Shahi"
+    "昆达尔-沙希语"
   ],
   "she": [
     "謝科語",
-    "谢科语",
-    "Sheko"
+    "谢科语"
   ],
   "shg": [
     "Shua",
@@ -27218,7 +25000,6 @@
   "shh": [
     "休休尼語",
     "休休尼语",
-    "Shoshone",
     "Shoshoni",
     "Gosiute",
     "Goshute",
@@ -27232,7 +25013,6 @@
   "shi": [
     "施盧赫語",
     "施卢赫语",
-    "Tashelhit",
     "Tachelhit",
     "Chleuh",
     "Shilha",
@@ -27246,21 +25026,18 @@
   ],
   "shk": [
     "什魯克語",
-    "什鲁克语",
-    "Shilluk"
+    "什鲁克语"
   ],
   "shl": [
     "Shendu"
   ],
   "shm": [
     "沙赫魯迪語",
-    "沙赫鲁迪语",
-    "Shahrudi"
+    "沙赫鲁迪语"
   ],
   "shn": [
     "撣語",
     "掸语",
-    "Shan",
     "Kwam Tai",
     "Kam Tai",
     "Tai Yai"
@@ -27270,10 +25047,7 @@
   ],
   "shp": [
     "希皮博-科尼博語",
-    "希皮博-科尼博语",
-    "希皮波-科尼波語",
-    "希皮波-科尼波语",
-    "Shipibo-Conibo"
+    "希皮博-科尼博语"
   ],
   "shq": [
     "Sala"
@@ -27289,34 +25063,28 @@
   ],
   "shu": [
     "乍得阿拉伯語",
-    "乍得阿拉伯语",
-    "查德阿拉伯語",
-    "查德阿拉伯语",
-    "Chadian Arabic"
+    "乍得阿拉伯语"
   ],
   "shv": [
     "山地語",
     "山地语",
-    "Shehri",
     "Jibbali"
   ],
   "shw": [
-    "Shwai",
     "Shwai"
   ],
   "shx": [
     "畲語",
     "畲语",
-    "She",
     "Ho Ne",
     "Ho Nte"
   ],
   "shy": [
     "塔查維特語",
     "塔查维特语",
-    "Tachawit",
     "Shawiya Berber",
-    "Chaouïa"
+    "Chaouïa",
+    "Tacawit"
   ],
   "shz": [
     "Syenara Senoufo"
@@ -27324,18 +25092,16 @@
   "si": [
     "僧加羅語",
     "僧加罗语",
-    "僧伽羅語",
-    "僧伽罗语"
+    "Singhalese",
+    "Sinhala"
   ],
   "sia": [
     "阿卡拉薩米語",
-    "阿卡拉萨米语",
-    "Akkala Sami"
+    "阿卡拉萨米语"
   ],
   "sib": [
     "塞波普語",
-    "塞波普语",
-    "Sebop"
+    "塞波普语"
   ],
   "sid": [
     "希達摩語",
@@ -27345,20 +25111,41 @@
   "sie": [
     "Simaa"
   ],
+  "sif": [
+    "Siamou"
+  ],
+  "sig": [
+    "Paasaal"
+  ],
+  "sih": [
+    "Zire"
+  ],
+  "sii": [
+    "Shom Peng"
+  ],
   "sij": [
     "農巴米語",
-    "农巴米语",
-    "Numbami"
+    "农巴米语"
+  ],
+  "sik": [
+    "Sikiana"
+  ],
+  "sil": [
+    "Tumulung Sisaala"
+  ],
+  "sim": [
+    "Seim",
+    "Mende",
+    "Mende (New Guinea)"
   ],
   "sio-pro": [
     "原始蘇語",
-    "原始苏语",
-    "Proto-Siouan"
+    "原始苏语"
   ],
   "sip": [
     "錫金語",
     "锡金语",
-    "Sikkimese",
+    "Bhutia",
     "Dranjongke",
     "Dranjoke",
     "Denjongka",
@@ -27375,7 +25162,7 @@
     "Siuslaw"
   ],
   "sit-bok": [
-    "Bokar",
+    "博嘎尔方言",
     "Ramo",
     "Pailibo"
   ],
@@ -27393,7 +25180,6 @@
   "sit-jap": [
     "茶堡話",
     "茶堡话",
-    "Japhug",
     "Chabao",
     "rGyalrong",
     "Rgyalrong",
@@ -27405,10 +25191,12 @@
     "Proto-Kham"
   ],
   "sit-liz": [
-    "Lizu"
+    "栗蘇語",
+    "栗苏语"
   ],
   "sit-luu-pro": [
-    "Proto-Luish"
+    "原始盧伊語",
+    "原始卢伊语"
   ],
   "sit-mor": [
     "Moran",
@@ -27419,13 +25207,11 @@
   ],
   "sit-pro": [
     "原始漢藏語",
-    "原始汉藏语",
-    "Proto-Sino-Tibetan"
+    "原始汉藏语"
   ],
   "sit-sit": [
     "四土話",
     "四土话",
-    "Situ",
     "Eastern rGyalrong",
     "rGyalrong",
     "Rgyalrong",
@@ -27443,8 +25229,7 @@
   ],
   "sit-tan-pro": [
     "原始達尼語",
-    "原始达尼语",
-    "Proto-Tani"
+    "原始达尼语"
   ],
   "sit-tgm": [
     "Tangam"
@@ -27455,7 +25240,6 @@
   "sit-tsh": [
     "草登話",
     "草登话",
-    "Tshobdun",
     "Caodeng",
     "Sidaba",
     "rGyalrong",
@@ -27492,8 +25276,7 @@
   ],
   "siy": [
     "斯凡迪語",
-    "斯凡迪语",
-    "Sivandi"
+    "斯凡迪语"
   ],
   "siz": [
     "Siwi",
@@ -27507,21 +25290,18 @@
   ],
   "sjd": [
     "基爾丁薩米語",
-    "基尔丁萨米语",
-    "Kildin Sami"
+    "基尔丁萨米语"
   ],
   "sje": [
     "皮特薩米語",
-    "皮特萨米语",
-    "Pite Sami"
+    "皮特萨米语"
   ],
   "sjg": [
     "Assangori"
   ],
   "sjk": [
     "凱米薩米語",
-    "凯米萨米语",
-    "Kemi Sami"
+    "凯米萨米语"
   ],
   "sjl": [
     "Miji",
@@ -27531,26 +25311,22 @@
   ],
   "sjm": [
     "馬蓬語",
-    "马蓬语",
-    "Sindarin"
+    "马蓬语"
   ],
   "sjn": [
     "辛達林語",
-    "辛达林语",
-    "Sindarin"
+    "辛达林语"
   ],
   "sjo": [
     "錫伯語",
     "锡伯语",
-    "Xibe",
     "Sibo",
     "Sibe",
     "Xibo"
   ],
   "sjp": [
     "蘇爾賈普里語",
-    "苏尔贾普里语",
-    "Surjapuri"
+    "苏尔贾普里语"
   ],
   "sjr": [
     "Siar-Lak"
@@ -27560,18 +25336,15 @@
   ],
   "sjt": [
     "特爾薩米語",
-    "特尔萨米语",
-    "Ter Sami"
+    "特尔萨米语"
   ],
   "sju": [
     "于默薩米語",
-    "于默萨米语",
-    "Ume Sami"
+    "于默萨米语"
   ],
   "sjw": [
     "肖尼語",
-    "肖尼语",
-    "Shawnee"
+    "肖尼语"
   ],
   "sk": [
     "斯洛伐克語",
@@ -27582,8 +25355,7 @@
   ],
   "skb": [
     "石語",
-    "石语",
-    "Saek"
+    "石语"
   ],
   "skc": [
     "Ma Manda",
@@ -27616,7 +25388,6 @@
   "ski": [
     "西卡語",
     "西卡语",
-    "Sika",
     "Sikanese"
   ],
   "skj": [
@@ -27645,14 +25416,12 @@
   "skr": [
     "沙拉基語",
     "沙拉基语",
-    "Saraiki",
     "Siraiki",
     "Seraiki"
   ],
   "sks": [
     "馬伊亞語",
     "马伊亚语",
-    "Maia",
     "Maya",
     "Banar",
     "Pila",
@@ -27689,7 +25458,6 @@
   "skw": [
     "斯克皮克里奧爾荷蘭語",
     "斯克皮克里奥尔荷兰语",
-    "Skepi Creole Dutch",
     "Skepi Dutch",
     "Skepi Dutch Creole",
     "Essequibo Dutch"
@@ -27700,24 +25468,20 @@
   "sky": [
     "西卡亞納語",
     "西卡亚纳语",
-    "Sikaiana",
     "Sikayana"
   ],
   "skz": [
     "塞卡爾語",
-    "塞卡尔语",
-    "Sekar"
+    "塞卡尔语"
   ],
   "sl": [
     "斯洛文尼亞語",
     "斯洛文尼亚语",
-    "斯洛維尼亞語",
-    "斯洛维尼亚语"
+    "Slovenian"
   ],
   "sla-pro": [
     "原始斯拉夫語",
     "原始斯拉夫语",
-    "Proto-Slavic",
     "Common Slavic"
   ],
   "slc": [
@@ -27732,13 +25496,11 @@
   ],
   "sle": [
     "紹拉加語",
-    "绍拉加语",
-    "Sholaga"
+    "绍拉加语"
   ],
   "slf": [
     "瑞士意大利語手語",
     "瑞士意大利语手语",
-    "Swiss-Italian Sign Language",
     "Swiss Italian Sign Language"
   ],
   "slg": [
@@ -27746,8 +25508,7 @@
   ],
   "slh": [
     "南普吉特海灣薩利希語",
-    "南普吉特海湾萨利希语",
-    "Southern Puget Sound Salish"
+    "南普吉特海湾萨利希语"
   ],
   "slj": [
     "Salumá"
@@ -27757,8 +25518,7 @@
   ],
   "slm": [
     "潘古塔蘭薩馬語",
-    "潘古塔兰萨马语",
-    "Pangutaran Sama"
+    "潘古塔兰萨马语"
   ],
   "sln": [
     "Salinan"
@@ -27766,7 +25526,6 @@
   "slp": [
     "拉馬霍洛特語",
     "拉马霍洛特语",
-    "Lamaholot",
     "Solor",
     "Solorese"
   ],
@@ -27775,13 +25534,11 @@
   ],
   "slr": [
     "撒拉語",
-    "撒拉语",
-    "Salar"
+    "撒拉语"
   ],
   "sls": [
     "新加坡手語",
-    "新加坡手语",
-    "Singapore Sign Language"
+    "新加坡手语"
   ],
   "slt": [
     "Sila"
@@ -27808,9 +25565,7 @@
   ],
   "sma": [
     "南薩米語",
-    "南萨米语",
-    "Southern Sami",
-    "Lule Sami"
+    "南萨米语"
   ],
   "smb": [
     "Simbari"
@@ -27820,8 +25575,7 @@
   ],
   "smd": [
     "薩馬語",
-    "萨马语",
-    "Sama"
+    "萨马语"
   ],
   "smf": [
     "Auwe"
@@ -27835,39 +25589,32 @@
   "smi-pro": [
     "原始薩米語",
     "原始萨米语",
-    "Proto-Samic",
     "Proto-Sami"
   ],
   "smj": [
     "呂勒薩米語",
-    "吕勒萨米语",
-    "Lule Sami"
+    "吕勒萨米语"
   ],
   "smk": [
     "博利瑙語",
     "博利瑙语",
-    "Bolinao",
     "Binubolinao"
   ],
   "sml": [
     "中薩馬語",
-    "中萨马语",
-    "Central Sama"
+    "中萨马语"
   ],
   "smm": [
     "穆薩薩語",
-    "穆萨萨语",
-    "Musasa"
+    "穆萨萨语"
   ],
   "smn": [
     "伊納里薩米語",
-    "伊纳里萨米语",
-    "Inari Sami"
+    "伊纳里萨米语"
   ],
   "smp": [
     "撒馬利亞希伯來語",
     "撒马利亚希伯来语",
-    "Samaritan Hebrew",
     "Samaritan"
   ],
   "smq": [
@@ -27876,7 +25623,6 @@
   "smr": [
     "錫默盧語",
     "锡默卢语",
-    "Simeulue",
     "Simalur",
     "Devayan",
     "Defayan",
@@ -27886,8 +25632,7 @@
   ],
   "sms": [
     "斯科爾特薩米語",
-    "斯科尔特萨米语",
-    "Skolt Sami"
+    "斯科尔特萨米语"
   ],
   "smt": [
     "Simte"
@@ -27897,48 +25642,40 @@
   ],
   "smv": [
     "桑維蒂語",
-    "桑维蒂语",
-    "Samvedi"
+    "桑维蒂语"
   ],
   "smw": [
     "松巴哇語",
-    "松巴哇语",
-    "Sumbawa"
+    "松巴哇语"
   ],
   "smx": [
     "Samba"
   ],
   "smy": [
     "森南尼語",
-    "森南尼语",
-    "Semnani"
+    "森南尼语"
   ],
   "smz": [
     "Simeku"
   ],
   "sn": [
     "修納語",
-    "修纳语",
-    "紹納語",
-    "绍纳语"
+    "修纳语"
   ],
   "snb": [
     "Sebuyau"
   ],
   "snc": [
     "西瑙高羅語",
-    "西瑙高罗语",
-    "Sinaugoro"
+    "西瑙高罗语"
   ],
   "sne": [
     "查格依語",
-    "查格依语",
-    "Bau Bidayuh"
+    "查格依语"
   ],
   "snf": [
     "努恩語",
-    "努恩语",
-    "Noon"
+    "努恩语"
   ],
   "sng": [
     "Sanga (Congo)",
@@ -28010,7 +25747,6 @@
   "soa": [
     "宋傣語",
     "宋傣语",
-    "Thai Song",
     "Lao Song",
     "Song"
   ],
@@ -28029,8 +25765,7 @@
   ],
   "sog": [
     "粟特語",
-    "粟特语",
-    "Sogdian"
+    "粟特语"
   ],
   "soh": [
     "Aka (Sudan)",
@@ -28046,18 +25781,15 @@
   ],
   "sok": [
     "索科羅語",
-    "索科罗语",
-    "Sokoro"
+    "索科罗语"
   ],
   "sol": [
     "索洛斯語",
-    "索洛斯语",
-    "Solos"
+    "索洛斯语"
   ],
   "son-pro": [
     "原始桑海語",
     "原始桑海语",
-    "Proto-Songhay",
     "Proto-Songhai"
   ],
   "soo": [
@@ -28083,16 +25815,12 @@
   "sou": [
     "南部泰語",
     "南部泰语",
-    "巴戴語",
-    "巴戴语",
-    "Southern Thai",
     "Dambro",
     "Pak Tai"
   ],
   "sov": [
     "松索羅爾語",
-    "松索罗尔语",
-    "Sonsorolese"
+    "松索罗尔语"
   ],
   "sow": [
     "Sowanda"
@@ -28100,7 +25828,6 @@
   "sox": [
     "索語",
     "索语",
-    "Swo",
     "So",
     "Sso",
     "Shwo",
@@ -28137,8 +25864,7 @@
   ],
   "spi": [
     "薩波尼語",
-    "萨波尼语",
-    "Saponi"
+    "萨波尼语"
   ],
   "spk": [
     "Sengo"
@@ -28173,8 +25899,7 @@
   ],
   "sps": [
     "薩波薩語",
-    "萨波萨语",
-    "Saposa"
+    "萨波萨语"
   ],
   "spt": [
     "Spiti Bhoti"
@@ -28185,14 +25910,12 @@
   "spv": [
     "桑巴爾普里語",
     "桑巴尔普里语",
-    "Sambalpuri",
     "Kosali",
     "Koshali"
   ],
   "spx": [
     "南皮賽恩語",
     "南皮赛恩语",
-    "South Picene",
     "Old Sabellic",
     "Old Sabellian",
     "Middle Adriatic",
@@ -28213,8 +25936,7 @@
   ],
   "sqj-pro": [
     "原始阿爾巴尼亞語",
-    "原始阿尔巴尼亚语",
-    "Proto-Albanian"
+    "原始阿尔巴尼亚语"
   ],
   "sqk": [
     "Albanian Sign Language"
@@ -28227,32 +25949,27 @@
   ],
   "sqo": [
     "索爾赫伊語",
-    "索尔赫伊语",
-    "Sorkhei"
+    "索尔赫伊语"
   ],
   "sqq": [
     "Sou"
   ],
   "sqr": [
     "西庫爾阿拉伯語",
-    "西库尔阿拉伯语",
-    "Siculo-Arabic"
+    "西库尔阿拉伯语"
   ],
   "sqs": [
     "斯里蘭卡手語",
-    "斯里兰卡手语",
-    "Sri Lankan Sign Language"
+    "斯里兰卡手语"
   ],
   "sqt": [
     "索科特拉語",
     "索科特拉语",
-    "Soqotri",
     "Socotri"
   ],
   "squ": [
     "斯闊米什語",
-    "斯阔米什语",
-    "Squamish"
+    "斯阔米什语"
   ],
   "sra": [
     "Saruga"
@@ -28271,29 +25988,25 @@
   ],
   "srh": [
     "薩里庫爾語",
-    "萨里库尔语",
-    "Sarikoli"
+    "萨里库尔语"
   ],
   "sri": [
     "Siriano"
   ],
   "srk": [
-    "Serudung Murut"
+    "Serudung Murut",
+    "Serudung"
   ],
   "srl": [
     "Isirawa"
   ],
   "srm": [
     "薩拉馬卡語",
-    "萨拉马卡语",
-    "Saramaccan"
+    "萨拉马卡语"
   ],
   "srn": [
     "蘇里南湯加語",
-    "苏里南汤加语",
-    "蘇里南語",
-    "苏里南语",
-    "Sranan Tongo"
+    "苏里南汤加语"
   ],
   "srq": [
     "Sirionó"
@@ -28321,8 +26034,7 @@
   ],
   "srv": [
     "瓦瑞索索貢語",
-    "瓦瑞索索贡语",
-    "Waray Sorsogon"
+    "瓦瑞索索贡语"
   ],
   "srw": [
     "Serua"
@@ -28335,14 +26047,12 @@
   ],
   "srz": [
     "沙赫米爾扎迪語",
-    "沙赫米尔扎迪语",
-    "Shahmirzadi"
+    "沙赫米尔扎迪语"
   ],
   "ss": [
     "史瓦濟語",
     "史瓦济语",
-    "斯威士語",
-    "斯威士语"
+    "Swati"
   ],
   "ssa-klk-pro": [
     "Proto-Kuliak",
@@ -28353,13 +26063,11 @@
   ],
   "ssa-pro": [
     "原始尼羅-撒哈拉語",
-    "原始尼罗-撒哈拉语",
-    "Proto-Nilo-Saharan"
+    "原始尼罗-撒哈拉语"
   ],
   "ssb": [
     "南薩馬語",
-    "南萨马语",
-    "Southern Sama"
+    "南萨马语"
   ],
   "ssc": [
     "Suba-Simbiti"
@@ -28384,7 +26092,6 @@
   "ssi": [
     "桑斯語",
     "桑斯语",
-    "Sansi",
     "Bhilki"
   ],
   "ssj": [
@@ -28399,16 +26106,12 @@
   "ssm": [
     "Semnam"
   ],
-  "ssn": [
-    "Waata"
-  ],
   "sso": [
     "Sissano"
   ],
   "ssp": [
     "西班牙手語",
-    "西班牙手语",
-    "Spanish Sign Language"
+    "西班牙手语"
   ],
   "ssq": [
     "So'a"
@@ -28416,7 +26119,6 @@
   "ssr": [
     "瑞士法國手語",
     "瑞士法国手语",
-    "Swiss-French Sign Language",
     "Swiss French Sign Language"
   ],
   "sss": [
@@ -28444,10 +26146,9 @@
   "st": [
     "塞索托語",
     "塞索托语",
-    "索托語",
-    "索托语",
-    "南部索托語",
-    "南部索托语"
+    "Sesotho",
+    "Southern Sesotho",
+    "Southern Sotho"
   ],
   "stb": [
     "北蘇巴農語",
@@ -28455,8 +26156,7 @@
   ],
   "std": [
     "桑提內爾語",
-    "桑提内尔语",
-    "Sentinelese"
+    "桑提内尔语"
   ],
   "ste": [
     "Liana-Seti"
@@ -28470,13 +26170,11 @@
   "sth": [
     "雪爾塔語",
     "雪尔塔语",
-    "Shelta",
     "Cant"
   ],
   "sti": [
     "布羅斯丁語",
-    "布罗斯丁语",
-    "Bulo Stieng"
+    "布罗斯丁语"
   ],
   "stj": [
     "Matya Samo"
@@ -28495,36 +26193,25 @@
   ],
   "stp": [
     "東南特佩瓦語",
-    "东南特佩瓦语",
-    "Southeastern Tepehuan"
+    "东南特佩瓦语"
   ],
   "stq": [
     "薩特弗里斯蘭語",
     "萨特弗里斯兰语",
-    "沙特弗里西語",
-    "沙特弗里西语",
-    "東弗里斯蘭語",
-    "东弗里斯兰语",
-    "東弗里西語",
-    "东弗里西语",
-    "Saterland Frisian",
     "East Frisian",
     "Eastern Frisian"
   ],
   "str": [
     "薩尼奇語",
-    "萨尼奇语",
-    "Saanich"
+    "萨尼奇语"
   ],
   "sts": [
     "舒馬斯梯語",
-    "舒马斯梯语",
-    "Shumashti"
+    "舒马斯梯语"
   ],
   "stt": [
     "布德斯丁語",
-    "布德斯丁语",
-    "Budeh Stieng"
+    "布德斯丁语"
   ],
   "stu": [
     "Samtao"
@@ -28534,13 +26221,11 @@
   ],
   "stw": [
     "薩塔瓦爾語",
-    "萨塔瓦尔语",
-    "Satawalese"
+    "萨塔瓦尔语"
   ],
   "sty": [
     "西伯利亞韃靼語",
-    "西伯利亚鞑靼语",
-    "Siberian Tatar"
+    "西伯利亚鞑靼语"
   ],
   "su": [
     "巽他語",
@@ -28558,26 +26243,22 @@
   ],
   "sue": [
     "蘇埃納語",
-    "苏埃纳语",
-    "Suena"
+    "苏埃纳语"
   ],
   "sug": [
     "Suganga"
   ],
   "sui": [
     "蘇基語",
-    "苏基语",
-    "Suki"
+    "苏基语"
   ],
   "suk": [
     "蘇庫馬語",
-    "苏库马语",
-    "Sukuma"
+    "苏库马语"
   ],
   "suq": [
     "蘇里語",
-    "苏里语",
-    "Suri"
+    "苏里语"
   ],
   "sur": [
     "Mwaghavul",
@@ -28599,16 +26280,11 @@
   ],
   "sux": [
     "蘇美爾語",
-    "苏美尔语",
-    "蘇美語",
-    "苏美语",
-    "Sumerian"
+    "苏美尔语"
   ],
   "suy": [
     "蘇亞語",
-    "苏亚语",
-    "Suyá",
-    "Kĩsêdjê"
+    "苏亚语"
   ],
   "suz": [
     "Sunwar"
@@ -28619,8 +26295,7 @@
   ],
   "sva": [
     "斯凡語",
-    "斯凡语",
-    "Svan"
+    "斯凡语"
   ],
   "svb": [
     "Ulau-Suain"
@@ -28633,15 +26308,11 @@
   ],
   "svk": [
     "斯洛伐克手語",
-    "斯洛伐克手语",
-    "Slovakian Sign Language"
+    "斯洛伐克手语"
   ],
   "svm": [
     "斯拉夫莫利塞語",
     "斯拉夫莫利塞语",
-    "斯拉沃莫利薩諾語",
-    "斯拉沃莫利萨诺语",
-    "Slavomolisano",
     "Slavo-molisano",
     "Molise Slavic",
     "Molise Croatian"
@@ -28651,8 +26322,7 @@
   ],
   "svx": [
     "斯卡洛維亞語",
-    "斯卡洛维亚语",
-    "Skalvian"
+    "斯卡洛维亚语"
   ],
   "sw": [
     "斯瓦希里語",
@@ -28660,21 +26330,18 @@
   ],
   "swb": [
     "馬約特科摩羅語",
-    "马约特科摩罗语",
-    "Maore Comorian"
+    "马约特科摩罗语"
   ],
   "swf": [
     "Sere"
   ],
   "swg": [
     "施瓦本語",
-    "施瓦本语",
-    "Swabian"
+    "施瓦本语"
   ],
   "swi": [
     "水語",
     "水语",
-    "Sui",
     "Ai Sui",
     "Shui",
     "Sui Li",
@@ -28718,8 +26385,7 @@
   ],
   "sww": [
     "索瓦語",
-    "索瓦语",
-    "Sowa"
+    "索瓦语"
   ],
   "swx": [
     "Suruahá",
@@ -28744,19 +26410,16 @@
   "sxg": [
     "史興語",
     "史兴语",
-    "Shixing",
     "Shuhi",
     "Xumi"
   ],
   "sxk": [
     "南卡拉普亞語",
-    "南卡拉普亚语",
-    "Southern Kalapuya"
+    "南卡拉普亚语"
   ],
   "sxl": [
     "瑟羅尼亞語",
     "瑟罗尼亚语",
-    "Selonian",
     "Selian"
   ],
   "sxm": [
@@ -28764,19 +26427,14 @@
   ],
   "sxn": [
     "桑格語",
-    "桑格语",
-    "Sangir"
+    "桑格语"
   ],
   "sxo": [
     "Sorothaptic"
   ],
   "sxr": [
     "拉阿魯哇語",
-    "拉阿鲁哇语",
-    "Saaroa",
-    "Hla'alua",
-    "沙阿魯哇語",
-    "沙阿鲁哇语"
+    "拉阿鲁哇语"
   ],
   "sxs": [
     "Sasaru"
@@ -28793,31 +26451,26 @@
   ],
   "syc": [
     "古典敘利亞語",
-    "古典叙利亚语",
-    "Classical Syriac"
+    "古典叙利亚语"
   ],
   "syd-fne": [
     "森林涅涅茨語",
-    "森林涅涅茨语",
-    "Forest Nenets"
+    "森林涅涅茨语"
   ],
   "syd-pro": [
     "原始薩莫耶德語",
-    "原始萨莫耶德语",
-    "Proto-Samoyedic"
+    "原始萨莫耶德语"
   ],
   "syi": [
     "Seki"
   ],
   "syk": [
     "蘇庫爾語",
-    "苏库尔语",
-    "Sukur"
+    "苏库尔语"
   ],
   "syl": [
     "錫爾赫特語",
-    "锡尔赫特语",
-    "Sylheti"
+    "锡尔赫特语"
   ],
   "sym": [
     "Maya Samo"
@@ -28865,7 +26518,6 @@
   "szl": [
     "西里西亞語",
     "西里西亚语",
-    "Silesian",
     "Upper Silesian",
     "Silesian Polish",
     "Upper Silesian Polish"
@@ -28895,16 +26547,11 @@
   ],
   "szy": [
     "撒奇萊雅語",
-    "撒奇莱雅语",
-    "Sakizaya"
+    "撒奇莱雅语"
   ],
   "ta": [
     "泰米爾語",
-    "泰米尔语",
-    "淡米爾語",
-    "淡米尔语",
-    "坦米爾語",
-    "坦米尔语"
+    "泰米尔语"
   ],
   "taa": [
     "Lower Tanana",
@@ -28914,13 +26561,11 @@
   "tab": [
     "塔巴薩蘭語",
     "塔巴萨兰语",
-    "Tabasaran",
     "Tabassaran"
   ],
   "tac": [
     "低地塔拉烏馬拉語",
-    "低地塔拉乌马拉语",
-    "Lowland Tarahumara"
+    "低地塔拉乌马拉语"
   ],
   "tad": [
     "Tause"
@@ -28936,13 +26581,11 @@
   ],
   "tai-pro": [
     "原始台語",
-    "原始台语",
-    "Proto-Tai"
+    "原始台语"
   ],
   "tai-swe-pro": [
     "原始西南台語",
-    "原始西南台语",
-    "Proto-Southwestern Tai"
+    "原始西南台语"
   ],
   "taj": [
     "Eastern Tamang"
@@ -28959,26 +26602,17 @@
   "tao": [
     "達悟語",
     "达悟语",
-    "Yami",
-    "雅美語",
-    "雅美语",
     "Tao"
   ],
   "tap": [
     "Taabwa"
   ],
-  "taq": [
-    "塔馬舍克語",
-    "塔马舍克语",
-    "Tamasheq"
-  ],
   "tar": [
     "中塔拉烏馬拉語",
-    "中塔拉乌马拉语",
-    "Central Tarahumara"
+    "中塔拉乌马拉语"
   ],
   "tas": [
-    "Tay Boi",
+    "Tây Bồi",
     "Tay Boi Pidgin French",
     "Vietnamese Pidgin French"
   ],
@@ -28998,11 +26632,7 @@
   ],
   "tay": [
     "泰雅語",
-    "泰雅语",
-    "Atayal",
-    "泰雅爾語",
-    "泰雅尔语",
-    "Tayal"
+    "泰雅语"
   ],
   "taz": [
     "Tocho"
@@ -29015,8 +26645,7 @@
   ],
   "tbc": [
     "塔基亞語",
-    "塔基亚语",
-    "Takia"
+    "塔基亚语"
   ],
   "tbd": [
     "Kaki Ae"
@@ -29047,8 +26676,7 @@
   ],
   "tbl": [
     "特波里語",
-    "特波里语",
-    "Tboli"
+    "特波里语"
   ],
   "tbm": [
     "Tagbu"
@@ -29066,19 +26694,16 @@
   ],
   "tbq-bdg-pro": [
     "原始博多-加羅語",
-    "原始博多-加罗语",
-    "Proto-Bodo-Garo"
+    "原始博多-加罗语"
   ],
   "tbq-kuk-pro": [
     "原始庫基-欽語",
     "原始库基-钦语",
-    "Proto-Kuki-Chin",
     "Proto-Kukish"
   ],
   "tbq-lal-pro": [
     "原始臘羅語",
-    "原始腊罗语",
-    "Proto-Lalo"
+    "原始腊罗语"
   ],
   "tbq-laz": [
     "Laze",
@@ -29087,19 +26712,20 @@
   ],
   "tbq-lob-pro": [
     "原始緬彝語",
-    "原始缅彝语",
-    "Proto-Lolo-Burmese"
+    "原始缅彝语"
   ],
   "tbq-lol-pro": [
     "原始彝語",
     "原始彝语",
-    "Proto-Loloish",
     "Proto-Nisoic"
+  ],
+  "tbq-ngo": [
+    "Ngochang",
+    "Ngachang"
   ],
   "tbq-plg": [
     "白狼語",
     "白狼语",
-    "Pai-lang",
     "Bai-lang",
     "Pailang",
     "Bailang"
@@ -29131,8 +26757,7 @@
   ],
   "tby": [
     "塔巴魯語",
-    "塔巴鲁语",
-    "Tabaru"
+    "塔巴鲁语"
   ],
   "tbz": [
     "Ditammari"
@@ -29152,21 +26777,18 @@
   ],
   "tce": [
     "南塔穹語",
-    "南塔穹语",
-    "Southern Tutchone"
+    "南塔穹语"
   ],
   "tcf": [
     "馬利納爾特佩克特拉帕克語",
-    "马利纳尔特佩克特拉帕克语",
-    "Malinaltepec Tlapanec"
+    "马利纳尔特佩克特拉帕克语"
   ],
   "tcg": [
     "Tamagario"
   ],
   "tch": [
     "特克斯和凱科斯群島克里奧爾英語",
-    "特克斯和凯科斯群岛克里奥尔英语",
-    "Turks and Caicos Creole English"
+    "特克斯和凯科斯群岛克里奥尔英语"
   ],
   "tci": [
     "Wára"
@@ -29175,9 +26797,9 @@
     "Tchitchege"
   ],
   "tcl": [
-    "Taman (Burma)",
+    "Taman (Myanmar)",
     "Taman",
-    "Taman (Myanmar)"
+    "Taman (Burma)"
   ],
   "tcm": [
     "Tanahmerah"
@@ -29195,7 +26817,6 @@
   "tcs": [
     "托雷斯海峽克里奧爾語",
     "托雷斯海峡克里奥尔语",
-    "Torres Strait Creole",
     "Big Thap",
     "Blaikman",
     "Brokan",
@@ -29211,26 +26832,22 @@
   ],
   "tct": [
     "佯僙語",
-    "佯僙语",
-    "T'en"
+    "佯僙语"
   ],
   "tcu": [
     "東南塔拉烏馬拉語",
-    "东南塔拉乌马拉语",
-    "Southeastern Tarahumara"
+    "东南塔拉乌马拉语"
   ],
   "tcw": [
     "特克帕特蘭托托納克語",
-    "特克帕特兰托托纳克语",
-    "Tecpatlán Totonac"
+    "特克帕特兰托托纳克语"
   ],
   "tcx": [
     "Toda"
   ],
   "tcy": [
     "圖陸語",
-    "图陆语",
-    "Tulu"
+    "图陆语"
   ],
   "tcz": [
     "Thado Chin",
@@ -29248,11 +26865,6 @@
   "tdd": [
     "傣納語",
     "傣纳语",
-    "傣那語",
-    "傣那语",
-    "德宏傣語",
-    "德宏傣语",
-    "Tai Nüa",
     "Tai Nuea",
     "Dehong Dai",
     "Tai Dehong",
@@ -29280,8 +26892,7 @@
   ],
   "tdj": [
     "塔基歐語",
-    "塔基欧语",
-    "Tajio"
+    "塔基欧语"
   ],
   "tdk": [
     "Tambas"
@@ -29305,8 +26916,7 @@
   ],
   "tdr": [
     "祖查語",
-    "祖查语",
-    "Todrah"
+    "祖查语"
   ],
   "tds": [
     "Doutai",
@@ -29315,7 +26925,6 @@
   "tdt": [
     "帝力德頓語",
     "帝力德顿语",
-    "Tetun Dili",
     "Tetum Dili",
     "Tetun Prasa",
     "Tétum Praça",
@@ -29330,8 +26939,7 @@
   ],
   "tdy": [
     "塔迪亞萬語",
-    "塔迪亚万语",
-    "Tadyawan"
+    "塔迪亚万语"
   ],
   "te": [
     "泰盧固語",
@@ -29351,8 +26959,7 @@
   ],
   "tee": [
     "韋韋特拉特佩瓦語",
-    "韦韦特拉特佩瓦语",
-    "Huehuetla Tepehua"
+    "韦韦特拉特佩瓦语"
   ],
   "tef": [
     "Teressa"
@@ -29394,8 +27001,7 @@
   ],
   "tep": [
     "特佩卡諾語",
-    "特佩卡诺语",
-    "Tepecano"
+    "特佩卡诺语"
   ],
   "teq": [
     "Temein"
@@ -29410,7 +27016,6 @@
   "tet": [
     "德頓語",
     "德顿语",
-    "Tetum",
     "Tetun"
   ],
   "teu": [
@@ -29422,7 +27027,6 @@
   "tew": [
     "特瓦語",
     "特瓦语",
-    "Tewa",
     "Tano",
     "Santa Clara Tewa",
     "San Ildefonso Tewa",
@@ -29453,21 +27057,21 @@
   ],
   "tfr": [
     "特里貝語",
-    "特里贝语",
-    "Teribe"
+    "特里贝语"
   ],
   "tft": [
     "特爾納特語",
-    "特尔纳特语",
-    "Ternate"
+    "特尔纳特语"
   ],
   "tg": [
     "塔吉克語",
     "塔吉克语",
-    "塔吉克波斯語",
-    "塔吉克波斯语",
-    "東波斯語",
-    "东波斯语"
+    "Eastern Persian",
+    "Tadjik",
+    "Tadzhik",
+    "Tajiki",
+    "Tajik Persian",
+    "Tajiki Persian"
   ],
   "tga": [
     "Sagalla"
@@ -29493,24 +27097,18 @@
   ],
   "tgh": [
     "多巴哥克里奧爾英語",
-    "多巴哥克里奥尔英语",
-    "托貝哥克里奧爾英語",
-    "托贝哥克里奥尔英语",
-    "Tobagonian Creole English"
+    "多巴哥克里奥尔英语"
   ],
   "tgi": [
     "Lawunuia"
   ],
   "tgn": [
     "坦達加農語",
-    "坦达加农语",
-    "Tandaganon"
+    "坦达加农语"
   ],
   "tgo": [
     "塔古拉語",
-    "塔古拉语",
-    "Sudest",
-    "Tagula"
+    "塔古拉语"
   ],
   "tgp": [
     "Tangoa"
@@ -29539,8 +27137,7 @@
   ],
   "tgx": [
     "塔吉什語",
-    "塔吉什语",
-    "Tagish"
+    "塔吉什语"
   ],
   "tgy": [
     "Togoyo"
@@ -29548,17 +27145,12 @@
   "th": [
     "泰語",
     "泰语",
-    "中部泰語",
-    "中部泰语",
-    "暹羅語",
-    "暹罗语"
+    "Central Thai",
+    "Siamese"
   ],
   "thc": [
     "傣包語",
-    "傣包语",
-    "Tai Hang Tong",
-    "Tai Pao",
-    "Tai Muong"
+    "傣包语"
   ],
   "thd": [
     "Kuuk Thaayorre",
@@ -29573,8 +27165,7 @@
   ],
   "thh": [
     "北塔拉烏馬拉語",
-    "北塔拉乌马拉语",
-    "Northern Tarahumara"
+    "北塔拉乌马拉语"
   ],
   "thi": [
     "Tai Long"
@@ -29596,8 +27187,7 @@
   ],
   "thp": [
     "湯普森語",
-    "汤普森语",
-    "Thompson"
+    "汤普森语"
   ],
   "thq": [
     "Kochila Tharu"
@@ -29614,28 +27204,13 @@
   "thu": [
     "Thuri"
   ],
-  "thv": [
-    "Tahaggart Tamahaq",
-    "Tamahaq",
-    "Tahaggart",
-    "Ahaggar"
-  ],
   "thy": [
     "Tha"
-  ],
-  "thz": [
-    "Tayart Tamajeq",
-    "Air Tamajeq"
   ],
   "ti": [
     "提格里尼亞語",
     "提格里尼亚语",
-    "提格利尼亞語",
-    "提格利尼亚语"
-  ],
-  "tia": [
-    "Tidikelt Tamazight",
-    "Tidikelt"
+    "Tigrigna"
   ],
   "tic": [
     "Tira"
@@ -29645,13 +27220,11 @@
   ],
   "tig": [
     "提格雷語",
-    "提格雷语",
-    "Tigre"
+    "提格雷语"
   ],
   "tih": [
     "蒂穆貢穆魯特語",
-    "蒂穆贡穆鲁特语",
-    "Timugon Murut"
+    "蒂穆贡穆鲁特语"
   ],
   "tii": [
     "Tiene"
@@ -29670,8 +27243,7 @@
   ],
   "tin": [
     "廷迪語",
-    "廷迪语",
-    "Tindi"
+    "廷迪语"
   ],
   "tio": [
     "Teop"
@@ -29697,7 +27269,8 @@
     "Tivi"
   ],
   "tiw": [
-    "Tiwi"
+    "提維語",
+    "提维语"
   ],
   "tix": [
     "Southern Tiwa",
@@ -29710,13 +27283,11 @@
   ],
   "tiy": [
     "蒂魯賴語",
-    "蒂鲁赖语",
-    "Tiruray"
+    "蒂鲁赖语"
   ],
   "tiz": [
     "紅金傣語",
-    "红金傣语",
-    "Tai Hongjin"
+    "红金傣语"
   ],
   "tja": [
     "Tajuasohn"
@@ -29728,19 +27299,29 @@
     "北部土家語",
     "北部土家语"
   ],
+  "tjl": [
+    "傣來語",
+    "傣来语",
+    "Red Tai (Myanmar)",
+    "Red Shan",
+    "Shan Bamar",
+    "Shan Kalee",
+    "Shan Ni",
+    "Tai Laeng",
+    "Tai Lai",
+    "Tai Leng",
+    "Tai Nai",
+    "Tai Naing"
+  ],
   "tjm": [
     "Timucua"
   ],
   "tjn": [
     "Tonjon"
   ],
-  "tjo": [
-    "Temacine Tamazight"
-  ],
   "tjs": [
     "南部土家語",
-    "南部土家语",
-    "Southern Tujia"
+    "南部土家语"
   ],
   "tju": [
     "Tjurruru"
@@ -29772,21 +27353,18 @@
   ],
   "tkl": [
     "托克勞語",
-    "托克劳语",
-    "Tokelauan"
+    "托克劳语"
   ],
   "tkm": [
     "Takelma"
   ],
   "tkn": [
     "德之島語",
-    "德之岛语",
-    "Toku-No-Shima"
+    "德之岛语"
   ],
   "tkp": [
     "蒂科皮亞語",
-    "蒂科皮亚语",
-    "Tikopia"
+    "蒂科皮亚语"
   ],
   "tkq": [
     "Tee"
@@ -29806,8 +27384,7 @@
   ],
   "tku": [
     "上內卡克薩托托納克語",
-    "上内卡克萨托托纳克语",
-    "Upper Necaxa Totonac"
+    "上内卡克萨托托纳克语"
   ],
   "tkv": [
     "Mur Pano",
@@ -29821,29 +27398,23 @@
   ],
   "tkz": [
     "謝古語",
-    "谢古语",
-    "Takua"
+    "谢古语"
   ],
   "tl": [
     "他加祿語",
-    "他加禄语",
-    "塔加洛語",
-    "塔加洛语"
+    "他加禄语"
   ],
   "tla": [
     "西南特佩瓦語",
-    "西南特佩瓦语",
-    "Southwestern Tepehuan"
+    "西南特佩瓦语"
   ],
   "tlb": [
     "托貝洛語",
-    "托贝洛语",
-    "Tobelo"
+    "托贝洛语"
   ],
   "tlc": [
     "耶庫阿特拉托托納克語",
     "耶库阿特拉托托纳克语",
-    "Misantla Totonac",
     "Yecuatla Totonac"
   ],
   "tld": [
@@ -29857,13 +27428,11 @@
   ],
   "tlh": [
     "克林貢語",
-    "克林贡语",
-    "Klingon"
+    "克林贡语"
   ],
   "tli": [
     "特林吉特語",
-    "特林吉特语",
-    "Tlingit"
+    "特林吉特语"
   ],
   "tlj": [
     "Talinga-Bwisi"
@@ -29885,8 +27454,7 @@
   ],
   "tlp": [
     "菲洛梅納-馬塔-科阿維特蘭托托納克語",
-    "菲洛梅纳-马塔-科阿维特兰托托纳克语",
-    "Filomena Mata-Coahuitlán Totonac"
+    "菲洛梅纳-马塔-科阿维特兰托托纳克语"
   ],
   "tlq": [
     "Tai Loi"
@@ -29907,7 +27475,6 @@
   "tlv": [
     "塔利亞布語",
     "塔利亚布语",
-    "Taliabu",
     "Soboyo"
   ],
   "tlx": [
@@ -29916,7 +27483,6 @@
   "tly": [
     "塔利什語",
     "塔利什语",
-    "Talysh",
     "Talyshi",
     "Talishi",
     "Taleshi",
@@ -29949,7 +27515,6 @@
   "tmh": [
     "圖阿雷格語",
     "图阿雷格语",
-    "Tuareg",
     "Tamashek",
     "Tamahaq",
     "Tamajaq",
@@ -29969,8 +27534,7 @@
   ],
   "tmm": [
     "傣奈語",
-    "傣奈语",
-    "Tai Thanh"
+    "傣奈语"
   ],
   "tmn": [
     "Taman (Indonesia)",
@@ -29978,9 +27542,6 @@
   ],
   "tmo": [
     "Temoq"
-  ],
-  "tmp": [
-    "Tai Mène"
   ],
   "tmq": [
     "Tumleo"
@@ -30008,8 +27569,7 @@
   "tn": [
     "茨瓦納語",
     "茨瓦纳语",
-    "波札那語",
-    "波札那语"
+    "Setswana"
   ],
   "tna": [
     "Tacana"
@@ -30066,19 +27626,15 @@
   ],
   "tnt": [
     "通騰博安語",
-    "通腾博安语",
-    "Tontemboan"
+    "通腾博安语"
   ],
   "tnu": [
     "岱康語",
-    "岱康语",
-    "Tay Khang"
+    "岱康语"
   ],
   "tnv": [
     "坦昌雅語",
-    "坦昌雅语",
-    "Tangchangya",
-    "Tanhangya"
+    "坦昌雅语"
   ],
   "tnw": [
     "Tonsawang"
@@ -30095,9 +27651,7 @@
   ],
   "to": [
     "湯加語",
-    "汤加语",
-    "東加語",
-    "东加语"
+    "汤加语"
   ],
   "tob": [
     "Toba",
@@ -30108,8 +27662,7 @@
   ],
   "toc": [
     "科尤特拉托托納克語",
-    "科尤特拉托托纳克语",
-    "Coyutla Totonac"
+    "科尤特拉托托纳克语"
   ],
   "tod": [
     "Toma"
@@ -30120,7 +27673,6 @@
   "tog": [
     "通加語（馬拉維）",
     "通加语（马拉维）",
-    "Tonga (Malawi)",
     "Kitonga",
     "Chitonga",
     "Siska",
@@ -30131,12 +27683,12 @@
   "toh": [
     "通加語（莫桑比克）",
     "通加语（莫桑比克）",
-    "Tonga (Mozambique)",
     "Gitonga",
     "Tonga"
   ],
   "toi": [
-    "Tonga (Zambia)",
+    "通加語（贊比亞）",
+    "通加语（赞比亚）",
     "Tonga",
     "Chitonga",
     "Plateau Tonga",
@@ -30144,13 +27696,11 @@
   ],
   "toj": [
     "托霍拉瓦爾語",
-    "托霍拉瓦尔语",
-    "Tojolabal"
+    "托霍拉瓦尔语"
   ],
   "tok": [
     "道本語",
-    "道本语",
-    "Toki Pona"
+    "道本语"
   ],
   "tol": [
     "Tolowa",
@@ -30162,13 +27712,11 @@
   ],
   "too": [
     "西科特佩克-德華雷斯托托納克語",
-    "西科特佩克-德华雷斯托托纳克语",
-    "Xicotepec de Juárez Totonac"
+    "西科特佩克-德华雷斯托托纳克语"
   ],
   "top": [
     "帕潘特拉托托納克語",
-    "帕潘特拉托托纳克语",
-    "Papantla Totonac"
+    "帕潘特拉托托纳克语"
   ],
   "toq": [
     "Toposa"
@@ -30178,8 +27726,7 @@
   ],
   "tos": [
     "高地托托納克語",
-    "高地托托纳克语",
-    "Highland Totonac"
+    "高地托托纳克语"
   ],
   "tou": [
     "Tho"
@@ -30218,7 +27765,6 @@
   "tpi": [
     "托克皮辛語",
     "托克皮辛语",
-    "Tok Pisin",
     "Melanesian Pidgin English",
     "Neo-Melanesian",
     "New Guinea Pidgin"
@@ -30239,18 +27785,15 @@
   ],
   "tpn": [
     "圖皮南巴語",
-    "图皮南巴语",
-    "Tupinambá"
+    "图皮南巴语"
   ],
   "tpo": [
     "行彤傣語",
-    "行彤傣语",
-    "Tai Pao"
+    "行彤傣语"
   ],
   "tpp": [
     "比薩佛洛勒斯特佩瓦語",
-    "比萨佛洛勒斯特佩瓦语",
-    "Pisaflores Tepehua"
+    "比萨佛洛勒斯特佩瓦语"
   ],
   "tpq": [
     "Tukpa"
@@ -30260,8 +27803,7 @@
   ],
   "tpt": [
     "特拉奇奇爾科特佩瓦語",
-    "特拉奇奇尔科特佩瓦语",
-    "Tlachichilco Tepehua"
+    "特拉奇奇尔科特佩瓦语"
   ],
   "tpu": [
     "Tampuan"
@@ -30272,15 +27814,11 @@
   "tpw": [
     "古圖皮語",
     "古图皮语",
-    "古典圖皮語",
-    "古典图皮语",
-    "Old Tupi",
     "Classical Tupi"
   ],
   "tpx": [
     "阿卡特佩克-梅帕語",
-    "阿卡特佩克-梅帕语",
-    "Acatepec Me'phaa"
+    "阿卡特佩克-梅帕语"
   ],
   "tpy": [
     "Trumai"
@@ -30314,8 +27852,7 @@
   ],
   "tqt": [
     "西托托納克語",
-    "西托托纳克语",
-    "Western Totonac"
+    "西托托纳克语"
   ],
   "tqu": [
     "Touo"
@@ -30345,8 +27882,7 @@
   ],
   "trf": [
     "千里達克里奧爾英語",
-    "千里达克里奥尔英语",
-    "Trinidadian Creole English"
+    "千里达克里奥尔英语"
   ],
   "trg": [
     "Lishán Didán"
@@ -30369,18 +27905,15 @@
   ],
   "trk-oat": [
     "古安納托利亞土耳其語",
-    "古安纳托利亚土耳其语",
-    "Old Anatolian Turkish"
+    "古安纳托利亚土耳其语"
   ],
   "trk-pro": [
     "原始突厥語",
-    "原始突厥语",
-    "Proto-Turkic"
+    "原始突厥语"
   ],
   "trl": [
     "旅行者蘇格蘭語",
-    "旅行者苏格兰语",
-    "Traveller Scottish"
+    "旅行者苏格兰语"
   ],
   "trm": [
     "Tregami"
@@ -30396,19 +27929,13 @@
   "tro": [
     "塔勞語",
     "塔劳语",
-    "Tarao",
     "Tarao Naga",
     "Taraotrong",
     "Tarau"
   ],
   "trp": [
     "博羅克語",
-    "博罗克语",
-    "Kokborok",
-    "廓博羅克語",
-    "廓博罗克语",
-    "特里普拉語",
-    "特里普拉语"
+    "博罗克语"
   ],
   "trq": [
     "San Martín Itunyoso Triqui"
@@ -30424,21 +27951,16 @@
   ],
   "tru": [
     "圖羅尤語",
-    "图罗尤语",
-    "Turoyo"
+    "图罗尤语"
   ],
   "trv": [
     "賽德克語",
     "赛德克语",
-    "Seediq",
-    "太魯閣語",
-    "太鲁阁语",
-    "Taroko"
+    "Seediq"
   ],
   "trw": [
     "托瓦利語",
-    "托瓦利语",
-    "Torwali"
+    "托瓦利语"
   ],
   "trx": [
     "Tringgus",
@@ -30448,7 +27970,6 @@
   "try": [
     "土隆語",
     "土隆语",
-    "Turung",
     "Tai Turung"
   ],
   "trz": [
@@ -30474,8 +27995,7 @@
   ],
   "tse": [
     "突尼西亞手語",
-    "突尼西亚手语",
-    "Tunisian Sign Language"
+    "突尼西亚手语"
   ],
   "tsf": [
     "Southwestern Tamang"
@@ -30490,46 +28010,38 @@
   ],
   "tsi": [
     "茨姆錫安語",
-    "茨姆锡安语",
-    "欽西安語",
-    "钦西安语",
-    "Tsimshian"
+    "茨姆锡安语"
   ],
   "tsj": [
-    "Tshangla",
+    "倉洛語",
+    "仓洛语",
     "Sharchop"
   ],
   "tsl": [
     "卜老語",
-    "卜老语",
-    "Ts'ün-Lao"
+    "卜老语"
   ],
   "tsm": [
     "土耳其手語",
-    "土耳其手语",
-    "Turkish Sign Language"
+    "土耳其手语"
   ],
   "tsp": [
     "Northern Toussian"
   ],
   "tsq": [
     "泰國手語",
-    "泰国手语",
-    "Thai Sign Language"
+    "泰国手语"
   ],
   "tsr": [
     "Akei"
   ],
   "tss": [
     "臺灣手語",
-    "台湾手语",
-    "Taiwan Sign Language"
+    "台湾手语"
   ],
   "tsu": [
     "鄒語",
-    "邹语",
-    "Cou",
-    "Tsou"
+    "邹语"
   ],
   "tsv": [
     "Tsogo"
@@ -30545,20 +28057,18 @@
   ],
   "tt": [
     "韃靼語",
-    "鞑靼语",
-    "塔塔爾語",
-    "塔塔尔语"
+    "鞑靼语"
   ],
   "tta": [
-    "Tutelo"
+    "圖特盧語",
+    "图特卢语"
   ],
   "ttb": [
     "Gaa"
   ],
   "ttc": [
     "特克提特克語",
-    "特克提特克语",
-    "Tektiteko"
+    "特克提特克语"
   ],
   "ttd": [
     "Tauade"
@@ -30572,8 +28082,7 @@
   ],
   "ttg": [
     "都東語",
-    "都东语",
-    "Tutong"
+    "都东语"
   ],
   "tth": [
     "Upper Ta'oih"
@@ -30593,8 +28102,7 @@
   ],
   "ttm": [
     "北塔穹語",
-    "北塔穹语",
-    "Northern Tutchone"
+    "北塔穹语"
   ],
   "ttn": [
     "Towei"
@@ -30605,20 +28113,12 @@
   "ttp": [
     "Tombelala"
   ],
-  "ttq": [
-    "Tawallammat Tamajaq"
-  ],
   "ttr": [
     "Tera"
   ],
   "tts": [
     "伊桑語",
     "伊桑语",
-    "依善語",
-    "依善语",
-    "東北泰語",
-    "东北泰语",
-    "Isan",
     "Isanese",
     "Isaan",
     "Issan",
@@ -30627,7 +28127,6 @@
   "ttt": [
     "塔特語",
     "塔特语",
-    "Tat",
     "Caucasian Tat",
     "Muslim Tat",
     "Armeno-Tat"
@@ -30637,9 +28136,7 @@
   ],
   "ttv": [
     "馬努斯語",
-    "马努斯语",
-    "Titan",
-    "Manus"
+    "马努斯语"
   ],
   "ttw": [
     "Long Wat",
@@ -30686,8 +28183,7 @@
   ],
   "tum": [
     "通布卡語",
-    "通布卡语",
-    "Tumbuka"
+    "通布卡语"
   ],
   "tun": [
     "Tunica"
@@ -30697,8 +28193,7 @@
   ],
   "tup-gua-pro": [
     "原始圖皮-瓜拉尼語",
-    "原始图皮-瓜拉尼语",
-    "Proto-Tupi-Guarani"
+    "原始图皮-瓜拉尼语"
   ],
   "tup-kab": [
     "Kabishiana",
@@ -30714,15 +28209,15 @@
   ],
   "tup-pro": [
     "原始圖皮語",
-    "原始图皮语",
-    "Proto-Tupian"
+    "原始图皮语"
   ],
   "tuq": [
     "Tedaga",
     "Teda"
   ],
   "tus": [
-    "Tuscarora"
+    "圖斯卡羅拉語",
+    "图斯卡罗拉语"
   ],
   "tuu": [
     "Tututni"
@@ -30732,18 +28227,15 @@
   ],
   "tuw-kkl": [
     "恰喀拉語",
-    "恰喀拉语",
-    "Kyakala"
+    "恰喀拉语"
   ],
   "tuw-pro": [
     "原始通古斯語",
-    "原始通古斯语",
-    "Proto-Tungusic"
+    "原始通古斯语"
   ],
   "tuw-sol": [
     "索倫語",
-    "索伦语",
-    "Solon"
+    "索伦语"
   ],
   "tux": [
     "Tuxináwa"
@@ -30768,8 +28260,7 @@
   ],
   "tvl": [
     "圖瓦盧語",
-    "图瓦卢语",
-    "Tuvaluan"
+    "图瓦卢语"
   ],
   "tvm": [
     "Tela-Masbuar"
@@ -30778,7 +28269,8 @@
     "Tavoyan"
   ],
   "tvo": [
-    "Tidore"
+    "蒂多雷語",
+    "蒂多雷语"
   ],
   "tvs": [
     "Taveta"
@@ -30795,18 +28287,11 @@
   ],
   "tvx": [
     "大武壠語",
-    "大武壠语",
-    "大滿語",
-    "大满语",
-    "大武壟語",
-    "大武垄语",
-    "Taivoan",
-    "Taivuan"
+    "大武垅语"
   ],
   "tvy": [
     "帝汶皮欽語",
     "帝汶皮钦语",
-    "Timor Pidgin",
     "Bidau Creole Portuguese"
   ],
   "twa": [
@@ -30826,7 +28311,6 @@
   "twf": [
     "陶斯語",
     "陶斯语",
-    "Taos",
     "Northern Tiwa"
   ],
   "twg": [
@@ -30835,9 +28319,6 @@
   "twh": [
     "傣端語",
     "傣端语",
-    "傣皓語",
-    "傣皓语",
-    "Tai Dón",
     "Tai Khao",
     "White Tai"
   ],
@@ -30859,8 +28340,7 @@
   ],
   "twr": [
     "西南塔拉烏馬拉語",
-    "西南塔拉乌马拉语",
-    "Southwestern Tarahumara"
+    "西南塔拉乌马拉语"
   ],
   "twt": [
     "Turiwára"
@@ -30881,11 +28361,6 @@
   "txb": [
     "吐火羅語B",
     "吐火罗语B",
-    "乙種吐火羅語",
-    "乙种吐火罗语",
-    "龜茲語",
-    "龟兹语",
-    "Tocharian B",
     "West Tocharian",
     "Kuchean"
   ],
@@ -30897,13 +28372,11 @@
   ],
   "txg": [
     "西夏語",
-    "西夏语",
-    "Tangut"
+    "西夏语"
   ],
   "txh": [
     "色雷斯語",
-    "色雷斯语",
-    "Thracian"
+    "色雷斯语"
   ],
   "txi": [
     "Ikpeng"
@@ -30913,16 +28386,14 @@
   ],
   "txm": [
     "托米尼語",
-    "托米尼语",
-    "Tomini"
+    "托米尼语"
   ],
   "txn": [
     "West Tarangan"
   ],
   "txo": [
     "投投語",
-    "投投语",
-    "Toto"
+    "投投语"
   ],
   "txq": [
     "Tii"
@@ -30944,14 +28415,11 @@
   ],
   "ty": [
     "大溪地語",
-    "大溪地语",
-    "塔希提語",
-    "塔希提语"
+    "大溪地语"
   ],
   "tya": [
     "陶亞語",
-    "陶亚语",
-    "Tauya"
+    "陶亚语"
   ],
   "tye": [
     "Kyenga"
@@ -30963,12 +28431,14 @@
     "Teke-Tsaayi"
   ],
   "tyj": [
-    "Tai Do"
+    "Tai Do",
+    "Tai Yo",
+    "Tai Mène",
+    "Tai Maen"
   ],
   "tyl": [
     "土僚語",
-    "土僚语",
-    "Thu Lao"
+    "土僚语"
   ],
   "tyn": [
     "Kombai"
@@ -30988,20 +28458,18 @@
   "tyr": [
     "傣亮語",
     "傣亮语",
-    "Tai Daeng"
+    "Red Tai (Vietnam)"
   ],
   "tys": [
     "沙爬語",
     "沙爬语",
-    "Sapa",
     "Sa Pa",
     "Tày Sa Pa",
     "Tai Sapa"
   ],
   "tyt": [
     "德地傣語",
-    "德地傣语",
-    "Tày Tac"
+    "德地傣语"
   ],
   "tyu": [
     "Kua"
@@ -31009,7 +28477,6 @@
   "tyv": [
     "圖瓦語",
     "图瓦语",
-    "Tuvan",
     "Tyvan"
   ],
   "tyx": [
@@ -31018,7 +28485,6 @@
   "tyz": [
     "岱依語",
     "岱依语",
-    "Tày",
     "Tay",
     "Tho",
     "Bao Yen",
@@ -31026,13 +28492,11 @@
   ],
   "tza": [
     "坦桑尼亞手語",
-    "坦桑尼亚手语",
-    "Tanzanian Sign Language"
+    "坦桑尼亚手语"
   ],
   "tzh": [
     "策爾塔爾語",
-    "策尔塔尔语",
-    "Tzeltal"
+    "策尔塔尔语"
   ],
   "tzj": [
     "Tz'utujil",
@@ -31043,16 +28507,14 @@
   ],
   "tzm": [
     "中阿特拉斯柏柏爾語",
-    "中阿特拉斯柏柏尔语",
-    "Central Atlas Tamazight"
+    "中阿特拉斯柏柏尔语"
   ],
   "tzn": [
     "Tugun"
   ],
   "tzo": [
     "佐齊爾語",
-    "佐齐尔语",
-    "Tzotzil"
+    "佐齐尔语"
   ],
   "tzx": [
     "Tabriak",
@@ -31063,8 +28525,7 @@
   ],
   "uan": [
     "寬語",
-    "宽语",
-    "Kuan"
+    "宽语"
   ],
   "uar": [
     "Tairuma"
@@ -31077,32 +28538,26 @@
   ],
   "ubl": [
     "布希農比科爾語",
-    "布希农比科尔语",
-    "Buhi'non Bikol"
+    "布希农比科尔语"
   ],
   "ubr": [
     "Ubir"
   ],
   "ubu": [
     "考蓋爾語",
-    "考盖尔语",
-    "Kaugel",
-    "Umbu-Ungu"
+    "考盖尔语"
   ],
   "uby": [
     "尤比克語",
-    "尤比克语",
-    "Ubykh"
+    "尤比克语"
   ],
   "uda": [
     "烏達語",
-    "乌达语",
-    "Uda"
+    "乌达语"
   ],
   "ude": [
     "烏德蓋語",
     "乌德盖语",
-    "Udihe",
     "Udege",
     "Udekhe",
     "Udeghe"
@@ -31112,8 +28567,7 @@
   ],
   "udi": [
     "烏迪語",
-    "乌迪语",
-    "Udi"
+    "乌迪语"
   ],
   "udj": [
     "Ujir"
@@ -31123,8 +28577,7 @@
   ],
   "udm": [
     "烏得穆爾特語",
-    "乌得穆尔特语",
-    "Udmurt"
+    "乌得穆尔特语"
   ],
   "udu": [
     "Uduk"
@@ -31138,13 +28591,13 @@
   "ug": [
     "維吾爾語",
     "维吾尔语",
-    "維語",
-    "维语"
+    "Uigur",
+    "Uighur",
+    "Uygur"
   ],
   "uga": [
     "烏加里特語",
-    "乌加里特语",
-    "Ugaritic"
+    "乌加里特语"
   ],
   "ugb": [
     "Kuku-Ugbanh"
@@ -31158,13 +28611,11 @@
   "ugo": [
     "貢語",
     "贡语",
-    "Gong",
     "Ugong"
   ],
   "ugy": [
     "烏拉圭手語",
-    "乌拉圭手语",
-    "Uruguayan Sign Language"
+    "乌拉圭手语"
   ],
   "uha": [
     "Uhami"
@@ -31200,8 +28651,7 @@
   ],
   "ukl": [
     "烏克蘭手語",
-    "乌克兰手语",
-    "Ukrainian Sign Language"
+    "乌克兰手语"
   ],
   "ukp": [
     "Ukpe-Bayobiri"
@@ -31227,17 +28677,16 @@
     "Ura"
   ],
   "ulb": [
+    "Olukumi",
     "Ulukwumi"
   ],
   "ulc": [
     "烏爾奇語",
-    "乌尔奇语",
-    "Ulch"
+    "乌尔奇语"
   ],
   "ule": [
     "盧萊語",
-    "卢莱语",
-    "Lule"
+    "卢莱语"
   ],
   "ulf": [
     "Afra"
@@ -31248,7 +28697,7 @@
   "ulk": [
     "梅里阿姆語",
     "梅里阿姆语",
-    "Meriam"
+    "Meriam Mir"
   ],
   "ull": [
     "Ullatan"
@@ -31259,7 +28708,6 @@
   "uln": [
     "拉包爾克里奧爾德語",
     "拉包尔克里奥尔德语",
-    "Unserdeutsch",
     "Rabaul Creole German"
   ],
   "ulu": [
@@ -31274,14 +28722,11 @@
   "umb": [
     "姆班杜語",
     "姆班杜语",
-    "Umbundu",
     "South Mbundu"
   ],
   "umc": [
     "馬魯西尼語",
-    "马鲁西尼语",
-    "Umbundu",
-    "South Mbundu"
+    "马鲁西尼语"
   ],
   "umd": [
     "Umbindhamu"
@@ -31312,13 +28757,11 @@
   ],
   "umu": [
     "門西語",
-    "门西语",
-    "Munsee"
+    "门西语"
   ],
   "una": [
     "北瓦圖特語",
-    "北瓦图特语",
-    "North Watut"
+    "北瓦图特语"
   ],
   "und": [
     "待定語言",
@@ -31351,7 +28794,8 @@
     "Philistinian"
   ],
   "und-wji": [
-    "Western Jicaque",
+    "西希卡克語",
+    "西希卡克语",
     "Jicaque of El Palmar",
     "Sula"
   ],
@@ -31367,8 +28811,7 @@
   ],
   "unm": [
     "烏納米語",
-    "乌纳米语",
-    "Unami"
+    "乌纳米语"
   ],
   "unn": [
     "Kurnai",
@@ -31385,8 +28828,7 @@
   ],
   "unr": [
     "蒙達里語",
-    "蒙达里语",
-    "Mundari"
+    "蒙达里语"
   ],
   "unu": [
     "Unubahe"
@@ -31407,8 +28849,7 @@
   ],
   "uon": [
     "龜崙語",
-    "龟仑语",
-    "Kulon"
+    "龟仑语"
   ],
   "upi": [
     "Umeda"
@@ -31426,7 +28867,6 @@
   "urb": [
     "烏魯布-卡波爾語",
     "乌鲁布-卡波尔语",
-    "Urubú-Kaapor",
     "Ka'apor",
     "Kaaporté"
   ],
@@ -31435,8 +28875,7 @@
   ],
   "ure": [
     "烏魯語",
-    "乌鲁语",
-    "Uru"
+    "乌鲁语"
   ],
   "urf": [
     "Uradhi"
@@ -31446,58 +28885,64 @@
   ],
   "urh": [
     "烏爾霍博語",
-    "乌尔霍博语",
-    "Urhobo"
+    "乌尔霍博语"
   ],
   "uri": [
     "Urim"
   ],
   "urj-fin-pro": [
     "原始芬蘭語",
-    "原始芬兰语",
-    "Proto-Finnic"
+    "原始芬兰语"
   ],
   "urj-koo": [
     "古科米語",
-    "古科米语"
+    "古科米语",
+    "Old Permian"
+  ],
+  "urj-kuk": [
+    "Kukkuzi",
+    "Kukkuzi Votic",
+    "Kukkuzi Ingrian",
+    "Kukkusi"
+  ],
+  "urj-kya": [
+    "Komi-Yazva"
   ],
   "urj-mdv-pro": [
     "原始莫爾多瓦語",
-    "原始莫尔多瓦语",
-    "Proto-Mordvinic"
+    "原始莫尔多瓦语"
   ],
   "urj-prm-pro": [
     "原始彼爾姆語",
-    "原始彼尔姆语",
-    "Proto-Permic"
+    "原始彼尔姆语"
   ],
   "urj-pro": [
     "原始烏拉爾語",
     "原始乌拉尔语",
-    "Proto-Uralic",
     "Proto-Finno-Ugric",
     "Proto-Finno-Permic"
   ],
   "urj-ugr-pro": [
     "原始烏戈爾語",
-    "原始乌戈尔语",
-    "Proto-Ugric"
+    "原始乌戈尔语"
   ],
   "urk": [
     "奧朗勞特語",
     "奥朗劳特语",
     "Urak Lawoi",
+    "Urak Lawoc",
     "Orak Lawoi'",
     "Orak Lawoi",
     "Lawta",
-    "Chao Tha Le",
+    "Chao Le",
     "Chao Nam",
-    "Lawoi"
+    "Lawoi'",
+    "Lawoi",
+    "Lawoc"
   ],
   "url": [
     "烏拉利語",
-    "乌拉利语",
-    "Urali"
+    "乌拉利语"
   ],
   "urm": [
     "Urapmin"
@@ -31517,18 +28962,15 @@
   ],
   "urt": [
     "烏拉特語",
-    "乌拉特语",
-    "Urat"
+    "乌拉特语"
   ],
   "uru": [
     "烏魯米語",
-    "乌鲁米语",
-    "Urumi"
+    "乌鲁米语"
   ],
   "urv": [
     "烏魯阿瓦語",
-    "乌鲁阿瓦语",
-    "Uruava"
+    "乌鲁阿瓦语"
   ],
   "urw": [
     "Sop",
@@ -31540,8 +28982,7 @@
   ],
   "urx": [
     "烏里莫語",
-    "乌里莫语",
-    "Urimo"
+    "乌里莫语"
   ],
   "ury": [
     "Orya"
@@ -31551,13 +28992,11 @@
   ],
   "usa": [
     "烏薩魯法語",
-    "乌萨鲁法语",
-    "Usarufa"
+    "乌萨鲁法语"
   ],
   "ush": [
     "烏修基語",
-    "乌修基语",
-    "Ushojo"
+    "乌修基语"
   ],
   "usi": [
     "Usui"
@@ -31583,9 +29022,6 @@
   "ute": [
     "尤特語",
     "尤特语",
-    "Ute",
-    "南派伍特語",
-    "南派伍特语",
     "Southern Paiute",
     "Colorado River Numic",
     "Chemehuevi"
@@ -31599,41 +29035,29 @@
   "utp": [
     "阿姆巴語",
     "阿姆巴语",
-    "Aba",
     "Amba",
     "Nebao",
     "Nembao"
   ],
   "utr": [
     "埃圖洛語",
-    "埃图洛语",
-    "Etulo"
+    "埃图洛语"
   ],
   "utu": [
     "烏圖語",
-    "乌图语",
-    "Utu"
+    "乌图语"
   ],
   "uum": [
     "烏魯姆語",
-    "乌鲁姆语",
-    "Urum"
+    "乌鲁姆语"
   ],
   "uun": [
     "龜崙-巴宰語",
     "龟仑-巴宰语",
-    "Kulon-Pazeh",
     "Pazeh",
     "Pazih",
     "Kulun",
-    "Kulon",
-    "龜崙語",
-    "龟仑语",
-    "巴宰語",
-    "巴宰语",
-    "噶哈巫語",
-    "噶哈巫语",
-    "Kaxabu"
+    "Kulon"
   ],
   "uur": [
     "Ura (Vanuatu)"
@@ -31645,7 +29069,6 @@
   "uve": [
     "西烏韋阿語",
     "西乌韦阿语",
-    "West Uvean",
     "Uvean",
     "Faga Ouvéa",
     "Fagauvea"
@@ -31664,14 +29087,11 @@
   ],
   "uz": [
     "烏茲別克語",
-    "乌兹别克语",
-    "烏孜別克語",
-    "乌孜别克语"
+    "乌兹别克语"
   ],
   "vaa": [
     "瓦加里博里語",
-    "瓦加里博里语",
-    "Vaagri Booli"
+    "瓦加里博里语"
   ],
   "vae": [
     "Vale"
@@ -31682,15 +29102,11 @@
   "vah": [
     "瓦爾哈迪語",
     "瓦尔哈迪语",
-    "Varhadi",
-    "Varhadi-Nagpuri",
-    "瓦爾哈迪-納格普里語",
-    "瓦尔哈迪-纳格普里语"
+    "Varhadi-Nagpuri"
   ],
   "vai": [
     "瓦伊語",
     "瓦伊语",
-    "Vai",
     "Gallinas",
     "Vy"
   ],
@@ -31707,8 +29123,7 @@
   ],
   "vam": [
     "瓦尼莫語",
-    "瓦尼莫语",
-    "Vanimo"
+    "瓦尼莫语"
   ],
   "van": [
     "Valman"
@@ -31727,8 +29142,7 @@
   ],
   "vas": [
     "瓦薩維語",
-    "瓦萨维语",
-    "Vasavi"
+    "瓦萨维语"
   ],
   "vau": [
     "Vanuma"
@@ -31736,7 +29150,6 @@
   "vav": [
     "瓦爾里語",
     "瓦尔里语",
-    "Varli",
     "Warli"
   ],
   "vay": [
@@ -31756,13 +29169,11 @@
   "vec": [
     "威尼斯語",
     "威尼斯语",
-    "Venetian",
     "Venetan"
   ],
   "ved": [
     "維達語",
-    "维达语",
-    "Veddah"
+    "维达语"
   ],
   "vem": [
     "Vemgo-Mabas"
@@ -31772,33 +29183,28 @@
   ],
   "vep": [
     "維普斯語",
-    "维普斯语",
-    "Veps"
+    "维普斯语"
   ],
   "ver": [
     "Mom Jango"
   ],
   "vgr": [
     "瓦戈里語",
-    "瓦戈里语",
-    "Vaghri"
+    "瓦戈里语"
   ],
   "vgt": [
     "佛蘭德手語",
-    "佛兰德手语",
-    "Flemish Sign Language"
+    "佛兰德手语"
   ],
   "vi": [
     "越南語",
     "越南语",
-    "安南語",
-    "安南语",
+    "Annamese",
     "Annamite"
   ],
   "vic": [
     "美屬維爾京群島克里奧爾語",
-    "美属维尔京群岛克里奥尔语",
-    "Virgin Islands Creole"
+    "美属维尔京群岛克里奥尔语"
   ],
   "vid": [
     "Vidunda"
@@ -31811,8 +29217,7 @@
   ],
   "vil": [
     "維萊拉語",
-    "维莱拉语",
-    "Vilela"
+    "维莱拉语"
   ],
   "vis": [
     "Vishavan"
@@ -31825,8 +29230,7 @@
   ],
   "vka": [
     "卡里亞拉語",
-    "卡里亚拉语",
-    "Kariyarra"
+    "卡里亚拉语"
   ],
   "vki": [
     "Ija-Zuba"
@@ -31860,29 +29264,25 @@
   ],
   "vku": [
     "庫拉馬語",
-    "库拉马语",
-    "Kurrama"
+    "库拉马语"
   ],
   "vlp": [
     "Valpei"
   ],
   "vls": [
     "西佛蘭德語",
-    "西佛兰德语",
-    "West Flemish"
+    "西佛兰德语"
   ],
   "vma": [
     "馬圖蘇利那語",
-    "马图苏利那语",
-    "Martuthunira"
+    "马图苏利那语"
   ],
   "vmb": [
     "Mbabaram"
   ],
   "vmc": [
     "尤克斯特拉瓦卡米斯特克語",
-    "尤克斯特拉瓦卡米斯特克语",
-    "Juxtlahuaca Mixtec"
+    "尤克斯特拉瓦卡米斯特克语"
   ],
   "vmd": [
     "Mudu Koraga"
@@ -31893,7 +29293,6 @@
   "vmf": [
     "東法蘭克尼亞語",
     "东法兰克尼亚语",
-    "East Franconian",
     "Ansbachisch",
     "Eastern Franconian",
     "Hohenlohisch",
@@ -31910,47 +29309,40 @@
   ],
   "vmh": [
     "馬拉格伊語",
-    "马拉格伊语",
-    "Maraghei"
+    "马拉格伊语"
   ],
   "vmi": [
     "Miwa"
   ],
   "vmj": [
     "伊斯塔尤特拉米斯特克語",
-    "伊斯塔尤特拉米斯特克语",
-    "Ixtayutla Mixtec"
+    "伊斯塔尤特拉米斯特克语"
   ],
   "vmk": [
     "Makhuwa-Shirima"
   ],
   "vml": [
     "馬爾加納語",
-    "马尔加纳语",
-    "Malgana"
+    "马尔加纳语"
   ],
   "vmm": [
     "米特拉通戈米斯特克語",
-    "米特拉通戈米斯特克语",
-    "Mitlatongo Mixtec"
+    "米特拉通戈米斯特克语"
   ],
   "vmp": [
     "索亞爾特佩克馬薩特克語",
-    "索亚尔特佩克马萨特克语",
-    "Soyaltepec Mazatec"
+    "索亚尔特佩克马萨特克语"
   ],
   "vmq": [
     "索亞爾特佩克米斯特克語",
-    "索亚尔特佩克米斯特克语",
-    "Soyaltepec Mixtec"
+    "索亚尔特佩克米斯特克语"
   ],
   "vmr": [
     "Marenje"
   ],
   "vmu": [
     "穆盧利吉語",
-    "穆卢利吉语",
-    "Muluridyi"
+    "穆卢利吉语"
   ],
   "vmv": [
     "Valley Maidu"
@@ -31960,18 +29352,15 @@
   ],
   "vmx": [
     "塔馬索拉米斯特克語",
-    "塔马索拉米斯特克语",
-    "Tamazola Mixtec"
+    "塔马索拉米斯特克语"
   ],
   "vmy": [
     "阿亞烏特拉馬薩特克語",
-    "阿亚乌特拉马萨特克语",
-    "Ayautla Mazatec"
+    "阿亚乌特拉马萨特克语"
   ],
   "vmz": [
     "馬薩特蘭馬薩特克語",
-    "马萨特兰马萨特克语",
-    "Mazatlán Mazatec"
+    "马萨特兰马萨特克语"
   ],
   "vnk": [
     "Lovono"
@@ -31991,16 +29380,14 @@
   ],
   "vot": [
     "沃特語",
-    "沃特语",
-    "Votic"
+    "沃特语"
   ],
   "vra": [
     "Vera'a"
   ],
   "vro": [
     "佛羅語",
-    "佛罗语",
-    "Võro"
+    "佛罗语"
   ],
   "vrs": [
     "Varisi"
@@ -32010,18 +29397,15 @@
   ],
   "vsi": [
     "摩爾多瓦手語",
-    "摩尔多瓦手语",
-    "Moldova Sign Language"
+    "摩尔多瓦手语"
   ],
   "vsl": [
     "委內瑞拉手語",
-    "委内瑞拉手语",
-    "Venezuelan Sign Language"
+    "委内瑞拉手语"
   ],
   "vsv": [
     "瓦倫西亞手語",
-    "瓦伦西亚手语",
-    "Valencian Sign Language"
+    "瓦伦西亚手语"
   ],
   "vto": [
     "Vitou"
@@ -32045,8 +29429,6 @@
   "vwa": [
     "阿佤語",
     "阿佤语",
-    "Awa (China)",
-    "阿佤方言",
     "Awa",
     "Ava",
     "Va"
@@ -32087,12 +29469,18 @@
     "Wolayta",
     "Wolaitta",
     "Wolaita",
-    "Welayta"
+    "Welaytta",
+    "Wälaytta",
+    "Wälayta",
+    "Walayta",
+    "Walaytta",
+    "Wolamo",
+    "Welamo",
+    "Wollamo"
   ],
   "wam": [
     "麻薩諸塞語",
     "麻萨诸塞语",
-    "Massachusett",
     "Wampanoag"
   ],
   "wan": [
@@ -32107,7 +29495,6 @@
   "waq": [
     "瓦吉曼語",
     "瓦吉曼语",
-    "Wageman",
     "Wagiman",
     "Wakiman",
     "Wogeman"
@@ -32115,15 +29502,13 @@
   "war": [
     "瓦瑞瓦瑞語",
     "瓦瑞瓦瑞语",
-    "Waray-Waray",
     "Waray",
     "Winaray",
     "Samar-Leyte"
   ],
   "was": [
     "瓦修語",
-    "瓦修语",
-    "Washo"
+    "瓦修语"
   ],
   "wat": [
     "Kaninuwa"
@@ -32131,7 +29516,6 @@
   "wau": [
     "沃雅語",
     "沃雅语",
-    "Wauja",
     "Waura",
     "Waurá",
     "Uaura"
@@ -32160,8 +29544,7 @@
   ],
   "wba": [
     "瓦勞語",
-    "瓦劳语",
-    "Warao"
+    "瓦劳语"
   ],
   "wbb": [
     "Wabo"
@@ -32184,42 +29567,35 @@
   ],
   "wbk": [
     "維加里語",
-    "维加里语",
-    "Waigali"
+    "维加里语"
   ],
   "wbl": [
     "瓦罕語",
-    "瓦罕语",
-    "Wakhi"
+    "瓦罕语"
   ],
   "wbm": [
     "佤語",
     "佤语",
-    "Wa",
     "Va"
   ],
   "wbp": [
     "瓦爾皮瑞語",
-    "瓦尔皮瑞语",
-    "Warlpiri"
+    "瓦尔皮瑞语"
   ],
   "wbq": [
     "Waddar"
   ],
   "wbr": [
     "瓦格迪語",
-    "瓦格迪语",
-    "Wagdi"
+    "瓦格迪语"
   ],
   "wbt": [
     "萬曼語",
-    "万曼语",
-    "Wanman"
+    "万曼语"
   ],
   "wbv": [
     "瓦賈里語",
-    "瓦贾里语",
-    "Wajarri"
+    "瓦贾里语"
   ],
   "wbw": [
     "Woi"
@@ -32239,7 +29615,6 @@
   "wdj": [
     "瓦吉吉尼語",
     "瓦吉吉尼语",
-    "Wadjiginy",
     "Wagaydy",
     "Wadyiginy",
     "Wogaity",
@@ -32260,15 +29635,16 @@
     "Wagatsch",
     "Waogatsch"
   ],
+  "wdt": [
+    "Wendat"
+  ],
   "wdu": [
     "瓦吉古語",
-    "瓦吉古语",
-    "Wadjigu"
+    "瓦吉古语"
   ],
   "wdy": [
     "瓦賈班蓋語",
-    "瓦贾班盖语",
-    "Wadjabangayi"
+    "瓦贾班盖语"
   ],
   "wea": [
     "Wewaw"
@@ -32299,7 +29675,6 @@
   "wes": [
     "喀麥隆皮欽語",
     "喀麦隆皮钦语",
-    "Cameroon Pidgin",
     "Cameroonian Pidgin English",
     "Cameroonian Creole",
     "Kamtok"
@@ -32310,14 +29685,12 @@
   "weu": [
     "衛朗語",
     "卫朗语",
-    "Welaung",
     "Rawngtu Chin",
     "Rawngtu"
   ],
   "wew": [
     "韋耶瓦語",
-    "韦耶瓦语",
-    "Weyewa"
+    "韦耶瓦语"
   ],
   "wfg": [
     "Yafi"
@@ -32330,8 +29703,7 @@
   ],
   "wgg": [
     "旺甘古魯語",
-    "旺甘古鲁语",
-    "Wangganguru"
+    "旺甘古鲁语"
   ],
   "wgi": [
     "Wahgi"
@@ -32341,13 +29713,11 @@
   ],
   "wgu": [
     "維蘭古語",
-    "维兰古语",
-    "Wirangu"
+    "维兰古语"
   ],
   "wgy": [
     "瓦爾加馬伊語",
-    "瓦尔加马伊语",
-    "Warrgamay"
+    "瓦尔加马伊语"
   ],
   "wha": [
     "Manusela",
@@ -32367,26 +29737,22 @@
   ],
   "wic": [
     "威奇塔語",
-    "威奇塔语",
-    "Wichita"
+    "威奇塔语"
   ],
   "wie": [
     "維克-埃帕語",
-    "维克-埃帕语",
-    "Wik-Epa"
+    "维克-埃帕语"
   ],
   "wif": [
     "Wik-Keyangan"
   ],
   "wig": [
     "維克-雅塔納語",
-    "维克-雅塔纳语",
-    "Wik-Ngathana"
+    "维克-雅塔纳语"
   ],
   "wih": [
     "維克-梅安哈語",
-    "维克-梅安哈语",
-    "Wik-Me'anha"
+    "维克-梅安哈语"
   ],
   "wii": [
     "Minidien"
@@ -32396,23 +29762,19 @@
   ],
   "wik": [
     "維卡爾坎語",
-    "维卡尔坎语",
-    "Wikalkan"
+    "维卡尔坎语"
   ],
   "wil": [
     "維拉維拉語",
-    "维拉维拉语",
-    "Wilawila"
+    "维拉维拉语"
   ],
   "wim": [
     "維克-蒙坎語",
-    "维克-蒙坎语",
-    "Wik-Mungkan"
+    "维克-蒙坎语"
   ],
   "win": [
     "溫尼貝戈語",
     "温尼贝戈语",
-    "Winnebago",
     "Hocak",
     "Hochank",
     "Hochunk"
@@ -32426,15 +29788,13 @@
   "wiv": [
     "維圖語",
     "维图语",
-    "Muduapa",
     "Vitu",
     "Vittu",
     "Witu"
   ],
   "wiy": [
     "維約特語",
-    "维约特语",
-    "Wiyot"
+    "维约特语"
   ],
   "wja": [
     "Waja"
@@ -32460,8 +29820,7 @@
   ],
   "wkw": [
     "瓦卡瓦卡語",
-    "瓦卡瓦卡语",
-    "Wakawaka"
+    "瓦卡瓦卡语"
   ],
   "wky": [
     "Wangkayutyuru"
@@ -32471,16 +29830,14 @@
   ],
   "wlc": [
     "莫愛利科摩羅語",
-    "莫爱利科摩罗语",
-    "Mwali Comorian"
+    "莫爱利科摩罗语"
   ],
   "wle": [
     "Wolane"
   ],
   "wlg": [
     "昆巴朗語",
-    "昆巴朗语",
-    "Kunbarlang"
+    "昆巴朗语"
   ],
   "wli": [
     "Waioli"
@@ -32494,13 +29851,11 @@
   ],
   "wlm": [
     "中古威爾士語",
-    "中古威尔士语",
-    "Middle Welsh"
+    "中古威尔士语"
   ],
   "wlo": [
     "窩里沃語",
-    "窝里沃语",
-    "Wolio"
+    "窝里沃语"
   ],
   "wlr": [
     "Wailapa"
@@ -32508,7 +29863,6 @@
   "wls": [
     "瓦利斯語",
     "瓦利斯语",
-    "Wallisian",
     "East Uvean",
     "ʻUvean",
     "Fakaʻuvea"
@@ -32533,8 +29887,7 @@
   ],
   "wmb": [
     "萬巴亞語",
-    "万巴亚语",
-    "Wambaya"
+    "万巴亚语"
   ],
   "wmc": [
     "Wamas"
@@ -32553,8 +29906,7 @@
   ],
   "wmi": [
     "瓦明語",
-    "瓦明语",
-    "Wamin"
+    "瓦明语"
   ],
   "wmm": [
     "Maiwa (Indonesia)",
@@ -32574,13 +29926,11 @@
   ],
   "wmt": [
     "瓦爾馬賈里語",
-    "瓦尔马贾里语",
-    "Walmajarri"
+    "瓦尔马贾里语"
   ],
   "wmw": [
     "姆瓦尼語",
     "姆瓦尼语",
-    "Mwani",
     "Kimwani"
   ],
   "wmx": [
@@ -32594,13 +29944,11 @@
   ],
   "wnd": [
     "萬達朗語",
-    "万达朗语",
-    "Wandarang"
+    "万达朗语"
   ],
   "wne": [
     "瓦內茨語",
     "瓦内茨语",
-    "Waneci",
     "Wanetsi",
     "Wanechi",
     "Chalgari",
@@ -32611,16 +29959,14 @@
   ],
   "wni": [
     "昂儒昂科摩羅語",
-    "昂儒昂科摩罗语",
-    "Ndzwani Comorian"
+    "昂儒昂科摩罗语"
   ],
   "wnk": [
     "Wanukaka"
   ],
   "wnm": [
     "旺加馬拉語",
-    "旺加马拉语",
-    "Wanggamala"
+    "旺加马拉语"
   ],
   "wno": [
     "Wano"
@@ -32657,8 +30003,7 @@
   ],
   "woe": [
     "沃雷埃語",
-    "沃雷埃语",
-    "Woleaian"
+    "沃雷埃语"
   ],
   "wog": [
     "Wogamusin"
@@ -32711,7 +30056,6 @@
   "wrg": [
     "瓦龍古語",
     "瓦龙古语",
-    "Warungu",
     "Warrungu",
     "Warrongo",
     "Warrangu",
@@ -32720,17 +30064,28 @@
   "wrh": [
     "威拉祖利語",
     "威拉祖利语",
-    "Wiradhuri"
+    "Wiradjuri",
+    "Wirradhuri",
+    "Wiradhuray",
+    "Wirradgerry",
+    "Wirradjerry",
+    "Wiradyuri",
+    "Wirrathuri",
+    "Wiratheri",
+    "Wooradgery",
+    "Wooragurie",
+    "Wiiratheri",
+    "Wooratherie",
+    "Waradgeri",
+    "Weri-ari"
   ],
   "wri": [
     "瓦里揚加語",
-    "瓦里扬加语",
-    "Wariyangga"
+    "瓦里扬加语"
   ],
   "wrk": [
     "加拉瓦語",
     "加拉瓦语",
-    "Garawa",
     "Garrwa",
     "Karawa",
     "Karrwa",
@@ -32738,13 +30093,11 @@
   ],
   "wrl": [
     "瓦爾曼帕語",
-    "瓦尔曼帕语",
-    "Warlmanpa"
+    "瓦尔曼帕语"
   ],
   "wrm": [
     "瓦魯孟古語",
-    "瓦鲁孟古语",
-    "Warumungu"
+    "瓦鲁孟古语"
   ],
   "wrn": [
     "Warnang"
@@ -32760,23 +30113,19 @@
   ],
   "wrr": [
     "瓦爾達曼語",
-    "瓦尔达曼语",
-    "Wardaman"
+    "瓦尔达曼语"
   ],
   "wrs": [
     "瓦里斯語",
-    "瓦里斯语",
-    "Waris"
+    "瓦里斯语"
   ],
   "wru": [
     "瓦魯語",
-    "瓦鲁语",
-    "Waru"
+    "瓦鲁语"
   ],
   "wrv": [
     "瓦魯納語",
-    "瓦鲁纳语",
-    "Waruna"
+    "瓦鲁纳语"
   ],
   "wrw": [
     "Gugu Warra"
@@ -32830,16 +30179,14 @@
   ],
   "wtm": [
     "梅瓦蒂語",
-    "梅瓦蒂语",
-    "Mewati"
+    "梅瓦蒂语"
   ],
   "wtw": [
     "Wotu"
   ],
   "wua": [
     "維克恩根切拉語",
-    "维克恩根切拉语",
-    "Wikngenchera"
+    "维克恩根切拉语"
   ],
   "wub": [
     "Wunambal"
@@ -32849,8 +30196,7 @@
   ],
   "wuh": [
     "五屯話",
-    "五屯话",
-    "Wutunhua"
+    "五屯话"
   ],
   "wul": [
     "Silimo"
@@ -32871,11 +30217,6 @@
   "wuu": [
     "吳語",
     "吴语",
-    "蘇州話",
-    "苏州话",
-    "上海話",
-    "上海话",
-    "Wu",
     "Suzhounese",
     "Shanghainese"
   ],
@@ -32885,8 +30226,7 @@
   ],
   "wux": [
     "伍勒納語",
-    "伍勒纳语",
-    "Wulna"
+    "伍勒纳语"
   ],
   "wuy": [
     "Wauyai"
@@ -32899,37 +30239,27 @@
   ],
   "wwr": [
     "瓦爾瓦語",
-    "瓦尔瓦语",
-    "Warrwa"
+    "瓦尔瓦语"
   ],
   "www": [
     "瓦瓦語",
-    "瓦瓦语",
-    "Wawa"
+    "瓦瓦语"
   ],
   "wxa": [
     "瓦鄉話",
-    "瓦乡话",
-    "Waxianghua"
+    "瓦乡话"
   ],
   "wxw": [
     "瓦爾丹迪語",
-    "瓦尔丹迪语",
-    "Wardandi"
+    "瓦尔丹迪语"
   ],
   "wya": [
     "懷安多特語",
-    "怀安多特语",
-    "懷恩多特語",
-    "怀恩多特语",
-    "Wyandot",
-    "休倫語",
-    "休伦语"
+    "怀安多特语"
   ],
   "wyb": [
     "恩吉亞姆巴語",
     "恩吉亚姆巴语",
-    "Ngiyambaa",
     "Wangaaybuwan-Ngiyambaa",
     "Wangaaybuwan",
     "Wayilwan"
@@ -32937,7 +30267,6 @@
   "wyi": [
     "沃伊伍龍語",
     "沃伊伍龙语",
-    "Woiwurrung",
     "Woiworung",
     "Woiwurrong",
     "Wuywurung",
@@ -32978,7 +30307,6 @@
   "wym": [
     "維拉莫維安語",
     "维拉莫维安语",
-    "Vilamovian",
     "Wilamowicean",
     "Vilamovicean",
     "Wymysorys"
@@ -32993,13 +30321,11 @@
   ],
   "wyy": [
     "西斐濟語",
-    "西斐济语",
-    "Western Fijian"
+    "西斐济语"
   ],
   "xaa": [
     "安達盧斯阿拉伯語",
     "安达卢斯阿拉伯语",
-    "Andalusian Arabic",
     "Andalusi Arabic",
     "Moorish Arabic",
     "Spanish Arabic"
@@ -33015,13 +30341,11 @@
   ],
   "xae": [
     "埃桂語",
-    "埃桂语",
-    "Aequian"
+    "埃桂语"
   ],
   "xag": [
     "高加索阿爾巴尼亞語",
     "高加索阿尔巴尼亚语",
-    "Aghwan",
     "Caucasian Albanian",
     "Old Udi"
   ],
@@ -33044,14 +30368,12 @@
   "xal": [
     "卡爾梅克衛拉特語",
     "卡尔梅克卫拉特语",
-    "Kalmyk",
     "Oirat",
     "Modern Oirat"
   ],
   "xam": [
     "卡姆語",
     "卡姆语",
-    "ǀXam",
     "ǀKham"
   ],
   "xan": [
@@ -33059,26 +30381,22 @@
   ],
   "xao": [
     "考語",
-    "考语",
-    "Khao"
+    "考语"
   ],
   "xap": [
     "阿帕拉契語",
-    "阿帕拉契语",
-    "Apalachee"
+    "阿帕拉契语"
   ],
   "xaq": [
     "阿基坦語",
-    "阿基坦语",
-    "Aquitanian"
+    "阿基坦语"
   ],
   "xar": [
     "Karami"
   ],
   "xas": [
     "卡馬斯語",
-    "卡马斯语",
-    "Kamassian"
+    "卡马斯语"
   ],
   "xat": [
     "Katawixi"
@@ -33101,25 +30419,21 @@
   "xbc": [
     "巴克特里亞語",
     "巴克特里亚语",
-    "Bactrian",
     "Greco-Bactrian",
     "Kushan",
     "Kushano-Bactrian"
   ],
   "xbd": [
     "賓達爾語",
-    "宾达尔语",
-    "Bindal"
+    "宾达尔语"
   ],
   "xbe": [
     "比加姆巴爾語",
-    "比加姆巴尔语",
-    "Bigambal"
+    "比加姆巴尔语"
   ],
   "xbg": [
     "本甘迪茲語",
-    "本甘迪兹语",
-    "Bunganditj"
+    "本甘迪兹语"
   ],
   "xbi": [
     "Kombio"
@@ -33129,8 +30443,7 @@
   ],
   "xbm": [
     "中古布列塔尼語",
-    "中古布列塔尼语",
-    "Middle Breton"
+    "中古布列塔尼语"
   ],
   "xbn": [
     "Kenaboi"
@@ -33138,7 +30451,6 @@
   "xbo": [
     "保加爾語",
     "保加尔语",
-    "Bulgar",
     "Bolğar",
     "Bulghar",
     "Bolghar",
@@ -33147,13 +30459,11 @@
   ],
   "xbp": [
     "比布爾曼語",
-    "比布尔曼语",
-    "Bibbulman"
+    "比布尔曼语"
   ],
   "xbr": [
     "坎貝拉語",
     "坎贝拉语",
-    "Kambera",
     "East Sumbanese",
     "Sumbanese"
   ],
@@ -33166,18 +30476,15 @@
   ],
   "xcb": [
     "坎伯蘭語",
-    "坎伯兰语",
-    "Cumbric"
+    "坎伯兰语"
   ],
   "xcc": [
     "卡莫尼語",
-    "卡莫尼语",
-    "Camunic"
+    "卡莫尼语"
   ],
   "xce": [
     "凱爾特伊比利亞語",
-    "凯尔特伊比利亚语",
-    "Celtiberian"
+    "凯尔特伊比利亚语"
   ],
   "xch": [
     "Chemakum"
@@ -33185,7 +30492,6 @@
   "xcl": [
     "古典亞美尼亞語",
     "古典亚美尼亚语",
-    "Old Armenian",
     "Classical Armenian",
     "Liturgical Armenian",
     "Grabar"
@@ -33199,28 +30505,25 @@
   "xco": [
     "花剌子模語",
     "花剌子模语",
-    "Khwarezmian",
     "Chorasmian",
     "Khwarazmian",
     "Khorezmian"
   ],
   "xcr": [
-    "Carian"
+    "卡里亞語",
+    "卡里亚语"
   ],
   "xct": [
     "古典藏語",
-    "古典藏语",
-    "Classical Tibetan"
+    "古典藏语"
   ],
   "xcu": [
     "庫爾蘭語",
-    "库尔兰语",
-    "Curonian"
+    "库尔兰语"
   ],
   "xcv": [
     "楚凡語",
     "楚凡语",
-    "Chuvan",
     "Chuvantsy",
     "Chuvansky"
   ],
@@ -33232,18 +30535,15 @@
   ],
   "xda": [
     "達金容語",
-    "达金容语",
-    "Darkinjung"
+    "达金容语"
   ],
   "xdc": [
     "達契亞語",
-    "达契亚语",
-    "Dacian"
+    "达契亚语"
   ],
   "xdk": [
     "達拉格語",
     "达拉格语",
-    "Dharug",
     "Darug",
     "Dharruk",
     "Dharuk",
@@ -33254,18 +30554,15 @@
   ],
   "xdm": [
     "以東語",
-    "以东语",
-    "Edomite"
+    "以东语"
   ],
   "xdy": [
     "馬來達雅語",
-    "马来达雅语",
-    "Malayic Dayak"
+    "马来达雅语"
   ],
   "xeb": [
     "埃勃拉語",
-    "埃勃拉语",
-    "Eblaite"
+    "埃勃拉语"
   ],
   "xed": [
     "Hdi"
@@ -33300,26 +30597,22 @@
   ],
   "xfa": [
     "法利斯克語",
-    "法利斯克语",
-    "Faliscan"
+    "法利斯克语"
   ],
   "xga": [
     "加拉提亞語",
-    "加拉提亚语",
-    "Galatian"
+    "加拉提亚语"
   ],
   "xgb": [
     "Gbin"
   ],
   "xgd": [
     "古當語",
-    "古当语",
-    "Gudang"
+    "古当语"
   ],
   "xgf": [
     "通瓦語",
     "通瓦语",
-    "Gabrielino-Fernandeño",
     "Tongva",
     "Gabrielino",
     "Gabrieleño",
@@ -33327,13 +30620,11 @@
   ],
   "xgg": [
     "戈倫語",
-    "戈伦语",
-    "Goreng"
+    "戈伦语"
   ],
   "xgi": [
     "加林巴爾語",
-    "加林巴尔语",
-    "Garingbal"
+    "加林巴尔语"
   ],
   "xgl": [
     "Galindan"
@@ -33341,7 +30632,6 @@
   "xgm": [
     "達龍巴爾語",
     "达龙巴尔语",
-    "Darumbal",
     "Darambal",
     "Dharumbal",
     "Dharambal",
@@ -33351,17 +30641,9 @@
     "Rakiwara",
     "Wapabara"
   ],
-  "xgn-kha": [
-    "哈木尼干蒙古語",
-    "哈木尼干蒙古语",
-    "Khamnigan Mongol",
-    "Khamnigan",
-    "Khamnigan Buryat"
-  ],
   "xgn-mgl": [
     "互助土族語",
     "互助土族语",
-    "Mongghul",
     "Monguor",
     "Mongour",
     "Mongor"
@@ -33369,15 +30651,19 @@
   "xgn-mgr": [
     "民和土族語",
     "民和土族语",
-    "Mangghuer",
     "Monguor",
     "Mongour",
     "Mongor"
   ],
   "xgn-pro": [
     "原始蒙古語",
-    "原始蒙古语",
-    "Proto-Mongolic"
+    "原始蒙古语"
+  ],
+  "xgn-rua": [
+    "柔然語",
+    "柔然语",
+    "Ruan-ruan",
+    "Rouran"
   ],
   "xgr": [
     "Garza"
@@ -33387,8 +30673,12 @@
   ],
   "xgw": [
     "古瓦語",
-    "古瓦语",
-    "Guwa"
+    "古瓦语"
+  ],
+  "xgx-tuh": [
+    "吐谷渾語",
+    "吐谷浑语",
+    "'Azha"
   ],
   "xh": [
     "科薩語",
@@ -33400,16 +30690,15 @@
   "xhc": [
     "匈人語",
     "匈人语",
-    "Hunnic",
     "Hunnish"
   ],
   "xhd": [
-    "Hadrami"
+    "哈德拉毛語",
+    "哈德拉毛语"
   ],
   "xhe": [
     "克特拉尼語",
     "克特拉尼语",
-    "Khetrani",
     "Khetranki"
   ],
   "xhm": [
@@ -33418,36 +30707,30 @@
   ],
   "xhr": [
     "赫爾尼基語",
-    "赫尔尼基语",
-    "Hernican"
+    "赫尔尼基语"
   ],
   "xht": [
     "哈梯語",
-    "哈梯语",
-    "Hattic"
+    "哈梯语"
   ],
   "xhu": [
     "胡里安語",
-    "胡里安语",
-    "Hurrian"
+    "胡里安语"
   ],
   "xhv": [
     "庫瓦語",
-    "库瓦语",
-    "Khua"
+    "库瓦语"
   ],
   "xib": [
     "伊比利亞語",
-    "伊比利亚语",
-    "Iberian"
+    "伊比利亚语"
   ],
   "xii": [
     "Xiri"
   ],
   "xil": [
     "伊利里亞語",
-    "伊利里亚语",
-    "Illyrian"
+    "伊利里亚语"
   ],
   "xin": [
     "Xinca"
@@ -33468,13 +30751,11 @@
   ],
   "xjb": [
     "明瓊巴爾語",
-    "明琼巴尔语",
-    "Minjungbal"
+    "明琼巴尔语"
   ],
   "xka": [
     "卡爾科提語",
-    "卡尔科提语",
-    "Kalkoti"
+    "卡尔科提语"
   ],
   "xkb": [
     "Manigri-Kambolé Ede Nago"
@@ -33482,7 +30763,6 @@
   "xkc": [
     "科伊因語",
     "科伊因语",
-    "Khoini",
     "Xoini, Kho'ini"
   ],
   "xkd": [
@@ -33504,26 +30784,20 @@
   ],
   "xki": [
     "肯尼亞手語",
-    "肯尼亚手语",
-    "肯亞手語",
-    "肯亚手语",
-    "Kenyan Sign Language"
+    "肯尼亚手语"
   ],
   "xkj": [
     "卡賈里語",
-    "卡贾里语",
-    "Kajali"
+    "卡贾里语"
   ],
   "xkk": [
     "卡喬語",
     "卡乔语",
-    "Kaco'",
     "Lamam"
   ],
   "xkl": [
     "巴庫語",
     "巴库语",
-    "Bakung",
     "Mainstream Kenyah",
     "Kenyah"
   ],
@@ -33532,13 +30806,11 @@
   ],
   "xko": [
     "焦爾語",
-    "焦尔语",
-    "Kiorr"
+    "焦尔语"
   ],
   "xkp": [
     "卡巴特伊語",
-    "卡巴特伊语",
-    "Kabatei"
+    "卡巴特伊语"
   ],
   "xkq": [
     "Koroni"
@@ -33585,9 +30857,10 @@
     "庫爾托普語",
     "库尔托普语",
     "Kurtop",
-    "Kurtöp",
+    "Kurtö",
     "Kurtopkha",
-    "Kurtokha"
+    "Kurtokha",
+    "Zhâke"
   ],
   "xla": [
     "Kamula"
@@ -33597,53 +30870,44 @@
   ],
   "xlc": [
     "呂基亞語",
-    "吕基亚语",
-    "Lycian"
+    "吕基亚语"
   ],
   "xld": [
     "呂底亞語",
-    "吕底亚语",
-    "Lydian"
+    "吕底亚语"
   ],
   "xle": [
     "利姆尼亞語",
-    "利姆尼亚语",
-    "Lemnian"
+    "利姆尼亚语"
   ],
   "xlg": [
     "古利古里亞語",
-    "古利古里亚语",
-    "Ancient Ligurian"
+    "古利古里亚语"
   ],
   "xli": [
     "利伯尼亞語",
-    "利伯尼亚语",
-    "Liburnian"
+    "利伯尼亚语"
   ],
   "xlo": [
     "Loup A"
   ],
   "xlp": [
     "南阿爾卑斯高盧語",
-    "南阿尔卑斯高卢语",
-    "Lepontic"
+    "南阿尔卑斯高卢语"
   ],
   "xls": [
     "盧西坦尼亞語",
-    "卢西坦尼亚语",
-    "Lusitanian"
+    "卢西坦尼亚语"
   ],
   "xlu": [
     "盧維語",
     "卢维语",
-    "Luwian",
     "Cuneiform Luwian",
     "Hieroglyphic Luwian"
   ],
   "xly": [
     "伊利米語",
-    "伊利米语",
-    "Elymian"
+    "伊利米语"
   ],
   "xmb": [
     "Mbonga",
@@ -33658,7 +30922,6 @@
   "xme-ker": [
     "克爾曼語",
     "克尔曼语",
-    "Kermanic",
     "Kermanian",
     "Central Dialects",
     "Central Iranian Dialects",
@@ -33716,13 +30979,11 @@
   ],
   "xme-mid": [
     "中古米底語",
-    "中古米底语",
-    "Middle Median"
+    "中古米底语"
   ],
   "xme-old": [
     "上古米底語",
-    "上古米底语",
-    "Old Median"
+    "上古米底语"
   ],
   "xme-ott": [
     "Old Tati",
@@ -33738,12 +30999,12 @@
     "Tafreshi"
   ],
   "xme-ttc-pro": [
-    "Proto-Tatic"
+    "原始塔蒂語",
+    "原始塔蒂语"
   ],
   "xmf": [
     "明格列爾語",
     "明格列尔语",
-    "Mingrelian",
     "Megrelian",
     "Mingrel",
     "Megrel"
@@ -33754,7 +31015,6 @@
   "xmh": [
     "庫庫-穆敏赫語",
     "库库-穆敏赫语",
-    "Kugu-Muminh",
     "Kuku-Muminh",
     "Wik-Muminh",
     "Kugu-Nganhcara",
@@ -33766,47 +31026,39 @@
   ],
   "xmk": [
     "古馬其頓語",
-    "古马其顿语",
-    "Ancient Macedonian"
+    "古马其顿语"
   ],
   "xml": [
     "馬來西亞手語",
-    "马来西亚手语",
-    "Malaysian Sign Language"
+    "马来西亚手语"
   ],
   "xmm": [
     "萬鴉老馬來語",
-    "万鸦老马来语",
-    "Manado Malay"
+    "万鸦老马来语"
   ],
   "xmo": [
     "Morerebi"
   ],
   "xmp": [
     "庫庫-穆因語",
-    "库库-穆因语",
-    "Kuku-Mu'inh"
+    "库库-穆因语"
   ],
   "xmq": [
     "庫庫-芒克語",
-    "库库-芒克语",
-    "Kuku-Mangk"
+    "库库-芒克语"
   ],
   "xmr": [
     "麥羅埃語",
     "麦罗埃语",
-    "Meroitic",
     "Kushite"
   ],
   "xms": [
     "摩洛哥手語",
-    "摩洛哥手语",
-    "Moroccan Sign Language"
+    "摩洛哥手语"
   ],
   "xmt": [
     "馬特巴特語",
-    "马特巴特语",
-    "Matbat"
+    "马特巴特语"
   ],
   "xmu": [
     "Kamu"
@@ -33816,27 +31068,23 @@
   ],
   "xmy": [
     "馬雅古杜納語",
-    "马雅古杜纳语",
-    "Mayaguduna"
+    "马雅古杜纳语"
   ],
   "xmz": [
     "Mori Bawah"
   ],
   "xna": [
     "古北阿拉伯語",
-    "古北阿拉伯语",
-    "Ancient North Arabian"
+    "古北阿拉伯语"
   ],
   "xnb": [
     "卡那卡那富語",
     "卡那卡那富语",
-    "Kanakanabu",
     "Kanakanavu"
   ],
   "xnd-pro": [
     "原始納-德內語",
     "原始纳-德内语",
-    "Proto-Na-Dene",
     "Proto-Na-Dené",
     "Proto-Athabaskan-Eyak-Tlingit"
   ],
@@ -33847,32 +31095,29 @@
   ],
   "xnh": [
     "寬話",
-    "宽话",
-    "Kuanhua"
+    "宽话"
   ],
   "xni": [
     "Ngarigu"
   ],
   "xnk": [
     "恩加納卡爾蒂語",
-    "恩加纳卡尔蒂语",
-    "Nganakarti"
+    "恩加纳卡尔蒂语"
   ],
   "xnn": [
     "Northern Kankanay"
   ],
   "xnr": [
     "康格里語",
-    "康格里语",
-    "Kangri"
+    "康格里语"
   ],
   "xns": [
-    "Kanashi"
+    "卡納西語",
+    "卡纳西语"
   ],
   "xnt": [
     "納拉甘塞特語",
-    "纳拉甘塞特语",
-    "Narragansett"
+    "纳拉甘塞特语"
   ],
   "xnu": [
     "Nukunul"
@@ -33880,7 +31125,6 @@
   "xny": [
     "尼亞帕里語",
     "尼亚帕里语",
-    "Nyiyaparli",
     "Nyiyabali",
     "Njijabali",
     "Nijadali"
@@ -33934,8 +31178,7 @@
   ],
   "xpa": [
     "皮里亞語",
-    "皮里亚语",
-    "Pirriya"
+    "皮里亚语"
   ],
   "xpb": [
     "Pyemmairre",
@@ -33949,8 +31192,7 @@
   ],
   "xpc": [
     "佩切涅格語",
-    "佩切涅格语",
-    "Pecheneg"
+    "佩切涅格语"
   ],
   "xpd": [
     "Paredarerme",
@@ -33964,21 +31206,18 @@
   ],
   "xpe": [
     "利比里亞克佩列語",
-    "利比里亚克佩列语",
-    "Liberia Kpelle"
+    "利比里亚克佩列语"
   ],
   "xpf": [
     "東南塔斯馬尼亞語",
     "东南塔斯马尼亚语",
-    "Southeast Tasmanian",
     "Mainland Southeast Tasmanian",
     "Nuenonne",
     "Nyunoni"
   ],
   "xpg": [
     "弗里吉亞語",
-    "弗里吉亚语",
-    "Phrygian"
+    "弗里吉亚语"
   ],
   "xph": [
     "Tyerrernotepanner",
@@ -33988,13 +31227,11 @@
   ],
   "xpi": [
     "皮克特語",
-    "皮克特语",
-    "Pictish"
+    "皮克特语"
   ],
   "xpj": [
     "姆帕利詹語",
     "姆帕利詹语",
-    "Mpalitjanh",
     "Luthigh"
   ],
   "xpk": [
@@ -34004,21 +31241,18 @@
   "xpl": [
     "索雷爾港語",
     "索雷尔港语",
-    "Port Sorell",
     "Port Sorell Tasmanian"
   ],
   "xpm": [
     "旁普科爾語",
-    "旁普科尔语",
-    "Pumpokol"
+    "旁普科尔语"
   ],
   "xpn": [
     "Kapinawá"
   ],
   "xpo": [
     "波丘特克語",
-    "波丘特克语",
-    "Pochutec"
+    "波丘特克语"
   ],
   "xpp": [
     "Puyo-Paekche"
@@ -34028,16 +31262,15 @@
   ],
   "xpr": [
     "安息語",
-    "安息语",
-    "Parthian"
+    "安息语"
   ],
   "xps": [
-    "Pisidian"
+    "皮西迪亞語",
+    "皮西迪亚语"
   ],
   "xpu": [
     "布匿語",
-    "布匿语",
-    "Punic"
+    "布匿语"
   ],
   "xpv": [
     "Tommeginne",
@@ -34055,8 +31288,7 @@
   ],
   "xpy": [
     "扶餘語",
-    "扶余语",
-    "Buyeo"
+    "扶余语"
   ],
   "xpz": [
     "Bruny Island",
@@ -34066,8 +31298,7 @@
   ],
   "xqa": [
     "喀喇汗語",
-    "喀喇汗语",
-    "Karakhanid"
+    "喀喇汗语"
   ],
   "xqt": [
     "Qatabanian"
@@ -34086,8 +31317,7 @@
   ],
   "xrg": [
     "米南語",
-    "米南语",
-    "Minang"
+    "米南语"
   ],
   "xri": [
     "Krikati-Timbira"
@@ -34101,13 +31331,11 @@
   "xrq": [
     "卡蘭加語",
     "卡兰加语",
-    "Karranga",
     "Karrangpurru"
   ],
   "xrr": [
     "雷蒂亞語",
     "雷蒂亚语",
-    "Raetic",
     "Rhaetic",
     "Rhaetian"
   ],
@@ -34116,43 +31344,38 @@
   ],
   "xru": [
     "馬利亞穆語",
-    "马利亚穆语",
-    "Marriammu"
+    "马利亚穆语"
   ],
   "xrw": [
     "Karawa"
   ],
   "xsa": [
     "賽伯伊語",
-    "赛伯伊语",
-    "Sabaean"
+    "赛伯伊语"
   ],
   "xsb": [
     "三描語",
     "三描语",
-    "Sambali",
     "Sambal",
     "Tina Sambal",
     "Tina"
   ],
   "xsc-pro": [
     "原始斯基泰語",
-    "原始斯基泰语",
-    "Proto-Scythian"
+    "原始斯基泰语"
   ],
   "xsc-sak-pro": [
     "原始塞語",
     "原始塞语",
-    "Proto-Saka",
     "Proto-Sakan"
   ],
   "xsc-skw-pro": [
     "原始塞-瓦罕語",
-    "原始塞-瓦罕语",
-    "Proto-Saka-Wakhi"
+    "原始塞-瓦罕语"
   ],
   "xsd": [
-    "Sidetic"
+    "西代語",
+    "西代语"
   ],
   "xse": [
     "Sempan"
@@ -34168,8 +31391,7 @@
   ],
   "xsl": [
     "南斯拉維語",
-    "南斯拉维语",
-    "South Slavey"
+    "南斯拉维语"
   ],
   "xsm": [
     "Kasem",
@@ -34190,11 +31412,11 @@
   ],
   "xsr": [
     "夏爾巴語",
-    "夏尔巴语",
-    "Sherpa"
+    "夏尔巴语"
   ],
   "xss": [
-    "Assan"
+    "阿桑語",
+    "阿桑语"
   ],
   "xsu": [
     "Sanumá"
@@ -34202,24 +31424,19 @@
   "xsv": [
     "蘇多維亞語",
     "苏多维亚语",
-    "Sudovian",
     "Jatvingian"
   ],
   "xsy": [
     "賽夏語",
-    "赛夏语",
-    "Saysiyat",
-    "SaySiyat"
+    "赛夏语"
   ],
   "xta": [
     "阿爾科紹卡米斯特克語",
-    "阿尔科绍卡米斯特克语",
-    "Alcozauca Mixtec"
+    "阿尔科绍卡米斯特克语"
   ],
   "xtb": [
     "查蘇姆巴米斯特克語",
-    "查苏姆巴米斯特克语",
-    "Chazumba Mixtec"
+    "查苏姆巴米斯特克语"
   ],
   "xtc": [
     "Kadugli",
@@ -34227,8 +31444,7 @@
   ],
   "xtd": [
     "迪烏斯-蒂蘭通戈米斯特克語",
-    "迪乌斯-蒂兰通戈米斯特克语",
-    "Diuxi-Tilantongo Mixtec"
+    "迪乌斯-蒂兰通戈米斯特克语"
   ],
   "xte": [
     "Ketengban"
@@ -34238,65 +31454,52 @@
   ],
   "xti": [
     "西尼卡瓦米斯特克語",
-    "西尼卡瓦米斯特克语",
-    "Sinicahua Mixtec"
+    "西尼卡瓦米斯特克语"
   ],
   "xtj": [
     "聖胡安泰塔米斯特克語",
-    "圣胡安泰塔米斯特克语",
-    "San Juan Teita Mixtec"
+    "圣胡安泰塔米斯特克语"
   ],
   "xtl": [
     "蒂哈爾特佩克米斯特克語",
-    "蒂哈尔特佩克米斯特克语",
-    "Tijaltepec Mixtec"
+    "蒂哈尔特佩克米斯特克语"
   ],
   "xtm": [
     "馬格達萊納佩尼亞斯科米斯特克語",
-    "马格达莱纳佩尼亚斯科米斯特克语",
-    "Magdalena Peñasco Mixtec"
+    "马格达莱纳佩尼亚斯科米斯特克语"
   ],
   "xtn": [
     "北特拉夏科米斯特克語",
-    "北特拉夏科米斯特克语",
-    "Northern Tlaxiaco Mixtec"
+    "北特拉夏科米斯特克语"
   ],
   "xto": [
     "吐火羅語A",
     "吐火罗语A",
-    "焉耆語",
-    "焉耆语",
-    "甲種吐火羅語",
-    "甲种吐火罗语",
-    "Tocharian A",
     "East Tocharian",
     "Agnean"
   ],
   "xtp": [
     "聖米格爾彼德拉斯-米斯特克語",
-    "圣米格尔彼德拉斯-米斯特克语",
-    "San Miguel Piedras Mixtec"
+    "圣米格尔彼德拉斯-米斯特克语"
   ],
   "xtq": [
-    "Tumshuqese"
+    "圖木舒克語",
+    "图木舒克语"
   ],
   "xtr": [
     "Early Tripuri"
   ],
   "xts": [
     "辛迪維米斯特克語",
-    "辛迪维米斯特克语",
-    "Sindihui Mixtec"
+    "辛迪维米斯特克语"
   ],
   "xtt": [
     "塔卡瓦米斯特克語",
-    "塔卡瓦米斯特克语",
-    "Tacahua Mixtec"
+    "塔卡瓦米斯特克语"
   ],
   "xtu": [
     "庫亞梅卡爾科米斯特克語",
-    "库亚梅卡尔科米斯特克语",
-    "Cuyamecalco Mixtec"
+    "库亚梅卡尔科米斯特克语"
   ],
   "xtv": [
     "Thawa"
@@ -34306,13 +31509,11 @@
   ],
   "xty": [
     "約洛索奇特爾米斯特克語",
-    "约洛索奇特尔米斯特克语",
-    "Yoloxochitl Mixtec"
+    "约洛索奇特尔米斯特克语"
   ],
   "xtz": [
     "塔斯馬尼亞語",
-    "塔斯马尼亚语",
-    "Tasmanian"
+    "塔斯马尼亚语"
   ],
   "xua": [
     "Alu Kurumba"
@@ -34325,8 +31526,7 @@
   ],
   "xug": [
     "國頭語",
-    "国头语",
-    "Kunigami"
+    "国头语"
   ],
   "xuj": [
     "Jennu Kurumba"
@@ -34336,8 +31536,7 @@
   ],
   "xum": [
     "翁布里亞語",
-    "翁布里亚语",
-    "Umbrian"
+    "翁布里亚语"
   ],
   "xun": [
     "Unggaranggu"
@@ -34351,13 +31550,11 @@
   "xur": [
     "烏拉爾圖語",
     "乌拉尔图语",
-    "Urartian",
     "Urartean"
   ],
   "xut": [
     "庫坦特語",
-    "库坦特语",
-    "Kuthant"
+    "库坦特语"
   ],
   "xuu": [
     "Khwe",
@@ -34365,18 +31562,15 @@
   ],
   "xve": [
     "威尼托語",
-    "威尼托语",
-    "Venetic"
+    "威尼托语"
   ],
   "xvn": [
     "汪達爾語",
-    "汪达尔语",
-    "Vandalic"
+    "汪达尔语"
   ],
   "xvo": [
     "沃爾西語",
-    "沃尔西语",
-    "Volscian"
+    "沃尔西语"
   ],
   "xvs": [
     "Vestinian"
@@ -34389,8 +31583,7 @@
   ],
   "xwd": [
     "瓦迪瓦迪語",
-    "瓦迪瓦迪语",
-    "Wadi Wadi"
+    "瓦迪瓦迪语"
   ],
   "xwe": [
     "Xwela Gbe"
@@ -34400,8 +31593,7 @@
   ],
   "xwj": [
     "瓦朱克語",
-    "瓦朱克语",
-    "Wajuk"
+    "瓦朱克语"
   ],
   "xwk": [
     "Wangkumara",
@@ -34414,8 +31606,7 @@
   ],
   "xwo": [
     "書面衛拉特語",
-    "书面卫拉特语",
-    "Written Oirat"
+    "书面卫拉特语"
   ],
   "xwr": [
     "Kwerba Mamberamo"
@@ -34423,7 +31614,6 @@
   "xww": [
     "溫巴溫巴語",
     "温巴温巴语",
-    "Wemba-Wemba",
     "Wemba Wemba",
     "Wamba-Wamba",
     "Wamba Wamba",
@@ -34452,21 +31642,18 @@
   ],
   "xya": [
     "雅伊吉爾語",
-    "雅伊吉尔语",
-    "Yaygir"
+    "雅伊吉尔语"
   ],
   "xyb": [
     "揚吉巴拉語",
-    "扬吉巴拉语",
-    "Yandjibara"
+    "扬吉巴拉语"
   ],
   "xyl": [
     "Yalakalore"
   ],
   "xyt": [
     "馬伊-他庫爾蒂語",
-    "马伊-他库尔蒂语",
-    "Mayi-Thakurti"
+    "马伊-他库尔蒂语"
   ],
   "xyy": [
     "Yorta Yorta",
@@ -34481,8 +31668,7 @@
   ],
   "xzh": [
     "象雄語",
-    "象雄语",
-    "Zhang-Zhung"
+    "象雄语"
   ],
   "xzm": [
     "Zemgalian",
@@ -34491,13 +31677,11 @@
   ],
   "xzp": [
     "古薩波特克語",
-    "古萨波特克语",
-    "Ancient Zapotec"
+    "古萨波特克语"
   ],
   "yaa": [
     "亞米納瓦語",
     "亚米纳瓦语",
-    "Yaminahua",
     "Yaminawa"
   ],
   "yab": [
@@ -34505,8 +31689,7 @@
   ],
   "yac": [
     "帕斯谷亞利語",
-    "帕斯谷亚利语",
-    "Pass Valley Yali"
+    "帕斯谷亚利语"
   ],
   "yad": [
     "Yagua"
@@ -34526,11 +31709,6 @@
   "yag": [
     "雅加語",
     "雅加语",
-    "雅馬納語",
-    "雅马纳语",
-    "雅甘語",
-    "雅甘语",
-    "Yámana",
     "Yagán",
     "Yahgan",
     "Yaghan"
@@ -34538,13 +31716,11 @@
   "yah": [
     "雅茲古拉米語",
     "雅兹古拉米语",
-    "Yazghulami",
     "Yazgulyam"
   ],
   "yai": [
     "雅格諾比語",
     "雅格诺比语",
-    "Yagnobi",
     "Yaghnobi",
     "Yaghnabi",
     "Yagnabi"
@@ -34573,13 +31749,11 @@
   ],
   "yap": [
     "雅浦語",
-    "雅浦语",
-    "Yapese"
+    "雅浦语"
   ],
   "yaq": [
     "亞基語",
     "亚基语",
-    "Yaqui",
     "Hiaki",
     "Yoeme"
   ],
@@ -34618,13 +31792,11 @@
   ],
   "ybe": [
     "西部裕固語",
-    "西部裕固语",
-    "Western Yugur"
+    "西部裕固语"
   ],
   "ybh": [
     "雅卡語",
-    "雅卡语",
-    "Yakkha"
+    "雅卡语"
   ],
   "ybi": [
     "Yamphu"
@@ -34634,8 +31806,7 @@
   ],
   "ybk": [
     "黑木吉語",
-    "黑木吉语",
-    "Bokha"
+    "黑木吉语"
   ],
   "ybl": [
     "Yukuben"
@@ -34656,12 +31827,12 @@
     "Yaweyuha"
   ],
   "ych": [
-    "Chesu"
+    "車蘇語",
+    "车苏语"
   ],
   "ycl": [
     "倮倮潑語",
-    "倮倮泼语",
-    "Lolopo"
+    "倮倮泼语"
   ],
   "ycn": [
     "Yucuna",
@@ -34672,20 +31843,24 @@
     "Jukuna"
   ],
   "ycp": [
-    "Chepya"
+    "切皮亞語",
+    "切皮亚语"
+  ],
+  "ycr": [
+    "寒溪語",
+    "寒溪语",
+    "Yilan Creole Japanese"
   ],
   "yda": [
     "揚達語",
-    "扬达语",
-    "Yanda"
+    "扬达语"
   ],
   "yde": [
     "Yangum Dey"
   ],
   "ydg": [
     "伊特格哈語",
-    "伊特格哈语",
-    "Yidgha"
+    "伊特格哈语"
   ],
   "ydk": [
     "Yoidik"
@@ -34695,8 +31870,7 @@
   ],
   "yec": [
     "葉尼什語",
-    "叶尼什语",
-    "Yeniche"
+    "叶尼什语"
   ],
   "yee": [
     "Yimas"
@@ -34706,9 +31880,7 @@
   ],
   "yej": [
     "猶太-希臘語",
-    "犹太-希腊语",
-    "Yevanic",
-    "Judeo-Greek"
+    "犹太-希腊语"
   ],
   "yen": [
     "Yendang",
@@ -34737,8 +31909,7 @@
   ],
   "ygi": [
     "伊寧蓋語",
-    "伊宁盖语",
-    "Yiningayi"
+    "伊宁盖语"
   ],
   "ygl": [
     "Yangum Gel"
@@ -34747,7 +31918,8 @@
     "Yagomi"
   ],
   "ygp": [
-    "Gepo"
+    "峨頗語",
+    "峨颇语"
   ],
   "ygr": [
     "Yagaria",
@@ -34755,13 +31927,11 @@
   ],
   "ygs": [
     "雍古手語",
-    "雍古手语",
-    "Yolngu Sign Language"
+    "雍古手语"
   ],
   "ygu": [
     "尤古爾語",
-    "尤古尔语",
-    "Yugul"
+    "尤古尔语"
   ],
   "ygw": [
     "Yagwoia"
@@ -34769,19 +31939,12 @@
   "yha": [
     "巴哈語",
     "巴哈语",
-    "Baha",
     "Baha Buyang",
     "Paha"
   ],
-  "yhd": [
-    "猶太伊拉克阿拉伯語",
-    "犹太伊拉克阿拉伯语",
-    "Judeo-Iraqi Arabic"
-  ],
   "yhl": [
     "圪勒頗普佤語",
-    "圪勒颇普佤语",
-    "Hlepho Phowa"
+    "圪勒颇普佤语"
   ],
   "yi": [
     "意第緒語",
@@ -34789,32 +31952,27 @@
   ],
   "yia": [
     "英加爾達語",
-    "英加尔达语",
-    "Yinggarda"
+    "英加尔达语"
   ],
   "yif": [
     "阿車語",
     "阿车语",
-    "Ache",
     "Azhe"
   ],
   "yig": [
     "烏撒納蘇語",
-    "乌撒纳苏语",
-    "Wusa Nasu"
+    "乌撒纳苏语"
   ],
   "yii": [
     "Yidiny"
   ],
   "yij": [
     "因吉班迪語",
-    "因吉班迪语",
-    "Yindjibarndi"
+    "因吉班迪语"
   ],
   "yik": [
     "東山壩臘羅語",
-    "东山坝腊罗语",
-    "Dongshanba Lalo"
+    "东山坝腊罗语"
   ],
   "yil": [
     "Yindjilandji"
@@ -34826,10 +31984,12 @@
     "Yinchia"
   ],
   "yip": [
-    "Pholo"
+    "仆拉語",
+    "仆拉语"
   ],
   "yiq": [
-    "Miqie",
+    "密察語",
+    "密察语",
     "Micha"
   ],
   "yir": [
@@ -34840,23 +32000,24 @@
   ],
   "yit": [
     "東臘魯語",
-    "东腊鲁语",
-    "Eastern Lalu"
+    "东腊鲁语"
   ],
   "yiu": [
-    "Awu",
+    "阿鄔語",
+    "阿邬语",
     "Lope"
   ],
   "yiv": [
-    "Northern Nisu"
+    "北尼蘇語",
+    "北尼苏语"
   ],
   "yix": [
-    "Axi Yi"
+    "阿細彝語",
+    "阿细彝语"
   ],
   "yiy": [
     "伊爾-約龍特語",
     "伊尔-约龙特语",
-    "Yir-Yoront",
     "Yir Yoront",
     "Yirr-Yoront",
     "Yirr-Yorront",
@@ -34866,22 +32027,22 @@
     "Yirr-Thangell"
   ],
   "yiz": [
-    "Azhe"
+    "阿哲語",
+    "阿哲语"
   ],
   "yka": [
     "亞坎語",
-    "亚坎语",
-    "Yakan",
-    "雅坎語",
-    "雅坎语"
+    "亚坎语"
   ],
   "ykg": [
     "北尤卡吉爾語",
     "北尤卡吉尔语",
-    "凍原尤卡吉爾語",
-    "冻原尤卡吉尔语",
-    "Northern Yukaghir",
     "Tundra Yukaghir"
+  ],
+  "ykh": [
+    "Khamnigan Mongol",
+    "Khamnigan",
+    "Khamnigan Buryat"
   ],
   "yki": [
     "Yoke"
@@ -34890,7 +32051,8 @@
     "Yakaikeke"
   ],
   "ykl": [
-    "Khlula"
+    "科魯拉語",
+    "科鲁拉语"
   ],
   "ykm": [
     "Kap",
@@ -34899,10 +32061,7 @@
   ],
   "ykn": [
     "河東彝語",
-    "河东彝语",
-    "跨恩斯話",
-    "跨恩斯话",
-    "Kua-nsi"
+    "河东彝语"
   ],
   "yko": [
     "Yasa"
@@ -34911,13 +32070,12 @@
     "Yekora"
   ],
   "ykt": [
-    "Kathu"
+    "嘎蘇話",
+    "嘎苏话"
   ],
   "yku": [
     "跨瑪斯話",
-    "跨玛斯话",
-    "松坪彝語",
-    "松坪彝语"
+    "跨玛斯话"
   ],
   "yky": [
     "Yakoma",
@@ -34932,9 +32090,7 @@
   ],
   "yle": [
     "耶里多涅語",
-    "耶里多涅语",
-    "耶勒語",
-    "耶勒语"
+    "耶里多涅语"
   ],
   "ylg": [
     "Yelogu"
@@ -34942,27 +32098,26 @@
   "yli": [
     "昂古魯克亞利語",
     "昂古鲁克亚利语",
-    "Angguruk Yali",
     "Northern Yali"
   ],
   "yll": [
     "Yil"
   ],
   "ylm": [
-    "Limi"
+    "留米語",
+    "留米语"
   ],
   "yln": [
     "郎念布央語",
-    "郎念布央语",
-    "Langnian Buyang"
+    "郎念布央语"
   ],
   "ylo": [
-    "Naluo Yi"
+    "納若語",
+    "纳若语"
   ],
   "ylr": [
     "亞蘭加語",
-    "亚兰加语",
-    "Yalarnnga"
+    "亚兰加语"
   ],
   "ylu": [
     "Aribwaung",
@@ -34978,11 +32133,11 @@
   ],
   "ymc": [
     "南木吉語",
-    "南木吉语",
-    "Southern Muji"
+    "南木吉语"
   ],
   "ymd": [
-    "Muda"
+    "木達語",
+    "木达语"
   ],
   "yme": [
     "Yameo"
@@ -34991,10 +32146,12 @@
     "Yamongeri"
   ],
   "ymh": [
-    "Mili"
+    "咪俚語",
+    "咪俚语"
   ],
   "ymi": [
-    "Moji"
+    "墨幾語",
+    "墨几语"
   ],
   "ymk": [
     "Makwe"
@@ -35017,35 +32174,34 @@
   ],
   "ymq": [
     "期臘木吉語",
-    "期腊木吉语",
-    "Qila Muji"
+    "期腊木吉语"
   ],
   "ymr": [
     "Malasar"
   ],
   "yms": [
     "密細亞語",
-    "密细亚语",
-    "Mysian"
+    "密细亚语"
   ],
   "ymx": [
     "北木吉語",
-    "北木吉语",
-    "Northern Muji"
+    "北木吉语"
   ],
   "ymz": [
-    "Muzi"
+    "木支語",
+    "木支语"
   ],
   "yna": [
-    "Aluo"
+    "阿羅語",
+    "阿罗语"
   ],
   "ynd": [
     "揚德魯萬塔語",
-    "扬德鲁万塔语",
-    "Yandruwandha"
+    "扬德鲁万塔语"
   ],
   "yne": [
-    "Lang'e"
+    "崀峨語",
+    "崀峨语"
   ],
   "yng": [
     "Yango"
@@ -35065,7 +32221,7 @@
   "yno": [
     "傣允語",
     "傣允语",
-    "Yong"
+    "Tai Yong"
   ],
   "yns": [
     "Yansi"
@@ -35084,18 +32240,15 @@
   ],
   "yog": [
     "尤加德語",
-    "尤加德语",
-    "Yogad"
+    "尤加德语"
   ],
   "yoi": [
     "與那國語",
-    "与那国语",
-    "Yonaguni"
+    "与那国语"
   ],
   "yol": [
     "約拉語",
-    "约拉语",
-    "Yola"
+    "约拉语"
   ],
   "yom": [
     "Yombe"
@@ -35105,63 +32258,51 @@
   ],
   "yox": [
     "與論語",
-    "与论语",
-    "Yoron"
+    "与论语"
   ],
   "yoy": [
     "堯依語",
-    "尧依语",
-    "Yoy"
+    "尧依语"
   ],
   "ypa": [
     "帕拉語",
-    "帕拉语",
-    "Phala"
+    "帕拉语"
   ],
   "ypb": [
     "拉波普佤語",
-    "拉波普佤语",
-    "Labo Phowa"
+    "拉波普佤语"
   ],
   "ypg": [
     "普拉語",
-    "普拉语",
-    "Phola"
+    "普拉语"
   ],
   "yph": [
     "富帕語",
-    "富帕语",
-    "Phupha"
+    "富帕语"
   ],
   "ypk-pro": [
     "原始尤皮克語",
-    "原始尤皮克语",
-    "Proto-Yupik"
+    "原始尤皮克语"
   ],
   "ypm": [
     "富馬語",
-    "富马语",
-    "Phuma"
+    "富马语"
   ],
   "ypn": [
     "阿尼普佤語",
-    "阿尼普佤语",
-    "Ani Phowa"
+    "阿尼普佤语"
   ],
   "ypo": [
     "阿洛普拉語",
-    "阿洛普拉语",
-    "Alo Phola"
+    "阿洛普拉语"
   ],
   "ypp": [
     "富巴語",
-    "富巴语",
-    "Phupa"
+    "富巴语"
   ],
   "ypz": [
     "富匝語",
-    "富匝语",
-    "Phuza"
+    "富匝语"
   ],
   "yra": [
     "Yerakai"
@@ -35174,13 +32315,11 @@
   ],
   "yri": [
     "亞里語",
-    "亚里语",
-    "Yarí"
+    "亚里语"
   ],
   "yrk": [
     "凍原涅涅茨語",
     "冻原涅涅茨语",
-    "Tundra Nenets",
     "Nenets",
     "Yurak"
   ],
@@ -35195,8 +32334,7 @@
   ],
   "yrn": [
     "耶容語",
-    "耶容语",
-    "Yerong"
+    "耶容语"
   ],
   "yro": [
     "Yaroamë",
@@ -35211,49 +32349,38 @@
   ],
   "yry": [
     "雅爾魯延迪語",
-    "雅尔鲁延迪语",
-    "Yarluyandi",
-    "Yassic"
+    "雅尔鲁延迪语"
   ],
   "ysc": [
     "雅西克語",
     "雅西克语",
-    "Jassic",
     "Yassic"
   ],
   "ysd": [
     "撒慕語",
     "撒慕语",
-    "撒馬多語",
-    "撒马多语",
-    "Samatao",
     "Samu",
     "Eastern Samadu"
   ],
   "ysg": [
     "鎖內嘎話",
-    "锁内嘎话",
-    "新峰彝語",
-    "新峰彝语",
-    "Sonaga"
+    "锁内嘎话"
   ],
   "ysl": [
     "南斯拉夫手語",
-    "南斯拉夫手语",
-    "Yugoslavian Sign Language"
+    "南斯拉夫手语"
   ],
   "ysn": [
     "撒尼語",
-    "撒尼语",
-    "Sani"
+    "撒尼语"
   ],
   "yso": [
-    "Nisi"
+    "尼斯彝語",
+    "尼斯彝语"
   ],
   "ysp": [
     "南倮倮潑語",
-    "南倮倮泼语",
-    "Southern Lolopo"
+    "南倮倮泼语"
   ],
   "ysr": [
     "Sirenik"
@@ -35265,57 +32392,42 @@
   ],
   "ysy": [
     "撒涅語",
-    "撒涅语",
-    "Sanie"
+    "撒涅语"
   ],
   "yta": [
     "他留語",
-    "他留语",
-    "Talu"
+    "他留语"
   ],
   "ytl": [
     "堂郎語",
     "堂郎语",
-    "Tanglang",
     "Tholo"
   ],
   "ytp": [
-    "Thopho"
+    "脫潑語",
+    "脱泼语"
   ],
   "ytw": [
     "Yout Wam"
   ],
   "yty": [
     "亞泰語",
-    "亚泰语",
-    "Yatay"
+    "亚泰语"
   ],
   "yua": [
     "尤卡坦瑪雅語",
-    "尤卡坦玛雅语",
-    "猶加敦馬雅語",
-    "犹加敦马雅语",
-    "Yucatec Maya"
+    "尤卡坦玛雅语"
   ],
   "yub": [
     "尤甘巴爾語",
-    "尤甘巴尔语",
-    "Yugambal"
+    "尤甘巴尔语"
   ],
   "yuc": [
     "Yuchi"
   ],
-  "yud": [
-    "猶太的黎波里塔尼亞阿拉伯語",
-    "犹太的黎波里塔尼亚阿拉伯语",
-    "Judeo-Tripolitanian Arabic"
-  ],
   "yue": [
     "粵語",
     "粤语",
-    "Cantonese",
-    "廣東話",
-    "广东话",
     "Yue",
     "Yüeh"
   ],
@@ -35325,7 +32437,6 @@
   "yug": [
     "尤格語",
     "尤格语",
-    "Yug",
     "Yugh"
   ],
   "yui": [
@@ -35370,8 +32481,7 @@
   ],
   "yur": [
     "尤羅克語",
-    "尤罗克语",
-    "Yurok"
+    "尤罗克语"
   ],
   "yut": [
     "Yopno"
@@ -35383,18 +32493,12 @@
   "yux": [
     "南尤卡吉爾語",
     "南尤卡吉尔语",
-    "科雷馬尤卡吉爾語",
-    "科雷马尤卡吉尔语",
-    "森林尤卡吉爾語",
-    "森林尤卡吉尔语",
-    "Southern Yukaghir",
     "Forest Yukaghir",
     "Kolyma Yukaghir"
   ],
   "yuy": [
     "東部裕固語",
     "东部裕固语",
-    "East Yugur",
     "Eastern Yugur",
     "Shera Yugur"
   ],
@@ -35415,13 +32519,11 @@
   ],
   "ywg": [
     "因哈旺卡語",
-    "因哈旺卡语",
-    "Yinhawangka"
+    "因哈旺卡语"
   ],
   "ywl": [
     "西臘魯語",
-    "西腊鲁语",
-    "Western Lalu"
+    "西腊鲁语"
   ],
   "ywn": [
     "Yawanawa"
@@ -35429,23 +32531,19 @@
   "ywq": [
     "納蘇語",
     "纳苏语",
-    "Nasu",
     "Wuding-Luquan Yi"
   ],
   "ywr": [
     "雅烏魯語",
-    "雅乌鲁语",
-    "Yawuru"
+    "雅乌鲁语"
   ],
   "ywt": [
     "中臘羅語",
-    "中腊罗语",
-    "Xishanba Lalo"
+    "中腊罗语"
   ],
   "ywu": [
     "烏蒙彝語",
     "乌蒙彝语",
-    "Wumeng Nasu",
     "Wumeng Yi",
     "Wusa Yi"
   ],
@@ -35454,65 +32552,49 @@
   ],
   "yxa": [
     "馬亞瓦利語",
-    "马亚瓦利语",
-    "Mayawali"
+    "马亚瓦利语"
   ],
   "yxg": [
     "亞加拉語",
-    "亚加拉语",
-    "Yagara"
+    "亚加拉语"
   ],
   "yxl": [
     "亞爾利語",
     "亚尔利语",
-    "亞爾德利亞瓦拉語",
-    "亚尔德利亚瓦拉语",
-    "Yarli",
     "Yardliyawarra",
     "Wadikali",
     "Malyangapa"
   ],
   "yxm": [
     "因溫語",
-    "因温语",
-    "Yinwum"
+    "因温语"
   ],
   "yxu": [
     "尤尤語",
-    "尤尤语",
-    "Yuyu"
+    "尤尤语"
   ],
   "yxy": [
     "亞布拉亞布拉語",
     "亚布拉亚布拉语",
-    "Yabula Yabula",
     "Yabula-Yabula",
     "Jabulajabula"
   ],
   "yyu": [
     "托里切利堯語",
     "托里切利尧语",
-    "堯語",
-    "尧语",
-    "Torricelli Yau",
     "Yau"
   ],
   "yyz": [
     "阿彝子語",
-    "阿彝子语",
-    "阿彝子話",
-    "阿彝子话",
-    "Ayizi"
+    "阿彝子语"
   ],
   "yzg": [
     "峨馬布央語",
-    "峨马布央语",
-    "E'ma Buyang"
+    "峨马布央语"
   ],
   "yzk": [
     "綽闊語",
-    "绰阔语",
-    "Zokhuo"
+    "绰阔语"
   ],
   "za": [
     "壯語",
@@ -35521,14 +32603,12 @@
   "zaa": [
     "胡亞雷斯山薩波特克語",
     "胡亚雷斯山萨波特克语",
-    "Sierra de Juárez Zapotec",
     "Ixtlán Zapotec",
     "Atepec"
   ],
   "zab": [
     "聖胡安格拉維亞薩波特克語",
     "圣胡安格拉维亚萨波特克语",
-    "San Juan Guelavía Zapotec",
     "Western Tlacolula Zapotec",
     "Western Tlacolula Valley Zapotec",
     "Tlacolula Valley Zapotec",
@@ -35545,13 +32625,11 @@
   ],
   "zac": [
     "奧科特蘭薩波特克語",
-    "奥科特兰萨波特克语",
-    "Ocotlán Zapotec"
+    "奥科特兰萨波特克语"
   ],
   "zad": [
     "卡霍諾斯薩波特克語",
     "卡霍诺斯萨波特克语",
-    "Cajonos Zapotec",
     "Southern Villa Alta Zapotec",
     "Yaganiza Zapotec",
     "Yaganiza-Xagacía Zapotec",
@@ -35560,19 +32638,16 @@
   "zae": [
     "亞雷尼薩波特克語",
     "亚雷尼萨波特克语",
-    "Yareni Zapotec",
     "Western Ixtlán Zapotec",
     "Etla Zapotec"
   ],
   "zaf": [
     "阿約克斯科薩波特克語",
-    "阿约克斯科萨波特克语",
-    "Ayoquesco Zapotec"
+    "阿约克斯科萨波特克语"
   ],
   "zag": [
     "札加瓦語",
     "札加瓦语",
-    "Zaghawa",
     "Zakhawa",
     "Beria"
   ],
@@ -35581,8 +32656,7 @@
   ],
   "zai": [
     "地峽薩波特克語",
-    "地峡萨波特克语",
-    "Isthmus Zapotec"
+    "地峡萨波特克语"
   ],
   "zaj": [
     "Zaramo"
@@ -35592,65 +32666,52 @@
   ],
   "zal": [
     "柔若語",
-    "柔若语",
-    "Zauzou"
+    "柔若语"
   ],
   "zam": [
     "米亞瓦特蘭薩波特克語",
-    "米亚瓦特兰萨波特克语",
-    "Central Mahuatlán Zapoteco",
-    "Miahuatlán Zapotec"
+    "米亚瓦特兰萨波特克语"
   ],
   "zao": [
     "奧索洛特佩克薩波特克語",
-    "奥索洛特佩克萨波特克语",
-    "Ozolotepec Zapotec"
+    "奥索洛特佩克萨波特克语"
   ],
   "zap": [
     "薩波特克語",
-    "萨波特克语",
-    "Zapotec"
+    "萨波特克语"
   ],
   "zaq": [
     "阿洛阿帕姆薩波特克語",
-    "阿洛阿帕姆萨波特克语",
-    "Aloápam Zapotec"
+    "阿洛阿帕姆萨波特克语"
   ],
   "zar": [
     "林松薩波特克語",
-    "林松萨波特克语",
-    "Rincón Zapotec"
+    "林松萨波特克语"
   ],
   "zas": [
     "聖多明各阿爾巴拉達斯薩波特克語",
-    "圣多明各阿尔巴拉达斯萨波特克语",
-    "Santo Domingo Albarradas Zapotec"
+    "圣多明各阿尔巴拉达斯萨波特克语"
   ],
   "zat": [
     "塔巴薩波特克語",
-    "塔巴萨波特克语",
-    "Tabaa Zapotec"
+    "塔巴萨波特克语"
   ],
   "zau": [
     "藏斯卡語",
     "藏斯卡语",
-    "Zangskari",
     "Zanskari"
   ],
   "zav": [
     "亞查奇薩波特克語",
-    "亚查奇萨波特克语",
-    "Yatzachi Zapotec"
+    "亚查奇萨波特克语"
   ],
   "zaw": [
     "米特拉薩波特克語",
-    "米特拉萨波特克语",
-    "Mitla Zapotec"
+    "米特拉萨波特克语"
   ],
   "zax": [
     "薩達尼薩波特克語",
-    "萨达尼萨波特克语",
-    "Xadani Zapotec"
+    "萨达尼萨波特克语"
   ],
   "zay": [
     "Zayse-Zergulla"
@@ -35660,32 +32721,24 @@
   ],
   "zbt": [
     "巴圖伊語",
-    "巴图伊语",
-    "Batui"
+    "巴图伊语"
   ],
   "zca": [
     "科亞特卡斯阿特拉斯薩波特克語",
-    "科亚特卡斯阿特拉斯萨波特克语",
-    "Coatecas Altas Zapotec"
+    "科亚特卡斯阿特拉斯萨波特克语"
   ],
   "zdj": [
     "大科摩羅語",
     "大科摩罗语",
-    "Ngazidja Comorian",
     "Ngazidja",
     "Shingazidja"
   ],
   "zea": [
     "澤蘭語",
-    "泽兰语",
-    "Zealandic"
+    "泽兰语"
   ],
   "zeg": [
     "Zenag"
-  ],
-  "zeh": [
-    "東紅水河壯語",
-    "东红水河壮语"
   ],
   "zen": [
     "澤納加語",
@@ -35697,30 +32750,18 @@
   "zgh": [
     "標準摩洛哥柏柏爾語",
     "标准摩洛哥柏柏尔语",
-    "Moroccan Amazigh",
-    "Standard Moroccan Tamazight",
     "Standard Moroccan Amazigh",
+    "Standard Moroccan Tamazight",
     "Standard Moroccan Berber",
     "Amazigh",
     "Tamazight"
-  ],
-  "zgm": [
-    "民講",
-    "民讲",
-    "Min Zhuang",
-    "Minz Zhuang"
   ],
   "zgr": [
     "Magori"
   ],
   "zh": [
     "漢語",
-    "汉语",
-    "Chinese",
-    "現代漢語",
-    "现代汉语",
-    "現代標準漢語",
-    "现代标准汉语"
+    "汉语"
   ],
   "zhb": [
     "Zhaba",
@@ -35732,7 +32773,6 @@
   "zhn": [
     "儂壯語",
     "侬壮语",
-    "Nong Zhuang",
     "Yanguang Zhuang",
     "Western Nung",
     "Nung Din"
@@ -35742,41 +32782,24 @@
   ],
   "zhx-min-pro": [
     "原始閩語",
-    "原始闽语",
-    "Proto-Min"
-  ],
-  "zhx-pin": [
-    "平話",
-    "平话"
+    "原始闽语"
   ],
   "zhx-sht": [
     "韶州土話",
     "韶州土话",
-    "Shaozhou Tuhua",
     "Xiangnan Tuhua",
     "Yuebei Tuhua",
     "Shipo",
     "Shina"
   ],
-  "zhx-sjc": [
-    "邵將語",
-    "邵将语",
-    "邵將話",
-    "邵将话",
-    "邵將閩語",
-    "邵将闽语",
-    "Shao-Jiang Min"
-  ],
   "zhx-tai": [
     "台山話",
     "台山话",
-    "Taishanese",
     "Toishanese"
   ],
   "zhx-teo": [
     "潮州話",
     "潮州话",
-    "Teochew",
     "Chiuchow"
   ],
   "zia": [
@@ -35784,10 +32807,7 @@
   ],
   "zib": [
     "津巴布韋手語",
-    "津巴布韦手语",
-    "辛巴威手語",
-    "辛巴威手语",
-    "Zimbabwe Sign Language"
+    "津巴布韦手语"
   ],
   "zik": [
     "Zimakani"
@@ -35815,115 +32835,93 @@
   ],
   "zkb": [
     "科伊巴爾語",
-    "科伊巴尔语",
-    "Koibal"
+    "科伊巴尔语"
   ],
   "zkg": [
     "高句麗語",
-    "高句丽语",
-    "Goguryeo"
+    "高句丽语"
   ],
   "zkh": [
     "花剌子模突厥語",
     "花剌子模突厥语",
-    "Khorezmian Turkic",
     "Khorezmian",
     "Khorezmian-Turkic"
   ],
   "zkk": [
-    "Karankawa"
+    "卡蘭卡瓦語",
+    "卡兰卡瓦语"
   ],
   "zko": [
     "科特語",
-    "科特语",
-    "Kott"
+    "科特语"
   ],
   "zkp": [
-    "São Paulo Kaingáng"
+    "聖保羅坎剛語",
+    "圣保罗坎刚语"
   ],
   "zkr": [
-    "Zakhring"
+    "扎話",
+    "扎话"
   ],
   "zkt": [
     "契丹語",
-    "契丹语",
-    "Khitan"
+    "契丹语"
   ],
   "zku": [
     "考爾納語",
-    "考尔纳语",
-    "加雲拿語",
-    "加云拿语",
-    "Kaurna"
+    "考尔纳语"
   ],
   "zkv": [
     "克雷溫語",
-    "克雷温语",
-    "Krevinian"
+    "克雷温语"
   ],
   "zkz": [
     "可薩語",
-    "可萨语",
-    "Khazar"
+    "可萨语"
   ],
   "zle-ono": [
     "古諾夫哥羅德語",
-    "古诺夫哥罗德语",
-    "Old Novgorodian"
+    "古诺夫哥罗德语"
   ],
   "zle-ort": [
     "古盧森尼亞語",
-    "古卢森尼亚语",
-    "羅塞尼亞語",
-    "罗塞尼亚语",
-    "魯塞尼亞語",
-    "鲁塞尼亚语",
-    "Old Ruthenian"
+    "古卢森尼亚语"
   ],
   "zlw-ocs": [
     "古捷克語",
-    "古捷克语",
-    "Old Czech"
+    "古捷克语"
   ],
   "zlw-opl": [
     "古波蘭語",
-    "古波兰语",
-    "Old Polish"
+    "古波兰语"
   ],
-  "zlw-pom": [
-    "波美拉尼亞語",
-    "波美拉尼亚语",
-    "Pomeranian"
+  "zlw-pom-pro": [
+    "原始波美拉尼亞語",
+    "原始波美拉尼亚语"
   ],
   "zlw-slv": [
     "斯洛溫語",
-    "斯洛温语",
-    "Slovincian"
+    "斯洛温语"
   ],
   "zma": [
     "曼達語（澳洲）",
-    "曼达语（澳洲）",
-    "Manda (Australia)"
+    "曼达语（澳洲）"
   ],
   "zmb": [
     "津巴語",
-    "津巴语",
-    "Zimba"
+    "津巴语"
   ],
   "zmc": [
     "馬爾加尼語",
-    "马尔加尼语",
-    "Margany"
+    "马尔加尼语"
   ],
   "zmd": [
     "馬里丹語",
-    "马里丹语",
-    "Maridan"
+    "马里丹语"
   ],
   "zme": [
     "曼格爾語",
-    "曼格尔语",
-    "Mangerr"
+    "曼格尔语"
   ],
   "zmf": [
     "Mfinu"
@@ -35936,26 +32934,22 @@
   ],
   "zmi": [
     "森美蘭馬來語",
-    "森美兰马来语",
-    "Negeri Sembilan Malay"
+    "森美兰马来语"
   ],
   "zmj": [
     "馬里提亞賓語",
-    "马里提亚宾语",
-    "Maridjabin"
+    "马里提亚宾语"
   ],
   "zmk": [
     "曼丹達尼語",
-    "曼丹达尼语",
-    "Mandandanyi"
+    "曼丹达尼语"
   ],
   "zml": [
     "Madngele"
   ],
   "zmm": [
     "馬里馬寧迪語",
-    "马里马宁迪语",
-    "Marimanindji"
+    "马里马宁迪语"
   ],
   "zmn": [
     "Mbangwe"
@@ -35973,7 +32967,6 @@
   "zmr": [
     "馬拉農庫語",
     "马拉农库语",
-    "Maranungku",
     "Maranunggu",
     "Marranunggu",
     "Marranungku",
@@ -35986,18 +32979,15 @@
   ],
   "zmt": [
     "馬林加爾語",
-    "马林加尔语",
-    "Maringarr"
+    "马林加尔语"
   ],
   "zmu": [
     "穆魯瓦里語",
-    "穆鲁瓦里语",
-    "Muruwari"
+    "穆鲁瓦里语"
   ],
   "zmv": [
     "姆巴里曼-古丁馬語",
     "姆巴里曼-古丁马语",
-    "Mbariman-Gudhinma",
     "Rimanggudhinma",
     "Rimang-Gudinhma",
     "Parimankutinma"
@@ -36012,8 +33002,7 @@
   ],
   "zmy": [
     "馬里耶迪語",
-    "马里耶迪语",
-    "Mariyedi"
+    "马里耶迪语"
   ],
   "zmz": [
     "Mbandja"
@@ -36025,12 +33014,12 @@
     "Zande"
   ],
   "zng": [
-    "Mang"
+    "莽語",
+    "莽语"
   ],
   "znk": [
     "馬南卡利語",
     "马南卡利语",
-    "Manangkari",
     "Naragani"
   ],
   "zns": [
@@ -36038,191 +33027,159 @@
   ],
   "zoc": [
     "克派納拉索克語",
-    "克派纳拉索克语",
-    "Copainalá Zoque"
+    "克派纳拉索克语"
   ],
   "zoh": [
     "奇馬拉帕索克語",
-    "奇马拉帕索克语",
-    "Chimalapa Zoque"
+    "奇马拉帕索克语"
   ],
   "zom": [
     "卓米語",
     "卓米语",
-    "Zou",
     "Zo",
     "Yo",
     "Yos"
   ],
   "zoo": [
     "亞松森-米斯特佩克薩波特克語",
-    "亚松森-米斯特佩克萨波特克语",
-    "Asunción Mixtepec Zapotec"
+    "亚松森-米斯特佩克萨波特克语"
   ],
   "zoq": [
     "塔巴斯科索克語",
-    "塔巴斯科索克语",
-    "Tabasco Zoque"
+    "塔巴斯科索克语"
   ],
   "zor": [
     "拉永索克語",
-    "拉永索克语",
-    "Rayón Zoque"
+    "拉永索克语"
   ],
   "zos": [
     "弗朗西斯科里昂索克語",
-    "弗朗西斯科里昂索克语",
-    "Francisco León Zoque"
+    "弗朗西斯科里昂索克语"
   ],
   "zpa": [
     "拉奇吉里薩波特克語",
-    "拉奇吉里萨波特克语",
-    "Lachiguiri Zapotec"
+    "拉奇吉里萨波特克语"
   ],
   "zpb": [
     "亞烏特佩克薩波特克語",
-    "亚乌特佩克萨波特克语",
-    "Yautepec Zapotec"
+    "亚乌特佩克萨波特克语"
   ],
   "zpc": [
     "喬亞潘薩波特克語",
     "乔亚潘萨波特克语",
-    "Choapan Zapotec",
     "Choapan Zapoteco"
   ],
   "zpd": [
     "東南伊斯特蘭薩波特克語",
-    "东南伊斯特兰萨波特克语",
-    "Southeastern Ixtlán Zapotec"
+    "东南伊斯特兰萨波特克语"
   ],
   "zpe": [
     "佩塔帕薩波特克語",
-    "佩塔帕萨波特克语",
-    "Petapa Zapotec"
+    "佩塔帕萨波特克语"
   ],
   "zpf": [
     "聖佩德羅基亞托尼薩波特克語",
-    "圣佩德罗基亚托尼萨波特克语",
-    "San Pedro Quiatoni Zapotec"
+    "圣佩德罗基亚托尼萨波特克语"
   ],
   "zpg": [
     "格韋亞德洪堡薩波特克語",
-    "格韦亚德洪堡萨波特克语",
-    "Guevea de Humboldt Zapotec"
+    "格韦亚德洪堡萨波特克语"
   ],
   "zph": [
     "托托馬查潘薩波特克語",
-    "托托马查潘萨波特克语",
-    "Totomachapan Zapotec"
+    "托托马查潘萨波特克语"
   ],
   "zpi": [
     "聖瑪利亞基耶戈拉尼薩波特克語",
-    "圣玛利亚基耶戈拉尼萨波特克语",
-    "Santa María Quiegolani Zapotec"
+    "圣玛利亚基耶戈拉尼萨波特克语"
   ],
   "zpj": [
     "基亞維庫薩斯薩波特克語",
-    "基亚维库萨斯萨波特克语",
-    "Quiavicuzas Zapotec"
+    "基亚维库萨斯萨波特克语"
   ],
   "zpk": [
     "特拉科盧利塔薩波特克語",
-    "特拉科卢利塔萨波特克语",
-    "Tlacolulita Zapotec"
+    "特拉科卢利塔萨波特克语"
   ],
   "zpl": [
     "拉奇西奧薩波特克語",
-    "拉奇西奥萨波特克语",
-    "Lachixío Zapotec"
+    "拉奇西奥萨波特克语"
   ],
   "zpm": [
     "米斯特佩克薩波特克語",
-    "米斯特佩克萨波特克语",
-    "Mixtepec Zapotec"
+    "米斯特佩克萨波特克语"
   ],
   "zpn": [
     "聖伊內斯亞切奇薩波特克語",
-    "圣伊内斯亚切奇萨波特克语",
-    "Santa Inés Yatzechi Zapotec"
+    "圣伊内斯亚切奇萨波特克语"
   ],
   "zpo": [
     "阿馬特蘭薩波特克語",
-    "阿马特兰萨波特克语",
-    "Amatlán Zapotec"
+    "阿马特兰萨波特克语"
   ],
   "zpp": [
     "阿爾托薩波特克語",
     "阿尔托萨波特克语",
-    "El Alto Zapotec",
     "El Alto Zapoteco"
   ],
   "zpq": [
     "蘇戈喬薩波特克語",
-    "苏戈乔萨波特克语",
-    "Zoogocho Zapotec"
+    "苏戈乔萨波特克语"
   ],
   "zpr": [
     "聖地亞哥薩尼卡薩波特克語",
-    "圣地亚哥萨尼卡萨波特克语",
-    "Santiago Xanica Zapotec"
+    "圣地亚哥萨尼卡萨波特克语"
   ],
   "zps": [
     "科亞特蘭薩波特克語",
-    "科亚特兰萨波特克语",
-    "Coatlán Zapotec"
+    "科亚特兰萨波特克语"
   ],
   "zpt": [
     "聖比森特科亞特蘭薩波特克語",
-    "圣比森特科亚特兰萨波特克语",
-    "San Vicente Coatlán Zapotec"
+    "圣比森特科亚特兰萨波特克语"
   ],
   "zpu": [
     "亞拉拉格薩波特克語",
-    "亚拉拉格萨波特克语",
-    "Yalálag Zapotec"
+    "亚拉拉格萨波特克语"
   ],
   "zpv": [
     "奇奇卡潘薩波特克語",
-    "奇奇卡潘萨波特克语",
-    "Chichicapan Zapotec"
+    "奇奇卡潘萨波特克语"
   ],
   "zpw": [
     "薩尼薩薩波特克語",
-    "萨尼萨萨波特克语",
-    "Zaniza Zapotec"
+    "萨尼萨萨波特克语"
   ],
   "zpx": [
     "聖巴爾塔扎洛希查薩波特克語",
-    "圣巴尔塔扎洛希查萨波特克语",
-    "San Baltazar Loxicha Zapotec"
+    "圣巴尔塔扎洛希查萨波特克语"
   ],
   "zpy": [
     "馬薩爾特佩克薩波特克語",
-    "马萨尔特佩克萨波特克语",
-    "Mazaltepec Zapotec"
+    "马萨尔特佩克萨波特克语"
   ],
   "zpz": [
     "特斯梅盧坎薩波特克語",
-    "特斯梅卢坎萨波特克语",
-    "Texmelucan Zapotec"
+    "特斯梅卢坎萨波特克语"
   ],
   "zra": [
     "伽耶語",
     "伽耶语",
-    "Kaya",
-    "Kara"
+    "Gaya",
+    "Kara",
+    "Karak"
   ],
   "zrg": [
     "米爾甘語",
     "米尔甘语",
-    "Mirgan",
     "Panika"
   ],
   "zrn": [
     "Zirenkel"
   ],
   "zro": [
-    "Záparo",
+    "扎巴拉語",
+    "扎巴拉语",
     "Zaparo"
   ],
   "zrs": [
@@ -36236,77 +33193,64 @@
     "Kaskian"
   ],
   "zsl": [
-    "Zambian Sign Language"
+    "贊比亞手語",
+    "赞比亚手语"
   ],
   "zsr": [
     "南林松薩波特克語",
-    "南林松萨波特克语",
-    "Southern Rincon Zapotec"
+    "南林松萨波特克语"
   ],
   "zsu": [
     "Sukurum"
   ],
   "zte": [
     "埃洛特佩克薩波特克語",
-    "埃洛特佩克萨波特克语",
-    "Elotepec Zapotec"
+    "埃洛特佩克萨波特克语"
   ],
   "ztg": [
     "薩那吉亞薩波特克語",
-    "萨那吉亚萨波特克语",
-    "Xanaguía Zapotec"
+    "萨那吉亚萨波特克语"
   ],
   "ztl": [
     "聖地亞哥拉帕吉亞薩波特克語",
-    "圣地亚哥拉帕吉亚萨波特克语",
-    "Lapaguía-Guivini Zapotec",
-    "Santiago Lapaguía Zapotec"
+    "圣地亚哥拉帕吉亚萨波特克语"
   ],
   "ztm": [
     "聖阿古斯丁米斯特佩克薩波特克語",
-    "圣阿古斯丁米斯特佩克萨波特克语",
-    "San Agustín Mixtepec Zapotec"
+    "圣阿古斯丁米斯特佩克萨波特克语"
   ],
   "ztn": [
     "聖卡塔里納阿爾巴拉達斯薩波特克語",
-    "圣卡塔里纳阿尔巴拉达斯萨波特克语",
-    "Santa Catarina Albarradas Zapotec"
+    "圣卡塔里纳阿尔巴拉达斯萨波特克语"
   ],
   "ztp": [
     "洛希查薩波特克語",
-    "洛希查萨波特克语",
-    "Loxicha Zapotec"
+    "洛希查萨波特克语"
   ],
   "ztq": [
     "基奧基塔尼-基耶里薩波特克語",
-    "基奥基塔尼-基耶里萨波特克语",
-    "Quioquitani-Quierí Zapotec"
+    "基奥基塔尼-基耶里萨波特克语"
   ],
   "zts": [
     "蒂爾基亞潘薩波特克語",
-    "蒂尔基亚潘萨波特克语",
-    "Tilquiapan Zapotec"
+    "蒂尔基亚潘萨波特克语"
   ],
   "ztt": [
     "特哈拉潘薩波特克語",
-    "特哈拉潘萨波特克语",
-    "Tejalapan Zapotec"
+    "特哈拉潘萨波特克语"
   ],
   "ztu": [
     "古伊拉薩波特克語",
-    "古伊拉萨波特克语",
-    "San Pablo Güilá Zapotec"
+    "古伊拉萨波特克语"
   ],
   "ztx": [
     "薩奇拉薩波特克語",
     "萨奇拉萨波特克语",
-    "Zaachila Zapotec",
     "Zaachila Zapoteco"
   ],
   "zty": [
     "亞蒂薩波特克語",
-    "亚蒂萨波特克语",
-    "Yatee Zapotec"
+    "亚蒂萨波特克语"
   ],
   "zu": [
     "祖魯語",
@@ -36321,8 +33265,7 @@
   ],
   "zum": [
     "孔扎里語",
-    "孔扎里语",
-    "Kumzari"
+    "孔扎里语"
   ],
   "zun": [
     "祖尼語",
@@ -36335,8 +33278,7 @@
   ],
   "zwa": [
     "扎伊語",
-    "扎伊语",
-    "Zay"
+    "扎伊语"
   ],
   "zyp": [
     "Zyphe",
@@ -36348,12 +33290,10 @@
   "zza": [
     "扎扎其語",
     "扎扎其语",
-    "Zazaki",
     "Zaza"
   ],
   "zzj": [
     "左江壯語",
-    "左江壮语",
-    "Zuojiang Zhuang"
+    "左江壮语"
   ]
 }


### PR DESCRIPTION
Thanks to the heads up from #271, this fixes the lua code for getting Chinese wiktionary language data; the modules were apparently significantly revised recently. Updates use `zhwiktionary-20230620-pages-articles.xml.bz2` and `enwiktionary-20230620-pages-articles.xml.bz2`.