### PR TITLE
Prase expanded headword line HTML tags

### DIFF
--- a/tests/test_zh_example.py
+++ b/tests/test_zh_example.py
@@ -1,21 +1,27 @@
 import unittest
 
+from unittest.mock import patch
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.wxr_context import WiktextractContext
 from wiktextract.extractor.zh.example import extract_examples
+from wiktextract.thesaurus import close_thesaurus_db
 
 
 class TestExample(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.wxr = WiktextractContext(
             Wtp(lang_code="zh"), WiktionaryConfig(dump_file_lang_code="zh")
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
-    def test_example_list(self):
+    def test_example_list(self) -> None:
         page_data = [
             {
                 "lang": "跨語言",
@@ -35,5 +41,36 @@ class TestExample(unittest.TestCase):
             page_data[0]["senses"][0].get("examples"),
             [
                 {"ref": "ref text", "text": "example text", "type": "quote"},
+            ],
+        )
+
+    @patch(
+        "wiktextract.extractor.zh.example.clean_node",
+        return_value="""ref text
+quote text
+translation text""",
+    )
+    def test_quote_example(self, mock_clean_node) -> None:
+        page_data = [
+            {
+                "lang": "跨語言",
+                "lang_code": "mul",
+                "word": "%",
+                "senses": [{"glosses": ["百分比"]}],
+            }
+        ]
+        wikitext = "#* {{RQ:Schuster Hepaticae}}"
+        self.wxr.wtp.start_page("test")
+        node = self.wxr.wtp.parse(wikitext)
+        extract_examples(self.wxr, page_data, node)
+        self.assertEqual(
+            page_data[0]["senses"][0].get("examples"),
+            [
+                {
+                    "ref": "ref text",
+                    "text": "quote text",
+                    "translation": "translation text",
+                    "type": "quote",
+                },
             ],
         )

--- a/tests/test_zh_gloss.py
+++ b/tests/test_zh_gloss.py
@@ -1,0 +1,70 @@
+import unittest
+
+from wikitextprocessor import Wtp
+from wiktextract.config import WiktionaryConfig
+from wiktextract.wxr_context import WiktextractContext
+from wiktextract.extractor.zh.page import extract_gloss
+from wiktextract.thesaurus import close_thesaurus_db
+
+
+class TestExample(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="zh"), WiktionaryConfig(dump_file_lang_code="zh")
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
+
+    def test_example_list(self) -> None:
+        page_data = [
+            {
+                "lang": "日語",
+                "lang_code": "ja",
+                "word": "可笑しい",
+                "senses": [],
+            }
+        ]
+        wikitext = """# [[好玩]]的：
+## 有趣的，滑稽的，可笑的
+## 奇怪的，不正常的
+## 不合理的，不合邏輯的
+# (棄用) [[有趣]]的：
+## [[有趣]]的
+## [[美味]]的
+## [[漂亮]]的
+## [[很好]]的，[[卓越]]的"""
+        self.wxr.wtp.start_page("test")
+        node = self.wxr.wtp.parse(wikitext)
+        extract_gloss(self.wxr, page_data, node.children[0].children, {})
+        self.assertEqual(
+            page_data[0]["senses"],
+            [
+                {"glosses": ["好玩的：", "有趣的，滑稽的，可笑的"]},
+                {"glosses": ["好玩的：", "奇怪的，不正常的"]},
+                {"glosses": ["好玩的：", "不合理的，不合邏輯的"]},
+                {
+                    "glosses": ["有趣的：", "有趣的"],
+                    "raw_glosses": ["(棄用) 有趣的："],
+                    "tags": ["棄用"],
+                },
+                {
+                    "glosses": ["有趣的：", "美味的"],
+                    "raw_glosses": ["(棄用) 有趣的："],
+                    "tags": ["棄用"],
+                },
+                {
+                    "glosses": ["有趣的：", "漂亮的"],
+                    "raw_glosses": ["(棄用) 有趣的："],
+                    "tags": ["棄用"],
+                },
+                {
+                    "glosses": ["有趣的：", "很好的，卓越的"],
+                    "raw_glosses": ["(棄用) 有趣的："],
+                    "tags": ["棄用"],
+                },
+            ],
+        )

--- a/wiktextract/extractor/share.py
+++ b/wiktextract/extractor/share.py
@@ -30,3 +30,11 @@ def strip_nodes(
         or (isinstance(node, str) and len(unescape(node).strip()) > 0),
         nodes,
     )
+
+
+def filter_child_wikinodes(node: WikiNode, node_type: NodeKind) -> List[Union[WikiNode, str]]:
+    return [
+        child
+        for child in node.children
+        if isinstance(child, WikiNode) and child.kind == node_type
+    ]

--- a/wiktextract/extractor/share.py
+++ b/wiktextract/extractor/share.py
@@ -1,3 +1,4 @@
+from html import unescape
 from typing import List, Union, Iterable
 
 from wikitextprocessor import WikiNode, NodeKind
@@ -23,9 +24,9 @@ def contains_list(
 def strip_nodes(
     nodes: List[Union[WikiNode, str]]
 ) -> Iterable[Union[WikiNode, str]]:
-    # filter nodes that only have newlines and white spaces
+    # filter nodes that only have newlines, white spaces and non-breaking spaces
     return filter(
         lambda node: isinstance(node, WikiNode)
-        or (isinstance(node, str) and len(node.strip()) > 0),
+        or (isinstance(node, str) and len(unescape(node).strip()) > 0),
         nodes,
     )

--- a/wiktextract/extractor/zh/example.py
+++ b/wiktextract/extractor/zh/example.py
@@ -87,8 +87,9 @@ def extract_quote_templates(
             key = "roman"
         else:
             key = "translation"
-            if expanded_line != "（請為本引文添加中文翻譯）":
-                example_data[key] = expanded_line
+
+        if expanded_line != "（請為本引文添加中文翻譯）":
+            example_data[key] = expanded_line
 
 
 def extract_template_ja_usex(

--- a/wiktextract/extractor/zh/headword_line.py
+++ b/wiktextract/extractor/zh/headword_line.py
@@ -1,20 +1,68 @@
-from typing import Dict, List
+import re
 
-from wikitextprocessor import WikiNode
-from wiktextract.datautils import data_append
+from typing import Dict, List, Union
+
+from wikitextprocessor import WikiNode, NodeKind
+from wiktextract.datautils import data_append, data_extend
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 
+from ..share import strip_nodes
 
-GENDERS = {"f": "feminine", "m": "masculine", "n": "neuter"}
+
+# https://zh.wiktionary.org/wiki/Module:Gender_and_number
+GENDERS = {
+    "f": "feminine",
+    "m": "masculine",
+    "n": "neuter",
+    "c": "common",
+    # Animacy
+    "an": "animate",
+    "in": "inanimate",
+    # Animal (for Ukrainian, Belarusian, Polish)
+    "anml": "animal",
+    # Personal (for Ukrainian, Belarusian, Polish)
+    "pr": "personal",
+    # Nonpersonal not currently used
+    "np": "nonpersonal",
+    # Virility (for Polish)
+    "vr": "virile",
+    "nv": "nonvirile",
+    # Numbers
+    "s": "singular number",
+    "d": "dual number",
+    "p": "plural number",
+    # Verb qualifiers
+    "impf": "imperfective aspect",
+    "pf": "perfective aspect",
+}
 
 
 FORM_TAGS = {
+    "不可數": ["uncountable"],
+    "通常不可數": ["uncountable"],
+    "可數": ["countable"],
     "複數": ["plural"],
+    # en-verb
     "第三人稱單數簡單現在時": ["third-person", "singular", "simple", "present"],
     "現在分詞": ["present", "participle"],
     "一般過去時及過去分詞": ["past", "participle"],
+    # fr-noun, fr-adj
+    # https://zh.wiktionary.org/wiki/Module:Fr-headword
     "指小詞": ["diminutive"],
+    "陰性": ["feminine"],
+    "陽性": ["masculine"],
+    "陽性複數": ["masculine", "plural"],
+    "陰性複數": ["feminine", "plural"],
+    "陽性單數": ["masculine", "singular"],
+    "元音前陽性單數": ["masculine", "singular", "before-vowel"],
+    "比較級": ["comparative"],
+    "最高級": ["superlative"],
+    # voice
+    "主動": ["active"],
+    "被動": ["passive"],
+    "及物": ["transitive"],
+    "不規則": ["irregular"],
 }
 
 
@@ -25,53 +73,132 @@ def extract_headword_line(
     lang_code: str,
 ) -> None:
     template_name = node.args[0][0]
-    if template_name == "head" or template_name.startswith(f"{lang_code}-"):
-        if lang_code == "ja":
-            pass
-        else:
-            extract_common_headword(wxr, page_data, node)
+    if template_name != "head" and not template_name.startswith(
+        f"{lang_code}-"
+    ):
+        return
 
-
-def extract_common_headword(
-    wxr: WiktextractContext, page_data: List[Dict], node: WikiNode
-) -> None:
-    expanded_text = clean_node(wxr, None, node)
-    headword_text = expanded_text.removeprefix(wxr.wtp.title).strip()
-    first_parenthesis_index = headword_text.find("(")
-    if first_parenthesis_index != "-1":
-        gender_text = headword_text[:first_parenthesis_index].strip()
-        if gender_type := GENDERS.get(gender_text):
-            data_append(wxr, page_data[-1], "tags", gender_type)
-        for split_text in headword_text[first_parenthesis_index + 1 : -1].split(
-            "，"
-        ):
-            if split_text.endswith("可數"):
-                for countable_text in split_text.split("&"):
-                    countable_text = countable_text.strip()
-                    countable_type = None
-                    if countable_text.endswith("不可數"):
-                        # "不可数" or "通常不可数"
-                        countable_type = "uncountable"
-                    elif countable_text == "可數":
-                        countable_type = "countable"
-                    data_append(wxr, page_data[-1], "tags", countable_type)
-            elif " " in split_text:
-                form_type_text, forms_text = split_text.split(maxsplit=1)
-                if form_type_text in FORM_TAGS:
-                    for form in forms_text.split("或"):
-                        gender_suffixes = tuple(
-                            f" {gender}" for gender in GENDERS.keys()
-                        )
-                        tags = FORM_TAGS[form_type_text]
-                        if form.endswith(gender_suffixes):
-                            form, gender_text = form.rsplit(maxsplit=1)
-                            tags.append(GENDERS[gender_text])
+    expanded_node = wxr.wtp.parse(
+        wxr.wtp.node_to_wikitext(node), expand_all=True
+    )
+    forms_start_index = 0
+    for index, child in enumerate(expanded_node.children):
+        if isinstance(child, WikiNode) and child.kind == NodeKind.HTML:
+            if child.args == "strong" and "headword" in child.attrs.get(
+                "class", ""
+            ):
+                forms_start_index = index + 1
+            elif child.args == "span":
+                class_names = child.attrs.get("class", "")
+                if "headword-tr" in class_names:
+                    forms_start_index = index + 1
+                    data_append(
+                        wxr,
+                        page_data[-1],
+                        "forms",
+                        {
+                            "form": clean_node(wxr, None, child),
+                            "tags": ["romanization"],
+                        },
+                    )
+                elif "gender" in class_names:
+                    forms_start_index = index + 1
+                    for abbr_tag in filter(
+                        lambda x: isinstance(x, WikiNode)
+                        and x.kind == NodeKind.HTML
+                        and x.args == "abbr",
+                        child.children,
+                    ):
+                        gender = abbr_tag.children[0]
                         data_append(
                             wxr,
                             page_data[-1],
-                            "forms",
-                            {
-                                "form": form.strip(),
-                                "tags": tags,
-                            },
+                            "tags",
+                            GENDERS.get(gender, gender),
                         )
+            elif child.args == "b":
+                # this is a form <b> tag, already inside form parentheses
+                break
+
+    extract_headword_forms(
+        wxr, page_data, expanded_node.children[forms_start_index:]
+    )
+
+
+def extract_headword_forms(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    form_nodes: List[Union[WikiNode, str]],
+) -> None:
+    current_nodes = []
+    for node in form_nodes:
+        if isinstance(node, str) and node.startswith("，"):
+            process_forms_text(wxr, page_data, current_nodes)
+            current_nodes = [node[1:]]
+        else:
+            current_nodes.append(node)
+
+    if len(current_nodes) > 0:
+        process_forms_text(wxr, page_data, current_nodes)
+
+
+def process_forms_text(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    form_nodes: List[Union[WikiNode, str]],
+) -> None:
+    tag_nodes = []
+    has_forms = False
+    striped_nodes = list(strip_nodes(form_nodes))
+    for index, node in enumerate(striped_nodes):
+        if (
+            isinstance(node, WikiNode)
+            and node.kind == NodeKind.HTML
+            and node.args == "b"
+        ):
+            has_forms = True
+            form = clean_node(wxr, None, node)
+            form_tags = extract_headword_tags(
+                clean_node(wxr, None, tag_nodes).strip("() ")
+            )
+            # check if next tag has gender data
+            if index < len(striped_nodes) - 1:
+                next_node = striped_nodes[index + 1]
+                if (
+                    isinstance(next_node, WikiNode)
+                    and next_node.kind == NodeKind.HTML
+                    and next_node.args == "span"
+                    and "gender" in next_node.attrs.get("class", "")
+                ):
+                    gender = clean_node(wxr, None, next_node)
+                    form_tags.append(GENDERS.get(gender, gender))
+            data_append(
+                wxr,
+                page_data[-1],
+                "forms",
+                {
+                    "form": form,
+                    "tags": form_tags,
+                },
+            )
+        else:
+            tag_nodes.append(node)
+
+    if not has_forms:
+        data_extend(
+            wxr,
+            page_data[-1],
+            "tags",
+            extract_headword_tags(
+                clean_node(wxr, None, tag_nodes).strip("() ")
+            ),
+        )
+
+
+def extract_headword_tags(tags_str: str) -> List[str]:
+    tags = []
+    for tag_str in (
+        s.strip() for s in re.split("&|或", tags_str) if len(s.strip()) > 0
+    ):
+        tags.extend(FORM_TAGS.get(tag_str, [tag_str]))
+    return tags


### PR DESCRIPTION
Check HTML tag and class name to find form text, gender text and romanization text, this is more reliable then only process the expanded plain text.

The mock HTML return value in tests are written in a single line because I tried to format them but `ikitextprocessor.Wtp.parse()` adds some extra `preformated` nodes.