### PR TITLE
Extract form and gender data from Chinese Wiktionary headword line

### DIFF
--- a/tests/test_zh_headword.py
+++ b/tests/test_zh_headword.py
@@ -1,0 +1,63 @@
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+from wikitextprocessor import Wtp
+from wiktextract.extractor.zh.headword_line import extract_headword_line
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestHeadword(TestCase):
+    @patch(
+        "wiktextract.extractor.zh.headword_line.clean_node",
+        return_value="manga (可數 & 不可數，複數 manga 或 mangas)",
+    )
+    def test_english_headword(self, mock_clean_node):
+        node = Mock()
+        node.args = [["en-noun"]]
+        page_data = [{}]
+        wtp = Wtp()
+        wtp.title = "manga"
+        wxr = WiktextractContext(wtp, Mock())
+        extract_headword_line(wxr, page_data, node, "en")
+        wtp.close_db_conn()
+        close_thesaurus_db(wxr.thesaurus_db_path, wxr.thesaurus_db_conn)
+        self.assertEqual(
+            page_data,
+            [
+                {
+                    "forms": [
+                        {"form": "manga", "tags": ["plural"]},
+                        {"form": "mangas", "tags": ["plural"]},
+                    ],
+                    "tags": ["countable", "uncountable"],
+                }
+            ],
+        )
+
+    @patch(
+        "wiktextract.extractor.zh.headword_line.clean_node",
+        return_value="manga m (複數 manga's，指小詞 mangaatje n)",
+    )
+    def test_headword_gender(self, mock_clean_node):
+        node = Mock()
+        node.args = [["nl-noun"]]
+        page_data = [{}]
+        wtp = Wtp()
+        wtp.title = "manga"
+        wxr = WiktextractContext(wtp, Mock())
+        extract_headword_line(wxr, page_data, node, "nl")
+        wtp.close_db_conn()
+        close_thesaurus_db(wxr.thesaurus_db_path, wxr.thesaurus_db_conn)
+        self.assertEqual(
+            page_data,
+            [
+                {
+                    "forms": [
+                        {"form": "manga's", "tags": ["plural"]},
+                        {"form": "mangaatje", "tags": ["diminutive", "neuter"]},
+                    ],
+                    "tags": ["masculine"],
+                }
+            ],
+        )

--- a/wiktextract/config.py
+++ b/wiktextract/config.py
@@ -26,7 +26,7 @@ def list_dict():
     return collections.defaultdict(list)
 
 
-class WiktionaryConfig(object):
+class WiktionaryConfig:
     """This class holds configuration data for Wiktionary parsing."""
 
     __slots__ = (

--- a/wiktextract/datautils.py
+++ b/wiktextract/datautils.py
@@ -2,10 +2,14 @@
 #
 # Copyright (c) 2018-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
-import re
-import functools
 import collections
+import functools
+import re
+
+from typing import Dict, Any, Iterable
+
 from wiktextract.wxr_context import WiktextractContext
+
 
 # Keys in ``data`` that can only have string values (a list of them)
 str_keys = ("tags", "glosses")
@@ -14,7 +18,9 @@ dict_keys = set(["pronunciations", "senses", "synonyms", "related",
                  "antonyms", "hypernyms", "holonyms", "forms"])
 
 
-def data_append(wxr, data, key, value):
+def data_append(
+    wxr: WiktextractContext, data: Dict, key: str, value: Any
+) -> None:
     """Appends ``value`` under ``key`` in the dictionary ``data``.  The key
     is created if it does not exist."""
     assert isinstance(wxr, WiktextractContext)
@@ -35,7 +41,9 @@ def data_append(wxr, data, key, value):
     lst.append(value)
 
 
-def data_extend(wxr, data, key, values):
+def data_extend(
+    wxr: WiktextractContext, data: Dict, key: str, values: Iterable
+) -> None:
     """Appends all values in a list under ``key`` in the dictionary ``data``."""
     assert isinstance(wxr, WiktextractContext)
     assert isinstance(data, dict)

--- a/wiktextract/extractor/zh/example.py
+++ b/wiktextract/extractor/zh/example.py
@@ -60,9 +60,7 @@ def extract_example_list(
             and child_node.kind == NodeKind.LIST
         ):
             example_data["type"] = "quote"
-            example_data["ref"] = clean_node(
-                wxr, None, node.children[:index]
-            )
+            example_data["ref"] = clean_node(wxr, None, node.children[:index])
             example_data["text"] = clean_node(
                 wxr, None, child_node.children[0].children
             )
@@ -76,20 +74,15 @@ def extract_quote_templates(
     """
     example_data["type"] = "quote"
     expanded_text = clean_node(wxr, None, node)
-    for line_num, expanded_line in enumerate(
-        expanded_text.splitlines()
-    ):
+    for line_num, expanded_line in enumerate(expanded_text.splitlines()):
         if line_num == 0:
             key = "ref"
         elif line_num == 1:
             key = "text"
         elif line_num == 2 and any(
-            template_arg[0].startswith(
-                "transliteration="
-            )
+            template_arg[0].startswith("transliteration=")
             for template_arg in node.args
-            if len(template_arg) > 0
-            and isinstance(template_arg[0], str)
+            if len(template_arg) > 0 and isinstance(template_arg[0], str)
         ):
             key = "roman"
         else:
@@ -102,9 +95,7 @@ def extract_template_ja_usex(
     wxr: WiktextractContext, node: WikiNode, example_data: Dict
 ) -> None:
     expanded_text = clean_node(wxr, None, node)
-    for line_num, expanded_line in enumerate(
-        expanded_text.splitlines()
-    ):
+    for line_num, expanded_line in enumerate(expanded_text.splitlines()):
         if line_num == 0:
             key = "text"
         elif line_num == 1:
@@ -124,9 +115,7 @@ def extract_template_zh_usex(
             # example sentence usually ends with
             # "繁體]" or "簡體]"
             if example_data.get("texts") is not None:
-                example_data["texts"].append(
-                    expanded_line
-                )
+                example_data["texts"].append(expanded_line)
             else:
                 example_data["texts"] = [expanded_line]
         elif expanded_line.endswith("]"):

--- a/wiktextract/extractor/zh/headword_line.py
+++ b/wiktextract/extractor/zh/headword_line.py
@@ -1,0 +1,77 @@
+from typing import Dict, List
+
+from wikitextprocessor import WikiNode
+from wiktextract.datautils import data_append
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
+
+
+GENDERS = {"f": "feminine", "m": "masculine", "n": "neuter"}
+
+
+FORM_TAGS = {
+    "複數": ["plural"],
+    "第三人稱單數簡單現在時": ["third-person", "singular", "simple", "present"],
+    "現在分詞": ["present", "participle"],
+    "一般過去時及過去分詞": ["past", "participle"],
+    "指小詞": ["diminutive"],
+}
+
+
+def extract_headword_line(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    node: WikiNode,
+    lang_code: str,
+) -> None:
+    template_name = node.args[0][0]
+    if template_name == "head" or template_name.startswith(f"{lang_code}-"):
+        if lang_code == "ja":
+            pass
+        else:
+            extract_common_headword(wxr, page_data, node)
+
+
+def extract_common_headword(
+    wxr: WiktextractContext, page_data: List[Dict], node: WikiNode
+) -> None:
+    expanded_text = clean_node(wxr, None, node)
+    headword_text = expanded_text.removeprefix(wxr.wtp.title).strip()
+    first_parenthesis_index = headword_text.find("(")
+    if first_parenthesis_index != "-1":
+        gender_text = headword_text[:first_parenthesis_index].strip()
+        if gender_type := GENDERS.get(gender_text):
+            data_append(wxr, page_data[-1], "tags", gender_type)
+        for split_text in headword_text[first_parenthesis_index + 1 : -1].split(
+            "，"
+        ):
+            if split_text.endswith("可數"):
+                for countable_text in split_text.split("&"):
+                    countable_text = countable_text.strip()
+                    countable_type = None
+                    if countable_text.endswith("不可數"):
+                        # "不可数" or "通常不可数"
+                        countable_type = "uncountable"
+                    elif countable_text == "可數":
+                        countable_type = "countable"
+                    data_append(wxr, page_data[-1], "tags", countable_type)
+            elif " " in split_text:
+                form_type_text, forms_text = split_text.split(maxsplit=1)
+                if form_type_text in FORM_TAGS:
+                    for form in forms_text.split("或"):
+                        gender_suffixes = tuple(
+                            f" {gender}" for gender in GENDERS.keys()
+                        )
+                        tags = FORM_TAGS[form_type_text]
+                        if form.endswith(gender_suffixes):
+                            form, gender_text = form.rsplit(maxsplit=1)
+                            tags.append(GENDERS[gender_text])
+                        data_append(
+                            wxr,
+                            page_data[-1],
+                            "forms",
+                            {
+                                "form": form.strip(),
+                                "tags": tags,
+                            },
+                        )

--- a/wiktextract/extractor/zh/page.py
+++ b/wiktextract/extractor/zh/page.py
@@ -309,10 +309,14 @@ def parse_page(
     page_data = []
     for node in filter(lambda n: isinstance(n, WikiNode), tree.children):
         # ignore link created by `also` template at the page top
+        # also ignore "character info" templates
         if node.kind == NodeKind.TEMPLATE and node.args[0][0].lower() in {
             "also",
             "see also",
             "亦",
+            "character info",
+            "character info/new",
+            "character info/var",
         }:
             continue
         if node.kind != NodeKind.LEVEL2:

--- a/wiktextract/extractor/zh/page.py
+++ b/wiktextract/extractor/zh/page.py
@@ -10,8 +10,10 @@ from wiktextract.page import clean_node, LEVEL_KINDS
 from wiktextract.wxr_context import WiktextractContext
 
 from .example import extract_examples
+from .headword_line import extract_headword_line
 from .linkage import extract_linkages
 from .pronunciation import extract_pronunciation_recursively
+from ..share import strip_nodes
 
 
 # Templates that are used to form panels on pages and that
@@ -85,7 +87,6 @@ PANEL_TEMPLATES = {
 PANEL_PREFIXES = {
     "list:compass points/",
     "list:Gregorian calendar months/",
-    "RQ:",
 }
 
 # Additional templates to be expanded in the pre-expand phase
@@ -158,9 +159,13 @@ def recursive_parse(
             pos_type = wxr.config.POS_SUBTITLES[subtitle]["pos"]
             base_data["pos"] = pos_type
             append_page_data(page_data, "pos", pos_type, base_data)
-            for node in node.children:
-                if isinstance(node, WikiNode) and node.kind == NodeKind.LIST:
-                    extract_gloss(wxr, page_data, node.children)
+            for index, node in enumerate(strip_nodes(node.children)):
+                if isinstance(node, WikiNode):
+                    if index == 0 and node.kind == NodeKind.TEMPLATE:
+                        lang_code = base_data.get("lang_code")
+                        extract_headword_line(wxr, page_data, node, lang_code)
+                    elif node.kind == NodeKind.LIST:
+                        extract_gloss(wxr, page_data, node.children)
                 else:
                     recursive_parse(wxr, page_data, base_data, node)
         elif (


### PR DESCRIPTION
`assert` are removed from `data_append()` and `data_extend()` because `Mock` objects won't pass `assert isinstance`.