### PR TITLE
Ignore templates that are inside variable `stop_head_at_these_templates`

### DIFF
--- a/tests/test_alt_form_of.py
+++ b/tests/test_alt_form_of.py
@@ -3,18 +3,25 @@
 # Copyright (c) 2021-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.form_descriptions import parse_alt_or_inflection_of
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class FormOfTests(unittest.TestCase):
-
     def setUp(self):
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def test_non_of1(self):
         ret = parse_alt_or_inflection_of(self.wxr, "inalienable", set())
@@ -28,16 +35,13 @@ class FormOfTests(unittest.TestCase):
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        print(ret)
         self.assertEqual(ret, None)
 
     def test_non_of3(self):
-        data = {}
         ret = parse_alt_or_inflection_of(self.wxr, "genitive", set())
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        print(ret)
         self.assertEqual(ret, (["genitive"], None))
 
     def test_simple1(self):
@@ -48,71 +52,76 @@ class FormOfTests(unittest.TestCase):
         self.assertEqual(ret, (["abbreviation", "alt-of"], [{"word": "foo"}]))
 
     def test_simple2(self):
-        ret = parse_alt_or_inflection_of(self.wxr,
-                    "abbreviation of New York, a city in the United States",
-                    set())
+        ret = parse_alt_or_inflection_of(
+            self.wxr,
+            "abbreviation of New York, a city in the United States",
+            set(),
+        )
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(ret, (["abbreviation", "alt-of"],
-                               [{"word": "New York",
-                                 "extra": "a city in the United States"}]))
+        self.assertEqual(
+            ret,
+            (
+                ["abbreviation", "alt-of"],
+                [{"word": "New York", "extra": "a city in the United States"}],
+            ),
+        )
 
     def test_simple3(self):
         ret = parse_alt_or_inflection_of(self.wxr, "inflection of foo", set())
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        print(ret)
         self.assertEqual(ret, (["form-of"], [{"word": "foo"}]))
 
     def test_simple4(self):
-        ret = parse_alt_or_inflection_of(self.wxr, "plural of instrumental",
-                                         set())
+        ret = parse_alt_or_inflection_of(
+            self.wxr, "plural of instrumental", set()
+        )
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        print(ret)
-        self.assertEqual(ret, (["form-of", "plural"],
-                               [{"word": "instrumental"}]))
+        self.assertEqual(
+            ret, (["form-of", "plural"], [{"word": "instrumental"}])
+        )
 
     def test_simple5(self):
-        ret = parse_alt_or_inflection_of(self.wxr, "plural of corgi or corgy",
-                                         set())
+        ret = parse_alt_or_inflection_of(
+            self.wxr, "plural of corgi or corgy", set()
+        )
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        print(ret)
-        self.assertEqual(ret, (["form-of", "plural"],
-                               [{"word": "corgi"},
-                                {"word": "corgy"}]))
+        self.assertEqual(
+            ret, (["form-of", "plural"], [{"word": "corgi"}, {"word": "corgy"}])
+        )
 
     def test_simple6(self):
-        ret = parse_alt_or_inflection_of(self.wxr, "plural of fish or chips",
-                                         set())
+        ret = parse_alt_or_inflection_of(
+            self.wxr, "plural of fish or chips", set()
+        )
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        print(ret)
-        self.assertEqual(ret, (["form-of", "plural"],
-                               [{"word": "fish or chips"}]))
+        self.assertEqual(
+            ret, (["form-of", "plural"], [{"word": "fish or chips"}])
+        )
 
     def test_simple7(self):
-        ret = parse_alt_or_inflection_of(self.wxr, "abbreviation of OK.",
-                                         set(["OK."]))
+        ret = parse_alt_or_inflection_of(
+            self.wxr, "abbreviation of OK.", set(["OK."])
+        )
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        print(ret)
-        self.assertEqual(ret, (["abbreviation", "alt-of"],
-                               [{"word": "OK."}]))
+        self.assertEqual(ret, (["abbreviation", "alt-of"], [{"word": "OK."}]))
 
     def test_simple8(self):
-        ret = parse_alt_or_inflection_of(self.wxr, "abbreviation of OK.",
-                                         set(["OK"]))
+        ret = parse_alt_or_inflection_of(
+            self.wxr, "abbreviation of OK.", set(["OK"])
+        )
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        print(ret)
-        self.assertEqual(ret, (["abbreviation", "alt-of"],
-                               [{"word": "OK"}]))
+        self.assertEqual(ret, (["abbreviation", "alt-of"], [{"word": "OK"}]))

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,9 +1,10 @@
 import unittest
-from wiktextract.clean import clean_value
+
 from wikitextprocessor import Wtp
+from wiktextract.clean import clean_value
 from wiktextract.config import WiktionaryConfig
-from wiktextract.wxr_context import WiktextractContext
 from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
 
 
 class WiktExtractTests(unittest.TestCase):
@@ -18,14 +19,10 @@ class WiktExtractTests(unittest.TestCase):
 
     def test_pos(self):
         poses = self.wxr.config.POS_TYPES
-        assert isinstance(poses, set)
-        assert "noun" in poses
-        assert "verb" in poses
-        assert "pron" in poses
-        assert "adj" in poses
-        assert "adv" in poses
-        assert "num" in poses
-        assert len(poses) < 50
+        self.assertTrue(isinstance(poses, set))
+        for pos_type in ["noun", "verb", "pron", "adj", "adv", "num"]:
+            self.assertTrue(pos_type in poses)
+        self.assertLess(len(poses), 50)
 
     def test_cv_plain(self):
         v = "This is a test."

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -3,11 +3,18 @@ from wiktextract.clean import clean_value
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.wxr_context import WiktextractContext
+from wiktextract.thesaurus import close_thesaurus_db
 
 
 class WiktExtractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
 
-    wxr = WiktextractContext(Wtp(), WiktionaryConfig())
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def test_pos(self):
         poses = self.wxr.config.POS_TYPES
@@ -273,3 +280,12 @@ class WiktExtractTests(unittest.TestCase):
         v = "a\u200eb"
         v = clean_value(self.wxr, v)
         self.assertEqual(v, "ab")
+
+    def test_second_ref_tag(self) -> None:
+        self.assertEqual(
+            clean_value(
+                self.wxr,
+                'some text<ref name="OED"/> some other text<ref>ref text</ref>'
+            ),
+            "some text some other text"
+        )

--- a/tests/test_desc.py
+++ b/tests/test_desc.py
@@ -1,17 +1,23 @@
 import unittest
-from wiktextract.config import WiktionaryConfig
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
+from wiktextract.config import WiktionaryConfig
 from wiktextract.datautils import split_at_comma_semi
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
 
 
 class DescTests(unittest.TestCase):
-
     def setUp(self):
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def test_comma_semi1(self):
         self.assertEqual(split_at_comma_semi(""), [])

--- a/tests/test_head.py
+++ b/tests/test_head.py
@@ -1,21 +1,27 @@
 # Tests for parse_word_head()
 #
 # Copyright (c) 2021-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
-import unittest
 import json
-from wiktextract.wxr_context import WiktextractContext
+import unittest
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.form_descriptions import parse_word_head
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class HeadTests(unittest.TestCase):
-
     def setUp(self):
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def test_reconstruction1(self):
         data = {}

--- a/tests/test_hiero.py
+++ b/tests/test_hiero.py
@@ -1,5 +1,7 @@
 import unittest
+
 from wiktextract.hieroglyphs import convert_hiero
+
 
 class TagTests(unittest.TestCase):
     def test_phoneme(self):

--- a/tests/test_infl_map_control_flow.py
+++ b/tests/test_infl_map_control_flow.py
@@ -5,20 +5,28 @@
 # Copyright (c) 2021-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
 import unittest
+
 from unittest.mock import patch
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
-from wiktextract.inflection import (expand_header, TableContext)
+from wiktextract.inflection import expand_header, TableContext
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
         self.tablecontext = TableContext("barfoo")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xexpand_header(self, text, i_map, lang="English", pos="verb",
                        base_tags=[],):
@@ -211,7 +219,7 @@ class InflTests(unittest.TestCase):
                     "if": "counterfactual",
                     "then": "positive"
                 },
-            
+
             },
         }
         ret = self.xexpand_header("foo", infl_map,
@@ -229,7 +237,7 @@ class InflTests(unittest.TestCase):
                     "if": "counterfactual",
                     "then": "positive"
                 },
-            
+
             },
         }
         ret = self.xexpand_header("foo", infl_map,
@@ -248,7 +256,7 @@ class InflTests(unittest.TestCase):
         ret = self.xexpand_header("foo", infl_map,
                                   lang="Finnish",
                                   base_tags=["indicative"],)
-        expected = [("positive",)] 
+        expected = [("positive",)]
         self.assertEqual(expected, ret)
 
     def test_lang2(self):
@@ -262,7 +270,7 @@ class InflTests(unittest.TestCase):
         ret = self.xexpand_header("foo", infl_map,
                                   lang="Finnish",
                                   base_tags=["indicative"],)
-        expected = [("negative",)] 
+        expected = [("negative",)]
         self.assertEqual(expected, ret)
 
     def test_pos1(self):
@@ -276,7 +284,7 @@ class InflTests(unittest.TestCase):
         ret = self.xexpand_header("foo", infl_map,
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("positive",)] 
+        expected = [("positive",)]
         self.assertEqual(expected, ret)
 
     def test_pos2(self):
@@ -290,7 +298,7 @@ class InflTests(unittest.TestCase):
         ret = self.xexpand_header("foo", infl_map,
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("negative",)] 
+        expected = [("negative",)]
         self.assertEqual(expected, ret)
 
     def test_tmplt_name1(self):
@@ -303,7 +311,7 @@ class InflTests(unittest.TestCase):
         }
         ret = self.xexpand_header("foo", infl_map,
                                   pos="noun",)
-        expected = [("positive",)] 
+        expected = [("positive",)]
         self.assertEqual(expected, ret)
 
     def test_tmplt_name2(self):
@@ -316,7 +324,7 @@ class InflTests(unittest.TestCase):
         }
         ret = self.xexpand_header("foo", infl_map,
                                   pos="noun",)
-        expected = [("negative",)] 
+        expected = [("negative",)]
         self.assertEqual(expected, ret)
 
     def test_combined_conditions1(self):
@@ -333,7 +341,7 @@ class InflTests(unittest.TestCase):
                                   lang="Finnish",
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("positive",)] 
+        expected = [("positive",)]
         self.assertEqual(expected, ret)
 
     def test_combined_conditions2(self):
@@ -350,7 +358,7 @@ class InflTests(unittest.TestCase):
                                   lang="Finnish",
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("negative",)] 
+        expected = [("negative",)]
         self.assertEqual(expected, ret)
 
     def test_combined_conditions3(self):
@@ -367,7 +375,7 @@ class InflTests(unittest.TestCase):
                                   lang="Finnish",
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("negative",)] 
+        expected = [("negative",)]
         self.assertEqual(expected, ret)
 
     def test_combined_conditions4(self):
@@ -384,7 +392,7 @@ class InflTests(unittest.TestCase):
                                   lang="Finnish",
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("negative",)] 
+        expected = [("negative",)]
         self.assertEqual(expected, ret)
 
     def test_combined_conditions5(self):
@@ -401,7 +409,7 @@ class InflTests(unittest.TestCase):
                                   lang="Finnish",
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("negative",)] 
+        expected = [("negative",)]
         self.assertEqual(expected, ret)
 
     def test_combined_conditions6(self):
@@ -418,7 +426,7 @@ class InflTests(unittest.TestCase):
                                   lang="Finnish",
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("negative",)] 
+        expected = [("negative",)]
         self.assertEqual(expected, ret)
 
     def test_combined_conditions7(self):
@@ -435,7 +443,7 @@ class InflTests(unittest.TestCase):
                                   lang="Finnish",
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("negative",)] 
+        expected = [("negative",)]
         self.assertEqual(expected, ret)
 
     def test_combined_conditions8(self):
@@ -452,7 +460,7 @@ class InflTests(unittest.TestCase):
                                   lang="Finnish",
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("negative",)] 
+        expected = [("negative",)]
         self.assertEqual(expected, ret)
 
     def test_combined_conditions9(self):
@@ -470,7 +478,7 @@ class InflTests(unittest.TestCase):
                                   lang="English",
                                   pos="verb",
                                   base_tags=["indicative"],)
-        expected = [("positive",)] 
+        expected = [("positive",)]
         self.assertEqual(expected, ret)
 
     def test_mixed1(self):
@@ -496,7 +504,7 @@ class InflTests(unittest.TestCase):
                                   lang="Finnish",
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("positive",)] 
+        expected = [("positive",)]
         self.assertEqual(expected, ret)
 
     def test_mixed2(self):
@@ -522,7 +530,7 @@ class InflTests(unittest.TestCase):
                                   lang="English",
                                   pos="noun",
                                   base_tags=["indicative"],)
-        expected = [("positive",)] 
+        expected = [("positive",)]
         self.assertEqual(expected, ret)
 
     def test_mixed3(self):
@@ -548,8 +556,5 @@ class InflTests(unittest.TestCase):
                                   lang="English",
                                   pos="verb",
                                   base_tags=["indicative"],)
-        expected = [("positive",)] 
+        expected = [("positive",)]
         self.assertEqual(expected, ret)
-
-            
-

--- a/tests/test_inflection_ar.py
+++ b/tests/test_inflection_ar.py
@@ -5,19 +5,26 @@
 # Copyright (c) 2021, 2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_az.py
+++ b/tests/test_inflection_az.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_cs.py
+++ b/tests/test_inflection_cs.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""
@@ -39,66 +45,66 @@ class InflTests(unittest.TestCase):
 
 {| class="wikitable" style="width%3A+43em%3B"
 
-|- 
+|-
 
 ! '''Present forms'''
 
-! colspan="2" |indicative 
+! colspan="2" |indicative
 
 ! colspan="2" |imperative
 
 
-|- 
+|-
 
-! 
-
-!singular
-
-!plural
+!
 
 !singular
 
 !plural
 
+!singular
 
-|- 
+!plural
+
+
+|-
 
 ! style="width%3A+10em%3B" |1st person
 
 
 | style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[myslím#Czech|myslím]]</span>
 
-| style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[myslíme#Czech|myslíme]]</span> 
+| style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[myslíme#Czech|myslíme]]</span>
 
-| style="width%3A+7em%3B" | &mdash; 
+| style="width%3A+7em%3B" | &mdash;
 
 | style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[mysleme#Czech|mysleme]]</span>
 
 
-|- 
+|-
 
-!2nd person 
+!2nd person
 
 
-| <span class="Latn" lang="cs">[[myslíš#Czech|myslíš]]</span> 
+| <span class="Latn" lang="cs">[[myslíš#Czech|myslíš]]</span>
 
-| <span class="Latn" lang="cs">[[myslíte#Czech|myslíte]]</span> 
+| <span class="Latn" lang="cs">[[myslíte#Czech|myslíte]]</span>
 
-| <span class="Latn" lang="cs">[[mysli#Czech|mysli]]</span> 
+| <span class="Latn" lang="cs">[[mysli#Czech|mysli]]</span>
 
 | <span class="Latn" lang="cs">[[myslete#Czech|myslete]]</span>
 
 
-|- 
+|-
 
-!3rd person 
+!3rd person
 
 
-| <span class="Latn" lang="cs">[[myslí#Czech|myslí]]</span> 
+| <span class="Latn" lang="cs">[[myslí#Czech|myslí]]</span>
 
-| <span class="Latn" lang="cs">[[myslí#Czech|myslí]]</span>, <span class="Latn" lang="cs">[[myslejí#Czech|myslejí]]</span> 
+| <span class="Latn" lang="cs">[[myslí#Czech|myslí]]</span>, <span class="Latn" lang="cs">[[myslejí#Czech|myslejí]]</span>
 
-| &mdash; 
+| &mdash;
 
 | &mdash;
 
@@ -107,7 +113,7 @@ class InflTests(unittest.TestCase):
 
 
 
-{| 
+{|
  class="wikitable"
 <td>The future tense: a combination of a future form of <i class="Latn+mention" lang="cs">[[být#Czech|být]]</i> + infinitive ''myslet''.</td>
 
@@ -117,7 +123,7 @@ class InflTests(unittest.TestCase):
 
 {| class="wikitable" style="width%3A+43em%3B"
 
-|- 
+|-
 
 ! '''Participles'''
 
@@ -126,63 +132,63 @@ class InflTests(unittest.TestCase):
 ! colspan="2" |Passive participles
 
 
-|- 
+|-
 
-! 
+!
 
-!singular 
+!singular
 
-!plural 
+!plural
 
-!singular 
+!singular
 
 !plural
 
 
-|- 
+|-
 
-! style="width%3A+10em%3B" |masculine animate 
+! style="width%3A+10em%3B" |masculine animate
 
 
-| rowspan="2" style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[myslel#Czech|myslel]]</span>, <span class="Latn" lang="cs">[[myslil#Czech|myslil]]</span> 
+| rowspan="2" style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[myslel#Czech|myslel]]</span>, <span class="Latn" lang="cs">[[myslil#Czech|myslil]]</span>
 
 | style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[mysleli#Czech|mysleli]]</span>, <span class="Latn" lang="cs">[[myslili#Czech|myslili]]</span>
 
-| rowspan="2" style="width%3A+7em%3B" |  <span class="Latn" lang="cs">[[myšlen#Czech|myšlen]]</span>  
+| rowspan="2" style="width%3A+7em%3B" |  <span class="Latn" lang="cs">[[myšlen#Czech|myšlen]]</span>
 
 | style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[myšleni#Czech|myšleni]]</span>
 
 
-|- 
+|-
 
-!masculine inanimate 
+!masculine inanimate
 
 
-| rowspan="2" style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[myslely#Czech|myslely]]</span>, <span class="Latn" lang="cs">[[myslily#Czech|myslily]]</span> 
+| rowspan="2" style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[myslely#Czech|myslely]]</span>, <span class="Latn" lang="cs">[[myslily#Czech|myslily]]</span>
 
 | rowspan="2" style="width%3A+7em%3B" |<span class="Latn" lang="cs">[[myšleny#Czech|myšleny]]</span>
 
 
-|- 
+|-
 
 !feminine
 
 
-|<span class="Latn" lang="cs">[[myslela#Czech|myslela]]</span>, <span class="Latn" lang="cs">[[myslila#Czech|myslila]]</span> 
+|<span class="Latn" lang="cs">[[myslela#Czech|myslela]]</span>, <span class="Latn" lang="cs">[[myslila#Czech|myslila]]</span>
 
 |<span class="Latn" lang="cs">[[myšlena#Czech|myšlena]]</span>
 
 
-|- 
+|-
 
 !neuter
 
 
-|<span class="Latn" lang="cs">[[myslelo#Czech|myslelo]]</span>, <span class="Latn" lang="cs">[[myslilo#Czech|myslilo]]</span> 
+|<span class="Latn" lang="cs">[[myslelo#Czech|myslelo]]</span>, <span class="Latn" lang="cs">[[myslilo#Czech|myslilo]]</span>
 
-| <span class="Latn" lang="cs">[[myslela#Czech|myslela]]</span>, <span class="Latn" lang="cs">[[myslila#Czech|myslila]]</span> 
+| <span class="Latn" lang="cs">[[myslela#Czech|myslela]]</span>, <span class="Latn" lang="cs">[[myslila#Czech|myslila]]</span>
 
-| <span class="Latn" lang="cs">[[myšleno#Czech|myšleno]]</span> 
+| <span class="Latn" lang="cs">[[myšleno#Czech|myšleno]]</span>
 
 |<span class="Latn" lang="cs">[[myšlena#Czech|myšlena]]</span>
 
@@ -193,41 +199,41 @@ class InflTests(unittest.TestCase):
 
 {| class="wikitable"
 
-|- 
+|-
 
 ! '''Transgressives'''
 
-!present 
+!present
 
 !past
 
 
-|- 
+|-
 
 ! masculine singular
 
 
-| style="width%3A+7em%3B" | <span class="Latn" lang="cs">[[mysle#Czech|mysle]]</span>, <span class="Latn" lang="cs">[[mysleje#Czech|mysleje]]</span>  
+| style="width%3A+7em%3B" | <span class="Latn" lang="cs">[[mysle#Czech|mysle]]</span>, <span class="Latn" lang="cs">[[mysleje#Czech|mysleje]]</span>
 
-| style="width%3A+7em%3B" | &mdash; 
+| style="width%3A+7em%3B" | &mdash;
 
 
-|- 
+|-
 
 !feminine + neuter singular
 
 
-|<span class="Latn" lang="cs">[[myslíc#Czech|myslíc]]</span>, <span class="Latn" lang="cs">[[myslejíc#Czech|myslejíc]]</span>  
+|<span class="Latn" lang="cs">[[myslíc#Czech|myslíc]]</span>, <span class="Latn" lang="cs">[[myslejíc#Czech|myslejíc]]</span>
 
 | &mdash;
 
 
-|- 
+|-
 
 !plural
 
 
-| <span class="Latn" lang="cs">[[myslíce#Czech|myslíce]]</span>, <span class="Latn" lang="cs">[[myslejíce#Czech|myslejíce]]</span>  
+| <span class="Latn" lang="cs">[[myslíce#Czech|myslíce]]</span>, <span class="Latn" lang="cs">[[myslejíce#Czech|myslejíce]]</span>
 
 | &mdash;
 

--- a/tests/test_inflection_da.py
+++ b/tests/test_inflection_da.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_de.py
+++ b/tests/test_inflection_de.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_el.py
+++ b/tests/test_inflection_el.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_en.py
+++ b/tests/test_inflection_en.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_es.py
+++ b/tests/test_inflection_es.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021, 2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_et.py
+++ b/tests/test_inflection_et.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_fi.py
+++ b/tests/test_inflection_fi.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_fr.py
+++ b/tests/test_inflection_fr.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_ga.py
+++ b/tests/test_inflection_ga.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_hu.py
+++ b/tests/test_inflection_hu.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021, 2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_it.py
+++ b/tests/test_inflection_it.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""
@@ -2379,4 +2385,3 @@ class InflTests(unittest.TestCase):
             ],
         }
         self.assertEqual(expected, ret)
-    

--- a/tests/test_inflection_la.py
+++ b/tests/test_inflection_la.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_lmo.py
+++ b/tests/test_inflection_lmo.py
@@ -3,20 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_lt.py
+++ b/tests/test_inflection_lt.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_lv.py
+++ b/tests/test_inflection_lv.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_nds_de.py
+++ b/tests/test_inflection_nds_de.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_nl.py
+++ b/tests/test_inflection_nl.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_pl.py
+++ b/tests/test_inflection_pl.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_pt.py
+++ b/tests/test_inflection_pt.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_ru.py
+++ b/tests/test_inflection_ru.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_sh.py
+++ b/tests/test_inflection_sh.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""
@@ -826,7 +832,7 @@ class InflTests(unittest.TestCase):
 
 {| class="inflection-table" style="text-align%3Acenter%3B+width%3A+100%25%3B"
 
-|- 
+|-
 
 ! style="height%3A3em%3B+background-color%3A%23d9ebff%3B" colspan="2" | '''Infinitive: <span class="Latn" lang="sh">[[nametati#Serbo-Croatian|nametati]]</span>'''
 
@@ -897,7 +903,7 @@ class InflTests(unittest.TestCase):
 ! '''<span class="Latn" lang="sh">[[oni#Serbo-Croatian|oni]]</span>''' / '''<span class="Latn" lang="sh">[[one#Serbo-Croatian|one]]</span>''' / '''<span class="Latn" lang="sh">[[ona#Serbo-Croatian|ona]]</span>'''
 
 
-|- 
+|-
 
 ! colspan="2" style="height%3A3em%3B+background-color%3A%23ccddff%3B" | '''Present'''
 
@@ -920,7 +926,7 @@ class InflTests(unittest.TestCase):
 | <span class="Latn" lang="sh">[[nameću#Serbo-Croatian|nameću]]</span>
 
 
-|- 
+|-
 
 ! rowspan="2" style="background-color%3A%23ccddff%3B" | '''Future'''
 
@@ -946,7 +952,7 @@ class InflTests(unittest.TestCase):
 | <span class="Latn" lang="sh">[[nametat#Serbo-Croatian|nametat]] [[će#Serbo-Croatian|će]]</span><sup>1</sup><br><span class="Latn" lang="sh">[[nametaće#Serbo-Croatian|nametaće]]</span>
 
 
-|- 
+|-
 
 ! style="height%3A3em%3B+background-color%3A%23ccddff%3B" | '''Future II'''
 
@@ -969,7 +975,7 @@ class InflTests(unittest.TestCase):
 | <span class="Latn" lang="sh">[[budu#Serbo-Croatian|bȕdū]] [[nametali#Serbo-Croatian|nametali]]</span><sup>2</sup>
 
 
-|- 
+|-
 
 ! rowspan="3" style="background-color%3A%23ccddff%3B" | '''Past'''
 
@@ -995,7 +1001,7 @@ class InflTests(unittest.TestCase):
 | <span class="Latn" lang="sh">[[nametali#Serbo-Croatian|nametali]] [[su#Serbo-Croatian|su]]</span><sup>2</sup>
 
 
-|- 
+|-
 
 ! style="height%3A3em%3B+background-color%3A%23ccddff%3B" | '''Pluperfect'''<sup>3</sup>
 
@@ -1018,7 +1024,7 @@ class InflTests(unittest.TestCase):
 | <span class="Latn" lang="sh">[[bili#Serbo-Croatian|bíli]] [[su#Serbo-Croatian|su]] [[nametali#Serbo-Croatian|nametali]]</span><sup>2</sup>
 
 
-|- 
+|-
 
 | style="height%3A+3em%3B+background%3A+%23ccddff%3B" | '''Imperfect'''
 
@@ -1041,7 +1047,7 @@ class InflTests(unittest.TestCase):
 | <span class="Latn" lang="sh">[[nametahu#Serbo-Croatian|nametahu]]</span>
 
 
-|- 
+|-
 
 ! colspan="2" style="height%3A3em%3B+background-color%3A%23ccddff%3B" | '''Conditional I'''
 
@@ -1064,7 +1070,7 @@ class InflTests(unittest.TestCase):
 | <span class="Latn" lang="sh">[[nametali#Serbo-Croatian|nametali]] [[bi#Serbo-Croatian|bi]]</span><sup>2</sup>
 
 
-|- 
+|-
 
 ! colspan="2" style="height%3A3em%3B+background-color%3A%23ccddff%3B" | '''Conditional II'''<sup>4</sup>
 
@@ -1087,7 +1093,7 @@ class InflTests(unittest.TestCase):
 | <span class="Latn" lang="sh">[[bili#Serbo-Croatian|bíli]] [[bi#Serbo-Croatian|bi]] [[nametali#Serbo-Croatian|nametali]]</span><sup>2</sup>
 
 
-|- 
+|-
 
 ! colspan="2" style="height%3A3em%3B+background-color%3A%23ccddff%3B" | '''Imperative'''
 
@@ -1110,7 +1116,7 @@ class InflTests(unittest.TestCase):
 | &mdash;
 
 
-|- 
+|-
 
 ! colspan="2" style="height%3A3em%3B+background-color%3A%23d9ebff%3B" | '''Active past participle'''
 
@@ -1121,7 +1127,7 @@ class InflTests(unittest.TestCase):
 | colspan="3" | <span class="Latn" lang="sh">[[nametali#Serbo-Croatian|nametali]]</span>&nbsp;<span class="gender"><abbr title="masculine+gender">m</abbr></span> / <span class="Latn" lang="sh">[[nametale#Serbo-Croatian|nametale]]</span>&nbsp;<span class="gender"><abbr title="feminine+gender">f</abbr></span> / <span class="Latn" lang="sh">[[nametala#Serbo-Croatian|nametala]]</span>&nbsp;<span class="gender"><abbr title="neuter+gender">n</abbr></span>
 
 
-|- 
+|-
 
 | colspan="2" style="height%3A+3em%3B+background%3A+%23d9ebff%3B" | '''Passive past participle'''
 
@@ -1132,7 +1138,7 @@ class InflTests(unittest.TestCase):
 | colspan="3" | <span class="Latn" lang="sh">[[nametani#Serbo-Croatian|nametani]]</span>&nbsp;<span class="gender"><abbr title="masculine+gender">m</abbr></span> / <span class="Latn" lang="sh">[[nametane#Serbo-Croatian|nametane]]</span>&nbsp;<span class="gender"><abbr title="feminine+gender">f</abbr></span> / <span class="Latn" lang="sh">[[nametana#Serbo-Croatian|nametana]]</span>&nbsp;<span class="gender"><abbr title="neuter+gender">n</abbr></span>
 
 
-|- 
+|-
 
 | colspan="8" style="text-align%3Aleft%3B" | <sup>1</sup> &nbsp; Croatian spelling: others omit the infinitive suffix completely and bind the clitic.<br><sup>2</sup> &nbsp; For masculine nouns; a feminine or neuter agent would use the feminine and neuter gender forms of the active past participle and auxiliary verb, respectively.<br><sup>3</sup> &nbsp; Often replaced by the past perfect in colloquial speech, i.e. the auxiliary verb ''[[biti]]'' (to be) is routinely dropped.
 <sup>4</sup> &nbsp; Often replaced by the conditional I in colloquial speech, i.e. the auxiliary verb ''[[biti]]'' (to be) is routinely dropped.

--- a/tests/test_inflection_sk.py
+++ b/tests/test_inflection_sk.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_sv.py
+++ b/tests/test_inflection_sv.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_table_context.py
+++ b/tests/test_inflection_table_context.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
-from wiktextract.inflection import (parse_inflection_section, TableContext)
+from wiktextract.inflection import parse_inflection_section, TableContext
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
 
 class InflTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xinfl(self, word, lang, pos, section, text):
         """Runs a single inflection table parsing test, and returns ``data``."""

--- a/tests/test_inflection_tagsets.py
+++ b/tests/test_inflection_tagsets.py
@@ -3,21 +3,27 @@
 # Tests for parsing inflection tables
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.inflection import or_tagsets, and_tagsets
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
 
-class TagsetTests(unittest.TestCase):
 
+class InflTests(unittest.TestCase):
     def setUp(self):
         self.maxDiff = 100000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def xop(self, op, ts1, ts2, expected, lang="English", pos="verb"):
         assert callable(op)

--- a/tests/test_linkages.py
+++ b/tests/test_linkages.py
@@ -4,23 +4,39 @@
 
 import json
 import unittest
-from wiktextract.linkages import parse_linkage_item_text
-from wiktextract.config import WiktionaryConfig
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
+from wiktextract.config import WiktionaryConfig
+from wiktextract.linkages import parse_linkage_item_text
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
 
 
 class LinkageTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 20000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
 
-    def run_data(self, item, word="testpage", lang="English",
-                 field="related", ruby=[], sense=None, senses=[],
-                 wxr=None, is_reconstruction=False):
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
+
+    def run_data(
+        self,
+        item,
+        word="testpage",
+        lang="English",
+        field="related",
+        ruby=[],
+        sense=None,
+        senses=[],
+        is_reconstruction=False,
+        check_errors=True,
+    ):
         """Runs a test where we expect the parsing to return None.  This
         function returns ``data``."""
         assert isinstance(item, str)
@@ -30,18 +46,23 @@ class LinkageTests(unittest.TestCase):
         assert isinstance(ruby, list)
         assert sense is None or isinstance(sense, str)
         assert isinstance(senses, list)
-        assert wxr is None or isinstance(wxr, WiktextractContext)
-        wxr1 = wxr if wxr is not None else WiktextractContext(
-                                                        Wtp(),
-                                                        WiktionaryConfig())
-        self.wxr = wxr1
+
         self.wxr.wtp.start_page(word)
         self.wxr.wtp.start_section(lang)
         data = {}
-        ret = parse_linkage_item_text(self.wxr, word, data, field, item,
-                                      sense, ruby, senses, is_reconstruction)
+        ret = parse_linkage_item_text(
+            self.wxr,
+            word,
+            data,
+            field,
+            item,
+            sense,
+            ruby,
+            senses,
+            is_reconstruction,
+        )
         self.assertIs(ret, None)
-        if wxr is None:
+        if check_errors:
             self.assertEqual(self.wxr.wtp.errors, [])
             self.assertEqual(self.wxr.wtp.warnings, [])
             self.assertEqual(self.wxr.wtp.debugs, [])
@@ -97,128 +118,189 @@ class LinkageTests(unittest.TestCase):
 
     def test_simple12(self):
         data = self.run_data("et cætera, et caetera")
-        self.assertEqual(data, {"related": [
-            {"word": "et cætera"},
-            {"word": "et caetera"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "et cætera"},
+                    {"word": "et caetera"},
+                ]
+            },
+        )
 
     def test_simple13(self):
         data = self.run_data("a, b, ..., z")
-        self.assertEqual(data, {"related": [
-            {"word": "a"},
-            {"word": "b"},
-            {"word": "z"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "a"},
+                    {"word": "b"},
+                    {"word": "z"},
+                ]
+            },
+        )
 
     def test_simple14(self):
         data = self.run_data("a, b, …, z")
-        self.assertEqual(data, {"related": [
-            {"word": "a"},
-            {"word": "b"},
-            {"word": "z"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "a"},
+                    {"word": "b"},
+                    {"word": "z"},
+                ]
+            },
+        )
 
     def test_simple15(self):
         data = self.run_data(",")
-        self.assertEqual(data, {"related": [
-            {"word": ","},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": ","},
+                ]
+            },
+        )
 
     def test_simple16(self):
         data = self.run_data(";")
-        self.assertEqual(data, {"related": [
-            {"word": ";"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": ";"},
+                ]
+            },
+        )
 
     def test_simple17(self):
         data = self.run_data("or")
-        self.assertEqual(data, {"related": [
-            {"word": "or"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "or"},
+                ]
+            },
+        )
 
     def test_simple18(self):
         data = self.run_data("and")
-        self.assertEqual(data, {"related": [
-            {"word": "and"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "and"},
+                ]
+            },
+        )
 
     def test_simple19(self):
         data = self.run_data("a or b")
-        self.assertEqual(data, {"related": [
-            {"word": "a"},
-            {"word": "b"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "a"},
+                    {"word": "b"},
+                ]
+            },
+        )
 
     def test_simple20(self):
         data = self.run_data("a (verb)")
-        self.assertEqual(data, {"related": [
-            {"word": "a", "tags": ["verb"]}]})
+        self.assertEqual(data, {"related": [{"word": "a", "tags": ["verb"]}]})
 
     def test_simple21(self):
         data = self.run_data("a (b)")
-        self.assertEqual(data, {"related": [
-            {"word": "a", "alt": "b"}]})
+        self.assertEqual(data, {"related": [{"word": "a", "alt": "b"}]})
 
     def test_simple22(self):
         data = self.run_data("human (Homo sapiens)")
-        self.assertEqual(data, {"related": [
-            {"word": "human", "taxonomic": "Homo sapiens"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "human", "taxonomic": "Homo sapiens"}]}
+        )
 
     def test_simple23(self):
         data = self.run_data("neanderthalin ihminen (×Homo neanderthalis)")
-        self.assertEqual(data, {"related": [
-            {"word": "neanderthalin ihminen",
-             "tags": ["extinct"],
-             "taxonomic": "Homo neanderthalis"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "neanderthalin ihminen",
+                        "tags": ["extinct"],
+                        "taxonomic": "Homo neanderthalis",
+                    }
+                ]
+            },
+        )
 
     def test_simple24(self):
         data = self.run_data("×Dinosauria")
-        self.assertEqual(data, {"related": [
-            {"word": "Dinosauria",
-             "tags": ["extinct"]}]})
+        self.assertEqual(
+            data, {"related": [{"word": "Dinosauria", "tags": ["extinct"]}]}
+        )
 
     def test_simple25(self):
         data = self.run_data("foo (×Dummy)")
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "alt": "Dummy",
-             "tags": ["extinct"]}]})
+        self.assertEqual(
+            data,
+            {"related": [{"word": "foo", "alt": "Dummy", "tags": ["extinct"]}]},
+        )
 
     def test_simple26(self):
         data = self.run_data('foo "a horse"')
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "english": "a horse"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "foo", "english": "a horse"}]}
+        )
 
     def test_simple27(self):
         data = self.run_data("起徛 (Zhangzhou Hokkien)")
-        self.assertEqual(data, {"related": [
-            {"word": "起徛",
-             "tags": ["Zhangzhou-Hokkien"]}]})
+        self.assertEqual(
+            data, {"related": [{"word": "起徛", "tags": ["Zhangzhou-Hokkien"]}]}
+        )
 
     def test_simple28(self):
         data = self.run_data("全部 (quánbù) (attributive)")
-        self.assertEqual(data, {"related": [
-            {"word": "全部",
-             "roman": "quánbù",
-             "tags": ["attributive"]}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "全部", "roman": "quánbù", "tags": ["attributive"]}
+                ]
+            },
+        )
 
     def test_simple29(self):
         data = self.run_data("整齊／整齐 (zhěngqí)")
-        self.assertEqual(data, {"related": [
-            {"word": "整齊",
-             "roman": "zhěngqí"},
-            {"word": "整齐",
-             "roman": "zhěngqí"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "整齊", "roman": "zhěngqí"},
+                    {"word": "整齐", "roman": "zhěngqí"},
+                ]
+            },
+        )
 
     def test_simple30(self):
         data = self.run_data("甘心 (gānxīn) (usually in the negative)")
-        self.assertEqual(data, {"related": [
-            {"word": "甘心",
-             "tags": ["usually", "with-negation"],
-             "roman": "gānxīn"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "甘心",
+                        "tags": ["usually", "with-negation"],
+                        "roman": "gānxīn",
+                    },
+                ]
+            },
+        )
 
     def test_reconstruction1(self):
         data = self.run_data("*foo", is_reconstruction=True)
@@ -231,10 +313,15 @@ class LinkageTests(unittest.TestCase):
     def test_dup1(self):
         # Duplicates should get eliminated
         data = self.run_data("foo, bar, foo")
-        self.assertEqual(data, {"related": [
-            {"word": "foo"},
-            {"word": "bar"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "foo"},
+                    {"word": "bar"},
+                ]
+            },
+        )
 
     def test_senseonly1(self):
         # In this case, parse_linkage_item_text should return the sense
@@ -242,20 +329,23 @@ class LinkageTests(unittest.TestCase):
         self.wxr.wtp.start_page("滿")
         self.wxr.wtp.start_section("Chinese")
         data = {}
-        ret = parse_linkage_item_text(self.wxr, "滿", data, "synonyms",
-                                      "(arrogant):", None, [], [], False)
+        ret = parse_linkage_item_text(
+            self.wxr, "滿", data, "synonyms", "(arrogant):", None, [], [], False
+        )
         self.assertEqual(ret, "arrogant")
 
     def test_sensearg1(self):
         data = self.run_data("foo", sense="test sense")
-        self.assertEqual(data, {"related": [{"word": "foo",
-                                             "sense": "test sense"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "foo", "sense": "test sense"}]}
+        )
 
     def test_sensearg2(self):
         data = self.run_data("foo", sense="intransitive verbs")
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "tags": ["intransitive", "verb"]}]})
+        self.assertEqual(
+            data,
+            {"related": [{"word": "foo", "tags": ["intransitive", "verb"]}]},
+        )
 
     def test_ignore1(self):
         self.run_empty("Historical and regional synonyms of foo")
@@ -307,14 +397,22 @@ class LinkageTests(unittest.TestCase):
 
     def test_taxonomic1(self):
         data = self.run_data("Hominidae - family")
-        self.assertEqual(data, {"related": [{"english": "family",
-                                             "word": "Hominidae"}]})
+        self.assertEqual(
+            data, {"related": [{"english": "family", "word": "Hominidae"}]}
+        )
+
     def test_taxonomic2(self):
         data = self.run_data("Aotidae, Atelidae - families")
-        self.assertEqual(data, {"related": [{"english": "family",
-                                             "word": "Aotidae"},
-                                            {"english": "family",
-                                             "word": "Atelidae"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"english": "family", "word": "Aotidae"},
+                    {"english": "family", "word": "Atelidae"},
+                ]
+            },
+        )
+
     def test_taxonomic3(self):
         # Currently no special handling for taxonomic terms in linkages.
         # This might change in the future.
@@ -322,801 +420,1286 @@ class LinkageTests(unittest.TestCase):
         self.assertEqual(data, {"related": [{"word": "Homo sapiens"}]})
 
     def test_taxonomic4(self):
-        data = self.run_data("(order): Eukaryota - superkingdom; "
-                             "Animalia - kingdom")
-        self.assertEqual(data, {"related": [
-            {"sense": "order", "english": "superkingdom", "word": "Eukaryota"},
-            {"sense": "order", "english": "kingdom", "word": "Animalia"}]})
+        data = self.run_data(
+            "(order): Eukaryota - superkingdom; " "Animalia - kingdom"
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "sense": "order",
+                        "english": "superkingdom",
+                        "word": "Eukaryota",
+                    },
+                    {
+                        "sense": "order",
+                        "english": "kingdom",
+                        "word": "Animalia",
+                    },
+                ]
+            },
+        )
 
     def test_truncate1(self):
         data = self.run_data("(blood type): from antigen B")
-        self.assertEqual(data, {"related": [
-            {"word": "antigen B", "sense": "blood type"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "antigen B", "sense": "blood type"}]}
+        )
 
     def test_truncate2(self):
         data = self.run_data("(symbol for boron): abbreviation of boron")
-        self.assertEqual(data, {"related": [
-            {"word": "boron",
-             "tags": ["abbreviation"],
-             "sense": "symbol for boron"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "boron",
+                        "tags": ["abbreviation"],
+                        "sense": "symbol for boron",
+                    }
+                ]
+            },
+        )
 
     def test_truncate3(self):
         data = self.run_data("(cricket, balls): abbreviation of balls")
-        self.assertEqual(data, {"related": [
-            {"word": "balls",
-             "tags": ["abbreviation"],
-             "topics": ["cricket", "ball-games", "games", "sports",
-                        "hobbies", "lifestyle"],
-             "sense": "balls",
-            }]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "balls",
+                        "tags": ["abbreviation"],
+                        "topics": [
+                            "cricket",
+                            "ball-games",
+                            "games",
+                            "sports",
+                            "hobbies",
+                            "lifestyle",
+                        ],
+                        "sense": "balls",
+                    }
+                ]
+            },
+        )
 
     def test_truncate4(self):
         data = self.run_data("(billion): abbreviation of billion")
-        self.assertEqual(data, {"related": [
-            {"word": "billion",
-             "tags": ["abbreviation"],
-             "sense": "billion",
-            }]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "billion",
+                        "tags": ["abbreviation"],
+                        "sense": "billion",
+                    }
+                ]
+            },
+        )
 
     def test_truncate5(self):
         data = self.run_data("Homo sapiens on Wikispecies")
-        self.assertEqual(data, {"related": [
-            {"word": "Homo sapiens"}
-        ]})
+        self.assertEqual(data, {"related": [{"word": "Homo sapiens"}]})
 
     def test_truncate6(self):
         data = self.run_data("dog on English Wiktionary.")
-        self.assertEqual(data, {"related": [
-            {"word": "dog"}
-        ]})
+        self.assertEqual(data, {"related": [{"word": "dog"}]})
 
     def test_prefix1(self):
         data = self.run_data("animal: pet, companion")
-        self.assertEqual(data, {"related": [
-            {"sense": "animal", "word": "pet"},
-            {"sense": "animal", "word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"sense": "animal", "word": "pet"},
+                    {"sense": "animal", "word": "companion"},
+                ]
+            },
+        )
 
     def test_prefix2(self):
         data = self.run_data("nouns: pet, companion")
-        self.assertEqual(data, {"related": [
-            {"tags": ["noun"], "word": "pet"},
-            {"tags": ["noun"], "word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"tags": ["noun"], "word": "pet"},
+                    {"tags": ["noun"], "word": "companion"},
+                ]
+            },
+        )
 
     def test_prefix3(self):
         data = self.run_data("finance: stock, trading")
-        self.assertEqual(data, {"related": [
-            {"topics": ["finance", "business"], "word": "stock"},
-            {"topics": ["finance", "business"], "word": "trading"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"topics": ["finance", "business"], "word": "stock"},
+                    {"topics": ["finance", "business"], "word": "trading"},
+                ]
+            },
+        )
 
     def test_prefix4(self):
         data = self.run_data("(animal): pet, companion")
-        self.assertEqual(data, {"related": [
-            {"sense": "animal", "word": "pet"},
-            {"sense": "animal", "word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"sense": "animal", "word": "pet"},
+                    {"sense": "animal", "word": "companion"},
+                ]
+            },
+        )
 
     def test_prefix5(self):
         data = self.run_data("(nouns): pet, companion")
-        self.assertEqual(data, {"related": [
-            {"tags": ["noun"], "word": "pet"},
-            {"tags": ["noun"], "word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"tags": ["noun"], "word": "pet"},
+                    {"tags": ["noun"], "word": "companion"},
+                ]
+            },
+        )
 
     def test_prefix6(self):
         data = self.run_data("(finance): stock, trading")
-        self.assertEqual(data, {"related": [
-            {"topics": ["finance", "business"], "word": "stock"},
-            {"topics": ["finance", "business"], "word": "trading"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"topics": ["finance", "business"], "word": "stock"},
+                    {"topics": ["finance", "business"], "word": "trading"},
+                ]
+            },
+        )
 
     def test_prefix7(self):
         # XXX should this affect first linkage only or all of them?
         data = self.run_data("(animal) pet, companion")
-        self.assertEqual(data, {"related": [
-            {"sense": "animal", "word": "pet"},
-            {"word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"sense": "animal", "word": "pet"},
+                    {"word": "companion"},
+                ]
+            },
+        )
 
     def test_prefix8(self):
         # XXX should this affect first linkage only or all of them?
         data = self.run_data("(nouns) pet, companion")
-        self.assertEqual(data, {"related": [
-            {"tags": ["noun"], "word": "pet"},
-            {"word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"tags": ["noun"], "word": "pet"},
+                    {"word": "companion"},
+                ]
+            },
+        )
 
     def test_prefix9(self):
         # XXX should this affect first linkage only or all of them?
         data = self.run_data("(finance) stock, trading")
-        self.assertEqual(data, {"related": [
-            {"topics": ["finance", "business"], "word": "stock"},
-            {"word": "trading"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"topics": ["finance", "business"], "word": "stock"},
+                    {"word": "trading"},
+                ]
+            },
+        )
 
     def test_prefix10(self):
         data = self.run_data("(intransitive, formal, to wander about) meander")
-        self.assertEqual(data, {"related": [
-            {"sense": "to wander about",
-             "tags": ["formal", "intransitive"],
-             "word": "meander"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "sense": "to wander about",
+                        "tags": ["formal", "intransitive"],
+                        "word": "meander",
+                    }
+                ]
+            },
+        )
 
     def test_prefix11(self):
         data = self.run_data("(to wander about, intransitive, formal) meander")
-        self.assertEqual(data, {"related": [
-            {"sense": "to wander about",
-             "tags": ["formal", "intransitive"],
-             "word": "meander"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "sense": "to wander about",
+                        "tags": ["formal", "intransitive"],
+                        "word": "meander",
+                    }
+                ]
+            },
+        )
 
     def test_prefix12(self):
         data = self.run_data("chemistry (slang): foo")
-        self.assertEqual(data, {"related": [
-            {"tags": ["slang"],
-             "topics": ["chemistry", "physical-sciences", "natural-sciences"],
-             "word": "foo"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "tags": ["slang"],
+                        "topics": [
+                            "chemistry",
+                            "physical-sciences",
+                            "natural-sciences",
+                        ],
+                        "word": "foo",
+                    }
+                ]
+            },
+        )
 
     def test_prefix13(self):
         data = self.run_data("foo: chemistry (slang)")
-        self.assertEqual(data, {"related": [
-            {"tags": ["slang"],
-             "topics": ["chemistry", "physical-sciences", "natural-sciences"],
-             "word": "foo"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "tags": ["slang"],
+                        "topics": [
+                            "chemistry",
+                            "physical-sciences",
+                            "natural-sciences",
+                        ],
+                        "word": "foo",
+                    }
+                ]
+            },
+        )
 
     def test_prefix14(self):
-        data = self.run_data("(2): foo", senses=[
-            {"glosses": ["sense1"]},
-            {"glosses": ["sense2", "sense2b"]},
-            {"glosses": ["sense3"]}])
-        self.assertEqual(data, {"related": [
-            {"sense": "sense2; sense2b",
-             "word": "foo"}]})
+        data = self.run_data(
+            "(2): foo",
+            senses=[
+                {"glosses": ["sense1"]},
+                {"glosses": ["sense2", "sense2b"]},
+                {"glosses": ["sense3"]},
+            ],
+        )
+        self.assertEqual(
+            data, {"related": [{"sense": "sense2; sense2b", "word": "foo"}]}
+        )
 
     def test_prefix15(self):
-        data = self.run_data("(3): foo", senses=[
-            {"glosses": ["sense1"]},
-            {"glosses": ["sense2", "sense2b"]},
-            {"glosses": ["sense3"]}])
-        self.assertEqual(data, {"related": [
-            {"sense": "sense3",
-             "word": "foo"}]})
+        data = self.run_data(
+            "(3): foo",
+            senses=[
+                {"glosses": ["sense1"]},
+                {"glosses": ["sense2", "sense2b"]},
+                {"glosses": ["sense3"]},
+            ],
+        )
+        self.assertEqual(
+            data, {"related": [{"sense": "sense3", "word": "foo"}]}
+        )
 
     def test_prefix16(self):
         # Triggers an error due to invalid gloss reference
-        wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-        data = self.run_data("(4): foo", wxr=wxr, senses=[
-            {"glosses": ["sense1"]},
-            {"glosses": ["sense2", "sense2b"]},
-            {"glosses": ["sense3"]}])
-        self.assertEqual(data, {"related": [
-            {"word": "foo"}]})
-        self.assertNotEqual(wxr.wtp.debugs, [])
+        data = self.run_data(
+            "(4): foo",
+            senses=[
+                {"glosses": ["sense1"]},
+                {"glosses": ["sense2", "sense2b"]},
+                {"glosses": ["sense3"]},
+            ],
+            check_errors=False,
+        )
+        self.assertEqual(data, {"related": [{"word": "foo"}]})
+        self.assertNotEqual(self.wxr.wtp.debugs, [])
 
     def test_prefix17(self):
-        data = self.run_data("(3): foo",
-                             sense="initial sense",
-                             senses=[
-            {"glosses": ["sense1"]},
-            {"glosses": ["sense2", "sense2b"]},
-            {"glosses": ["sense3"]}])
-        self.assertEqual(data, {"related": [
-            {"sense": "initial sense; sense3",
-             "word": "foo"}]})
+        data = self.run_data(
+            "(3): foo",
+            sense="initial sense",
+            senses=[
+                {"glosses": ["sense1"]},
+                {"glosses": ["sense2", "sense2b"]},
+                {"glosses": ["sense3"]},
+            ],
+        )
+        self.assertEqual(
+            data,
+            {"related": [{"sense": "initial sense; sense3", "word": "foo"}]},
+        )
 
     def test_prefix18(self):
         # Triggers error due to invalid prefix
-        wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-        data = self.run_data("dsafjdasfkldjas: foo", wxr=wxr)
+        data = self.run_data("dsafjdasfkldjas: foo", check_errors=False)
         self.assertEqual(data, {"related": [{"word": "foo"}]})
-        self.assertNotEqual(wxr.wtp.debugs, [])
+        self.assertNotEqual(self.wxr.wtp.debugs, [])
 
     def test_prefix19(self):
         data = self.run_data("NATO phonetic: Bravo")
-        self.assertEqual(data, {"related": [
-            {"word": "Bravo", "english": "NATO phonetic"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "Bravo", "english": "NATO phonetic"}]}
+        )
 
     def test_prefix20(self):
         data = self.run_data("Morse code: –···")
-        self.assertEqual(data, {"related": [
-            {"word": "–···", "english": "Morse code"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "–···", "english": "Morse code"}]}
+        )
 
     def test_prefix21(self):
         data = self.run_data("Braille: ⠃")
-        self.assertEqual(data, {"related": [
-            {"word": "⠃", "english": "Braille"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "⠃", "english": "Braille"}]}
+        )
 
     def test_prefix22(self):
         data = self.run_data("something else in English: foo")
-        self.assertEqual(data, {"related": [
-            {"word": "foo", "sense": "something else in English"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "foo", "sense": "something else in English"}
+                ]
+            },
+        )
 
     def test_prefix23(self):
-        data = self.run_data("(intransitive, transitive, verb, frequentative): "
-                             "foo")
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "tags": ["frequentative", "intransitive", "transitive", "verb"]}]})
+        data = self.run_data(
+            "(intransitive, transitive, verb, frequentative): " "foo"
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "foo",
+                        "tags": [
+                            "frequentative",
+                            "intransitive",
+                            "transitive",
+                            "verb",
+                        ],
+                    }
+                ]
+            },
+        )
 
     def test_prefix24(self):
         data = self.run_data("foo: verb")
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "tags": ["verb"]}]})
+        self.assertEqual(data, {"related": [{"word": "foo", "tags": ["verb"]}]})
 
     def test_prefix25(self):
-        data = self.run_data("(intransitive, to run, transitive, "
-                             "ditransitive): foo")
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "sense": "to run",
-             "tags": ["ditransitive", "intransitive", "transitive"]}]})
+        data = self.run_data(
+            "(intransitive, to run, transitive, " "ditransitive): foo"
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "foo",
+                        "sense": "to run",
+                        "tags": ["ditransitive", "intransitive", "transitive"],
+                    }
+                ]
+            },
+        )
 
     def test_prefix26(self):
         data = self.run_data("(to run, transitive): foo")
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "sense": "to run",
-             "tags": ["transitive"]}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "foo", "sense": "to run", "tags": ["transitive"]}
+                ]
+            },
+        )
 
     def test_prefix27(self):
         data = self.run_data("alternative (B): foo")
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "sense": "alternative (B)"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "foo", "sense": "alternative (B)"}]}
+        )
 
     def test_prefix28(self):
         data = self.run_data("(human, Homo sapiens): foo")
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "sense": "human, Homo sapiens"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "foo", "sense": "human, Homo sapiens"}]}
+        )
 
     def test_prefix29(self):
         data = self.run_data("Homo sapiens: foo (human)")
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "english": "human",
-             "sense": "Homo sapiens"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "foo", "english": "human", "sense": "Homo sapiens"}
+                ]
+            },
+        )
 
     def test_prefix30(self):
         data = self.run_data("^() foo")
-        self.assertEqual(data, {"related": [
-            {"word": "foo"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "foo"},
+                ]
+            },
+        )
 
     def test_prefix31(self):
         data = self.run_data("^( ) foo")
-        self.assertEqual(data, {"related": [
-            {"word": "foo"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "foo"},
+                ]
+            },
+        )
 
     def test_prefix32(self):
         data = self.run_data("^ foo")
-        self.assertEqual(data, {"related": [
-            {"word": "foo"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "foo"},
+                ]
+            },
+        )
 
     def test_prefix33(self):
-        data = self.run_data('(any member of the suborder (sometimes superfamily) Feliformia or Feloidea): feliform ("cat-like" carnivoran), feloid (compare Caniformia, Canoidea)')
-        self.assertEqual(data, {"related": [
-            {"sense": "any member of the suborder (sometimes superfamily) Feliformia or Feloidea",
-             "word": "feliform",
-             "english": 'cat-like; carnivoran'},
-            {"sense": "any member of the suborder (sometimes superfamily) Feliformia or Feloidea",
-             "word": "feloid",
-             "english": "compare Caniformia, Canoidea"},
-        ]})
+        data = self.run_data(
+            '(any member of the suborder (sometimes superfamily) Feliformia or Feloidea): feliform ("cat-like" carnivoran), feloid (compare Caniformia, Canoidea)'
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "sense": "any member of the suborder (sometimes superfamily) Feliformia or Feloidea",
+                        "word": "feliform",
+                        "english": "cat-like; carnivoran",
+                    },
+                    {
+                        "sense": "any member of the suborder (sometimes superfamily) Feliformia or Feloidea",
+                        "word": "feloid",
+                        "english": "compare Caniformia, Canoidea",
+                    },
+                ]
+            },
+        )
 
     def test_suffix1(self):
         data = self.run_data("pet (animal), companion")
-        self.assertEqual(data, {"related": [
-            {"english": "animal", "word": "pet"},
-            {"word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"english": "animal", "word": "pet"},
+                    {"word": "companion"},
+                ]
+            },
+        )
 
     def test_suffix2(self):
         data = self.run_data("pet, companion (animal)")
-        self.assertEqual(data, {"related": [
-            {"word": "pet"},
-            {"english": "animal", "word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "pet"},
+                    {"english": "animal", "word": "companion"},
+                ]
+            },
+        )
 
     def test_suffix3(self):
         data = self.run_data("pet, companion (animal) (female)")
-        self.assertEqual(data, {"related": [
-            {"word": "pet"},
-            {"english": "animal", "tags": ["feminine"], "word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "pet"},
+                    {
+                        "english": "animal",
+                        "tags": ["feminine"],
+                        "word": "companion",
+                    },
+                ]
+            },
+        )
 
     def test_suffix4(self):
         data = self.run_data("pet, companion (female, animal)")
-        self.assertEqual(data, {"related": [
-            {"word": "pet"},
-            {"english": "animal", "tags": ["feminine"], "word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "pet"},
+                    {
+                        "english": "animal",
+                        "tags": ["feminine"],
+                        "word": "companion",
+                    },
+                ]
+            },
+        )
 
     def test_suffix5(self):
         data = self.run_data("pet (verb), companion (female, animal)")
-        self.assertEqual(data, {"related": [
-            {"tags": ["verb"], "word": "pet"},
-            {"english": "animal", "tags": ["feminine"], "word": "companion"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"tags": ["verb"], "word": "pet"},
+                    {
+                        "english": "animal",
+                        "tags": ["feminine"],
+                        "word": "companion",
+                    },
+                ]
+            },
+        )
 
     def test_suffix6(self):
         data = self.run_data("foo, bar - verbs")
-        self.assertEqual(data, {"related": [
-            {"tags": ["verb"], "word": "foo"},
-            {"tags": ["verb"], "word": "bar"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"tags": ["verb"], "word": "foo"},
+                    {"tags": ["verb"], "word": "bar"},
+                ]
+            },
+        )
 
     def test_suffix7(self):
         data = self.run_data("a - b")
-        self.assertEqual(data, {"related": [
-            {"word": "a - b"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "a - b"},
+                ]
+            },
+        )
 
     def test_suffix8(self):
         data = self.run_data("(no superlative): foo, bar - adjectives")
-        self.assertEqual(data, {"related": [
-            {"tags": ["adjective", "no-superlative"], "word": "foo"},
-            {"tags": ["adjective", "no-superlative"], "word": "bar"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"tags": ["adjective", "no-superlative"], "word": "foo"},
+                    {"tags": ["adjective", "no-superlative"], "word": "bar"},
+                ]
+            },
+        )
 
     def test_eq1(self):
         data = self.run_data("luoda = to create")
-        self.assertEqual(data, {"related": [
-            {"word": "luoda", "english": "to create"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "luoda", "english": "to create"}]}
+        )
 
     def test_eq2(self):
         # This should also work in the opposite order (and it is used both ways)
         data = self.run_data("to create = luoda")
-        self.assertEqual(data, {"related": [
-            {"word": "luoda", "english": "to create"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "luoda", "english": "to create"}]}
+        )
 
     def test_gender1(self):
         data = self.run_data("foo f", lang="Swedish")
-        self.assertEqual(data, {"related": [
-            {"tags": ["feminine"], "word": "foo"}]})
+        self.assertEqual(
+            data, {"related": [{"tags": ["feminine"], "word": "foo"}]}
+        )
 
     def test_gender2(self):
         data = self.run_data("foo m", lang="Swedish")
-        self.assertEqual(data, {"related": [
-            {"tags": ["masculine"], "word": "foo"}]})
+        self.assertEqual(
+            data, {"related": [{"tags": ["masculine"], "word": "foo"}]}
+        )
 
     def test_gender3(self):
         data = self.run_data("foo n", lang="Swedish")
-        self.assertEqual(data, {"related": [
-            {"tags": ["neuter"], "word": "foo"}]})
+        self.assertEqual(
+            data, {"related": [{"tags": ["neuter"], "word": "foo"}]}
+        )
 
     def test_gender4(self):
         # XXX "common" should distinguish gender vs. frequent meanings
         data = self.run_data("foo c", lang="Swedish")
-        self.assertEqual(data, {"related": [
-            {"tags": ["common-gender"], "word": "foo"}]})
+        self.assertEqual(
+            data, {"related": [{"tags": ["common-gender"], "word": "foo"}]}
+        )
 
     def test_gender5(self):
         # Numeric inflection classes should only be interpreted for certain
         # languages (e.g., Bantu languages)
-        wxr = WiktextractContext(Wtp(), WiktionaryConfig())  # To allow debug messages
-        data = self.run_data("foo 1", lang="Swedish", wxr=wxr)
-        self.assertEqual(data, {"related": [
-            {"word": "foo 1"}]})
+        data = self.run_data("foo 1", lang="Swedish", check_errors=False)
+        self.assertEqual(data, {"related": [{"word": "foo 1"}]})
 
     def test_gender6(self):
         data = self.run_data("foo 1", lang="Zulu")
-        self.assertEqual(data, {"related": [
-            {"tags": ["class-1"], "word": "foo"}]})
+        self.assertEqual(
+            data, {"related": [{"tags": ["class-1"], "word": "foo"}]}
+        )
 
     def test_gender7(self):
         data = self.run_data("foo 5/6", lang="Zulu")
-        self.assertEqual(data, {"related": [
-            {"tags": ["class-5", "class-6"], "word": "foo"}]})
+        self.assertEqual(
+            data, {"related": [{"tags": ["class-5", "class-6"], "word": "foo"}]}
+        )
 
     def test_gender8(self):
         data = self.run_data("foo 1a", lang="Zulu")
-        self.assertEqual(data, {"related": [
-            {"tags": ["class-1a"], "word": "foo"}]})
+        self.assertEqual(
+            data, {"related": [{"tags": ["class-1a"], "word": "foo"}]}
+        )
 
     def test_gender9(self):
         # These special inflection class markers should only be recognized
         # for certain languages
         data = self.run_data("foo mu", lang="Swahili")
-        self.assertEqual(data, {"related": [
-            {"tags": ["class-18"], "word": "foo"}]})
+        self.assertEqual(
+            data, {"related": [{"tags": ["class-18"], "word": "foo"}]}
+        )
 
     def test_gender10(self):
         # Make sure the marker with "or" is handled properly
         data = self.run_data("foo ki or vi", lang="Swahili")
-        self.assertEqual(data, {"related": [
-            {"tags": ["class-7", "class-8"], "word": "foo"}]})
+        self.assertEqual(
+            data, {"related": [{"tags": ["class-7", "class-8"], "word": "foo"}]}
+        )
 
     def test_gender11(self):
         # For languages that don't recognize these markers, the "or" should
         # split linkage into two
         data = self.run_data("foo ki or vi", lang="English")
-        self.assertEqual(data, {"related": [
-            {"word": "foo ki"},
-            {"word": "vi"}]})
+        self.assertEqual(
+            data, {"related": [{"word": "foo ki"}, {"word": "vi"}]}
+        )
 
     def test_gender12(self):
         data = self.run_data("foo 1 or 2", lang="Ngazidja Comorian")
-        self.assertEqual(data, {"related": [
-            {"word": "foo",
-             "tags": ["class-1", "class-2"]},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "foo", "tags": ["class-1", "class-2"]},
+                ]
+            },
+        )
 
     def test_gender13(self):
         # They should not be interpreted for other languages
-        wxr = WiktextractContext(Wtp(), WiktionaryConfig())  # To allow debug messages
-        data = self.run_data("foo 1 or 2", lang="English", wxr=wxr)
-        self.assertEqual(data, {"related": [
-            {"word": "foo 1"},
-            {"word": "2"},
-        ]})
+        data = self.run_data("foo 1 or 2", lang="English", check_errors=False)
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "foo 1"},
+                    {"word": "2"},
+                ]
+            },
+        )
 
     def test_gender14(self):
         # pants/English/Translations
         data = self.run_data("kelnės f or n", lang="Lithuanian")
-        self.assertEqual(data, {"related": [
-            {"word": "kelnės", "tags": ["feminine", "neuter"]},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "kelnės", "tags": ["feminine", "neuter"]},
+                ]
+            },
+        )
 
     def test_gender15(self):
         # inclusive or/English/Translations
-        wxr = WiktextractContext(Wtp(), WiktionaryConfig())  # To allow debug messages
-        data = self.run_data("μη αποκλειστικό or n (mi apokleistikó or)",
-                             lang="Greek", word="inclusive or", wxr=wxr)
-        self.assertEqual(data, {"related": [
-            {"word": "μη αποκλειστικό or", "tags": ["neuter"],
-             "roman": "mi apokleistikó or"},
-        ]})
+        data = self.run_data(
+            "μη αποκλειστικό or n (mi apokleistikó or)",
+            lang="Greek",
+            word="inclusive or",
+            check_errors=False,
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "μη αποκλειστικό or",
+                        "tags": ["neuter"],
+                        "roman": "mi apokleistikó or",
+                    },
+                ]
+            },
+        )
 
     def test_gender16(self):
         # simplified from wife/English/Translations
-        data = self.run_data("ווײַב‎ n or f, פֿרוי‎ f (froy)",
-                             lang="Yiddish")
+        data = self.run_data("ווײַב‎ n or f, פֿרוי‎ f (froy)", lang="Yiddish")
         print(json.dumps(data, indent=2, sort_keys=True))
-        self.assertEqual(data, {"related": [
-            {"word": "ווײַב‎", "tags": ["feminine", "neuter"]},
-            {"word": "פֿרוי‎", "tags": ["feminine"], "roman": "froy"},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "ווײַב‎", "tags": ["feminine", "neuter"]},
+                    {"word": "פֿרוי‎", "tags": ["feminine"], "roman": "froy"},
+                ]
+            },
+        )
 
     def test_gender16orig(self):
         # wife/English/Translations
-        data = self.run_data("ווײַב‎ n (vayb) or f, פֿרוי‎ f (froy)",
-                             lang="Yiddish")
-        self.assertEqual(data, {"related": [
-            {"word": "ווײַב‎", "tags": ["feminine", "neuter"],
-             "roman": "vayb"},
-            {"word": "פֿרוי‎", "tags": ["feminine"], "roman": "froy"},
-        ]})
+        data = self.run_data(
+            "ווײַב‎ n (vayb) or f, פֿרוי‎ f (froy)", lang="Yiddish"
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "ווײַב‎",
+                        "tags": ["feminine", "neuter"],
+                        "roman": "vayb",
+                    },
+                    {"word": "פֿרוי‎", "tags": ["feminine"], "roman": "froy"},
+                ]
+            },
+        )
 
     def test_gender17(self):
         # homonym/English/Translations/French
-        data = self.run_data("homonyme m or n",
-                             lang="French")
-        self.assertEqual(data, {"related": [
-            {"word": "homonyme", "tags": ["masculine", "neuter"]},
-        ]})
+        data = self.run_data("homonyme m or n", lang="French")
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "homonyme", "tags": ["masculine", "neuter"]},
+                ]
+            },
+        )
 
     def test_gender18(self):
         # dragonfly/Eng/Tr/Zulu
-        data = self.run_data("uzekamanzi 1a or 2a",
-                             lang="Zulu")
-        self.assertEqual(data, {"related": [
-            {"word": "uzekamanzi", "tags": ["class-1a", "class-2a"]},
-        ]})
+        data = self.run_data("uzekamanzi 1a or 2a", lang="Zulu")
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "uzekamanzi", "tags": ["class-1a", "class-2a"]},
+                ]
+            },
+        )
 
     def test_gender19(self):
         # Spanish Netherlands/Tr/French
-        data = self.run_data("Pays-Bas espagnois pl or m",
-                             lang="French")
-        self.assertEqual(data, {"related": [
-            {"word": "Pays-Bas espagnois",
-             "tags": ["masculine", "plural", "singular"]},
-        ]})
+        data = self.run_data("Pays-Bas espagnois pl or m", lang="French")
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "Pays-Bas espagnois",
+                        "tags": ["masculine", "plural", "singular"],
+                    },
+                ]
+            },
+        )
 
     def test_begining_tags1(self):
-        data = self.run_data("frequentative juoksennella, cohortative juostaan",
-                             lang="Finnish")
-        self.assertEqual(data, {"related": [
-            {"tags": ["frequentative"], "word": "juoksennella"},
-            {"tags": ["cohortative"], "word": "juostaan"}]})
+        data = self.run_data(
+            "frequentative juoksennella, cohortative juostaan", lang="Finnish"
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"tags": ["frequentative"], "word": "juoksennella"},
+                    {"tags": ["cohortative"], "word": "juostaan"},
+                ]
+            },
+        )
 
     def test_begining_tags2(self):
         data = self.run_data("frequentative", lang="Finnish")
-        self.assertEqual(data, {"related": [
-            {"word": "frequentative"}]})
+        self.assertEqual(data, {"related": [{"word": "frequentative"}]})
 
     def test_jp1(self):
-        data = self.run_data("一犬 (ikken): one dog", lang="Japanese",
-                             field="compounds", ruby=[("一犬", "いっけん")])
-        self.assertEqual(data, {"compounds": [
-            {"word": "一犬",
-             "roman": "ikken",
-             "ruby": [("一犬", "いっけん")],
-             "english": "one dog"}]})
+        data = self.run_data(
+            "一犬 (ikken): one dog",
+            lang="Japanese",
+            field="compounds",
+            ruby=[("一犬", "いっけん")],
+        )
+        self.assertEqual(
+            data,
+            {
+                "compounds": [
+                    {
+                        "word": "一犬",
+                        "roman": "ikken",
+                        "ruby": [("一犬", "いっけん")],
+                        "english": "one dog",
+                    }
+                ]
+            },
+        )
 
     def test_jp2(self):
         # This twisted test just tries to cover a rare code path
         data = self.run_data("一犬 (ikken): one dog - family")
-        self.assertEqual(data, {"related": [
-            {"word": "一犬",
-             "roman": "ikken",
-             "english": "family; one dog"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "一犬",
+                        "roman": "ikken",
+                        "english": "family; one dog",
+                    }
+                ]
+            },
+        )
 
     def test_jp3(self):
         # This synthetic test tries to cover a case where there is also
         # an "alt" in the parentheses
         data = self.run_data("一犬 (滿洲, ikken): one dog")
-        self.assertEqual(data, {"related": [
-            {"word": "一犬",
-             "alt": "滿洲",
-             "roman": "ikken",
-             "english": "one dog"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "一犬",
+                        "alt": "滿洲",
+                        "roman": "ikken",
+                        "english": "one dog",
+                    }
+                ]
+            },
+        )
 
     def test_ko1(self):
-        data = self.run_data("만주 (滿洲, Manju, “Manchuria”)",
-                             lang="Korean")
-        self.assertEqual(data, {"related": [
-            {"word": "만주",
-             "alt": "滿洲",
-             "roman": "Manju",
-             "english": "Manchuria"}]})
+        data = self.run_data("만주 (滿洲, Manju, “Manchuria”)", lang="Korean")
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "만주",
+                        "alt": "滿洲",
+                        "roman": "Manju",
+                        "english": "Manchuria",
+                    }
+                ]
+            },
+        )
 
     def test_zh1(self):
-        data = self.run_data("(to be brimming with): 充滿／充满 (chōngmǎn), "
-                             "充盈 (chōngyíng), 洋溢 (yángyì)",
-                             field="synonyms")
-        self.assertEqual(data, {"synonyms": [
-            {"sense": "to be brimming with",
-             "word": "充滿",
-             "roman": "chōngmǎn"},
-            {"sense": "to be brimming with",
-             "word": "充满",
-             "roman": "chōngmǎn"},
-            {"sense": "to be brimming with",
-             "word": "充盈",
-             "roman": "chōngyíng"},
-            {"sense": "to be brimming with",
-             "word": "洋溢",
-             "roman": "yángyì"}]})
+        data = self.run_data(
+            "(to be brimming with): 充滿／充满 (chōngmǎn), "
+            "充盈 (chōngyíng), 洋溢 (yángyì)",
+            field="synonyms",
+        )
+        self.assertEqual(
+            data,
+            {
+                "synonyms": [
+                    {
+                        "sense": "to be brimming with",
+                        "word": "充滿",
+                        "roman": "chōngmǎn",
+                    },
+                    {
+                        "sense": "to be brimming with",
+                        "word": "充满",
+                        "roman": "chōngmǎn",
+                    },
+                    {
+                        "sense": "to be brimming with",
+                        "word": "充盈",
+                        "roman": "chōngyíng",
+                    },
+                    {
+                        "sense": "to be brimming with",
+                        "word": "洋溢",
+                        "roman": "yángyì",
+                    },
+                ]
+            },
+        )
 
     def test_papersizes1(self):
-        data = self.run_data("(A paper sizes): 2A0   A0   A1   A2   A3   A4   "
-                             "A5   A6   A7   A8   A9   A10")
-        self.assertEqual(data, {"related": [
-            {"sense": "A paper sizes", "word": "2A0"},
-            {"sense": "A paper sizes", "word": "A0"},
-            {"sense": "A paper sizes", "word": "A1"},
-            {"sense": "A paper sizes", "word": "A2"},
-            {"sense": "A paper sizes", "word": "A3"},
-            {"sense": "A paper sizes", "word": "A4"},
-            {"sense": "A paper sizes", "word": "A5"},
-            {"sense": "A paper sizes", "word": "A6"},
-            {"sense": "A paper sizes", "word": "A7"},
-            {"sense": "A paper sizes", "word": "A8"},
-            {"sense": "A paper sizes", "word": "A9"},
-            {"sense": "A paper sizes", "word": "A10"}]})
+        data = self.run_data(
+            "(A paper sizes): 2A0   A0   A1   A2   A3   A4   "
+            "A5   A6   A7   A8   A9   A10"
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"sense": "A paper sizes", "word": "2A0"},
+                    {"sense": "A paper sizes", "word": "A0"},
+                    {"sense": "A paper sizes", "word": "A1"},
+                    {"sense": "A paper sizes", "word": "A2"},
+                    {"sense": "A paper sizes", "word": "A3"},
+                    {"sense": "A paper sizes", "word": "A4"},
+                    {"sense": "A paper sizes", "word": "A5"},
+                    {"sense": "A paper sizes", "word": "A6"},
+                    {"sense": "A paper sizes", "word": "A7"},
+                    {"sense": "A paper sizes", "word": "A8"},
+                    {"sense": "A paper sizes", "word": "A9"},
+                    {"sense": "A paper sizes", "word": "A10"},
+                ]
+            },
+        )
 
     def test_papersizes2(self):
-        data = self.run_data("  (B paper sizes): B0   B1   B2   B3   B4   "
-                             "B5   B6   B7   B8   B9   B10        ")
-        self.assertEqual(data, {"related": [
-            {"sense": "B paper sizes", "word": "B0"},
-            {"sense": "B paper sizes", "word": "B1"},
-            {"sense": "B paper sizes", "word": "B2"},
-            {"sense": "B paper sizes", "word": "B3"},
-            {"sense": "B paper sizes", "word": "B4"},
-            {"sense": "B paper sizes", "word": "B5"},
-            {"sense": "B paper sizes", "word": "B6"},
-            {"sense": "B paper sizes", "word": "B7"},
-            {"sense": "B paper sizes", "word": "B8"},
-            {"sense": "B paper sizes", "word": "B9"},
-            {"sense": "B paper sizes", "word": "B10"}]})
+        data = self.run_data(
+            "  (B paper sizes): B0   B1   B2   B3   B4   "
+            "B5   B6   B7   B8   B9   B10        "
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"sense": "B paper sizes", "word": "B0"},
+                    {"sense": "B paper sizes", "word": "B1"},
+                    {"sense": "B paper sizes", "word": "B2"},
+                    {"sense": "B paper sizes", "word": "B3"},
+                    {"sense": "B paper sizes", "word": "B4"},
+                    {"sense": "B paper sizes", "word": "B5"},
+                    {"sense": "B paper sizes", "word": "B6"},
+                    {"sense": "B paper sizes", "word": "B7"},
+                    {"sense": "B paper sizes", "word": "B8"},
+                    {"sense": "B paper sizes", "word": "B9"},
+                    {"sense": "B paper sizes", "word": "B10"},
+                ]
+            },
+        )
 
     def test_script1(self):
         data = self.run_data("(Arabic digits): 0 1 2 3 4 5 6 7 8 9")
-        self.assertEqual(data, {"related": [
-            {"tags": ["Arabic", "digit"], "word": "0"},
-            {"tags": ["Arabic", "digit"], "word": "1"},
-            {"tags": ["Arabic", "digit"], "word": "2"},
-            {"tags": ["Arabic", "digit"], "word": "3"},
-            {"tags": ["Arabic", "digit"], "word": "4"},
-            {"tags": ["Arabic", "digit"], "word": "5"},
-            {"tags": ["Arabic", "digit"], "word": "6"},
-            {"tags": ["Arabic", "digit"], "word": "7"},
-            {"tags": ["Arabic", "digit"], "word": "8"},
-            {"tags": ["Arabic", "digit"], "word": "9"}]})
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"tags": ["Arabic", "digit"], "word": "0"},
+                    {"tags": ["Arabic", "digit"], "word": "1"},
+                    {"tags": ["Arabic", "digit"], "word": "2"},
+                    {"tags": ["Arabic", "digit"], "word": "3"},
+                    {"tags": ["Arabic", "digit"], "word": "4"},
+                    {"tags": ["Arabic", "digit"], "word": "5"},
+                    {"tags": ["Arabic", "digit"], "word": "6"},
+                    {"tags": ["Arabic", "digit"], "word": "7"},
+                    {"tags": ["Arabic", "digit"], "word": "8"},
+                    {"tags": ["Arabic", "digit"], "word": "9"},
+                ]
+            },
+        )
 
     def test_script2(self):
-        data = self.run_data("(Latin script):  Aa  Bb  Cc  Dd  Ee  Ff  Gg  Hh  "
-                             "Ii  Jj  Kk  Ll  Mm  Nn  Oo  Pp  Qq  Rr  Sſs  Tt  "
-                             "Uu  Vv  Ww  Xx  Yy  Zz")
-        self.assertEqual(data, {"related": [
-            {"tags": ["Latin", "character"], "word": "A"},
-            {"tags": ["Latin", "character"], "word": "a"},
-            {"tags": ["Latin", "character"], "word": "B"},
-            {"tags": ["Latin", "character"], "word": "b"},
-            {"tags": ["Latin", "character"], "word": "C"},
-            {"tags": ["Latin", "character"], "word": "c"},
-            {"tags": ["Latin", "character"], "word": "D"},
-            {"tags": ["Latin", "character"], "word": "d"},
-            {"tags": ["Latin", "character"], "word": "E"},
-            {"tags": ["Latin", "character"], "word": "e"},
-            {"tags": ["Latin", "character"], "word": "F"},
-            {"tags": ["Latin", "character"], "word": "f"},
-            {"tags": ["Latin", "character"], "word": "G"},
-            {"tags": ["Latin", "character"], "word": "g"},
-            {"tags": ["Latin", "character"], "word": "H"},
-            {"tags": ["Latin", "character"], "word": "h"},
-            {"tags": ["Latin", "character"], "word": "I"},
-            {"tags": ["Latin", "character"], "word": "i"},
-            {"tags": ["Latin", "character"], "word": "J"},
-            {"tags": ["Latin", "character"], "word": "j"},
-            {"tags": ["Latin", "character"], "word": "K"},
-            {"tags": ["Latin", "character"], "word": "k"},
-            {"tags": ["Latin", "character"], "word": "L"},
-            {"tags": ["Latin", "character"], "word": "l"},
-            {"tags": ["Latin", "character"], "word": "M"},
-            {"tags": ["Latin", "character"], "word": "m"},
-            {"tags": ["Latin", "character"], "word": "N"},
-            {"tags": ["Latin", "character"], "word": "n"},
-            {"tags": ["Latin", "character"], "word": "O"},
-            {"tags": ["Latin", "character"], "word": "o"},
-            {"tags": ["Latin", "character"], "word": "P"},
-            {"tags": ["Latin", "character"], "word": "p"},
-            {"tags": ["Latin", "character"], "word": "Q"},
-            {"tags": ["Latin", "character"], "word": "q"},
-            {"tags": ["Latin", "character"], "word": "R"},
-            {"tags": ["Latin", "character"], "word": "r"},
-            {"tags": ["Latin", "character"], "word": "S"},
-            {"tags": ["Latin", "character"], "word": "ſ"},
-            {"tags": ["Latin", "character"], "word": "s"},
-            {"tags": ["Latin", "character"], "word": "T"},
-            {"tags": ["Latin", "character"], "word": "t"},
-            {"tags": ["Latin", "character"], "word": "U"},
-            {"tags": ["Latin", "character"], "word": "u"},
-            {"tags": ["Latin", "character"], "word": "V"},
-            {"tags": ["Latin", "character"], "word": "v"},
-            {"tags": ["Latin", "character"], "word": "W"},
-            {"tags": ["Latin", "character"], "word": "w"},
-            {"tags": ["Latin", "character"], "word": "X"},
-            {"tags": ["Latin", "character"], "word": "x"},
-            {"tags": ["Latin", "character"], "word": "Y"},
-            {"tags": ["Latin", "character"], "word": "y"},
-            {"tags": ["Latin", "character"], "word": "Z"},
-            {"tags": ["Latin", "character"], "word": "z"},
-        ]})
+        data = self.run_data(
+            "(Latin script):  Aa  Bb  Cc  Dd  Ee  Ff  Gg  Hh  "
+            "Ii  Jj  Kk  Ll  Mm  Nn  Oo  Pp  Qq  Rr  Sſs  Tt  "
+            "Uu  Vv  Ww  Xx  Yy  Zz"
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"tags": ["Latin", "character"], "word": "A"},
+                    {"tags": ["Latin", "character"], "word": "a"},
+                    {"tags": ["Latin", "character"], "word": "B"},
+                    {"tags": ["Latin", "character"], "word": "b"},
+                    {"tags": ["Latin", "character"], "word": "C"},
+                    {"tags": ["Latin", "character"], "word": "c"},
+                    {"tags": ["Latin", "character"], "word": "D"},
+                    {"tags": ["Latin", "character"], "word": "d"},
+                    {"tags": ["Latin", "character"], "word": "E"},
+                    {"tags": ["Latin", "character"], "word": "e"},
+                    {"tags": ["Latin", "character"], "word": "F"},
+                    {"tags": ["Latin", "character"], "word": "f"},
+                    {"tags": ["Latin", "character"], "word": "G"},
+                    {"tags": ["Latin", "character"], "word": "g"},
+                    {"tags": ["Latin", "character"], "word": "H"},
+                    {"tags": ["Latin", "character"], "word": "h"},
+                    {"tags": ["Latin", "character"], "word": "I"},
+                    {"tags": ["Latin", "character"], "word": "i"},
+                    {"tags": ["Latin", "character"], "word": "J"},
+                    {"tags": ["Latin", "character"], "word": "j"},
+                    {"tags": ["Latin", "character"], "word": "K"},
+                    {"tags": ["Latin", "character"], "word": "k"},
+                    {"tags": ["Latin", "character"], "word": "L"},
+                    {"tags": ["Latin", "character"], "word": "l"},
+                    {"tags": ["Latin", "character"], "word": "M"},
+                    {"tags": ["Latin", "character"], "word": "m"},
+                    {"tags": ["Latin", "character"], "word": "N"},
+                    {"tags": ["Latin", "character"], "word": "n"},
+                    {"tags": ["Latin", "character"], "word": "O"},
+                    {"tags": ["Latin", "character"], "word": "o"},
+                    {"tags": ["Latin", "character"], "word": "P"},
+                    {"tags": ["Latin", "character"], "word": "p"},
+                    {"tags": ["Latin", "character"], "word": "Q"},
+                    {"tags": ["Latin", "character"], "word": "q"},
+                    {"tags": ["Latin", "character"], "word": "R"},
+                    {"tags": ["Latin", "character"], "word": "r"},
+                    {"tags": ["Latin", "character"], "word": "S"},
+                    {"tags": ["Latin", "character"], "word": "ſ"},
+                    {"tags": ["Latin", "character"], "word": "s"},
+                    {"tags": ["Latin", "character"], "word": "T"},
+                    {"tags": ["Latin", "character"], "word": "t"},
+                    {"tags": ["Latin", "character"], "word": "U"},
+                    {"tags": ["Latin", "character"], "word": "u"},
+                    {"tags": ["Latin", "character"], "word": "V"},
+                    {"tags": ["Latin", "character"], "word": "v"},
+                    {"tags": ["Latin", "character"], "word": "W"},
+                    {"tags": ["Latin", "character"], "word": "w"},
+                    {"tags": ["Latin", "character"], "word": "X"},
+                    {"tags": ["Latin", "character"], "word": "x"},
+                    {"tags": ["Latin", "character"], "word": "Y"},
+                    {"tags": ["Latin", "character"], "word": "y"},
+                    {"tags": ["Latin", "character"], "word": "Z"},
+                    {"tags": ["Latin", "character"], "word": "z"},
+                ]
+            },
+        )
 
     def test_script3(self):
-        data = self.run_data("(Variations of letter B):  Ḃḃ  Ḅḅ  Ḇḇ  Ƀƀ  Ɓɓ  Ƃƃ  ᵬ  ᶀ  ʙ  Ｂｂ  ȸ  ℔  Ꞗꞗ")
-        self.assertEqual(data, {"related": [
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "Ḃ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ḃ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "Ḅ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ḅ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "Ḇ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ḇ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "Ƀ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ƀ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "Ɓ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ɓ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "Ƃ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ƃ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ᵬ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ᶀ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ʙ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "Ｂ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ｂ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ȸ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "℔"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "Ꞗ"},
-            {"sense": "Variations of letter B",
-             "tags": ["letter"],
-             "word": "ꞗ"},
-        ]})
+        data = self.run_data(
+            "(Variations of letter B):  Ḃḃ  Ḅḅ  Ḇḇ  Ƀƀ  Ɓɓ  Ƃƃ  ᵬ  ᶀ  ʙ  Ｂｂ  ȸ  ℔  Ꞗꞗ"
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "Ḃ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ḃ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "Ḅ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ḅ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "Ḇ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ḇ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "Ƀ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ƀ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "Ɓ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ɓ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "Ƃ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ƃ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ᵬ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ᶀ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ʙ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "Ｂ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ｂ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ȸ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "℔",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "Ꞗ",
+                    },
+                    {
+                        "sense": "Variations of letter B",
+                        "tags": ["letter"],
+                        "word": "ꞗ",
+                    },
+                ]
+            },
+        )
 
     def test_script4(self):
         # This should get ignored
-        data = self.run_data('For more variations, see Appendix:Variations of "b".')
+        data = self.run_data(
+            'For more variations, see Appendix:Variations of "b".'
+        )
         self.assertEqual(data, {})
 
     def test_script5(self):
-        data = self.run_data('(other scripts) Β (B, “Beta”), Б (B, “Be”), '
-                             'В (V, “Ve”), ב‎ (b, “beth”)')
-        self.assertEqual(data, {"related": [
-            {"word": "Β", "roman": "B", "english": "Beta",
-             "sense": "other scripts"},
-            {"word": "Б", "roman": "B", "english": "Be"},
-            {"word": "В", "roman": "V", "english": "Ve"},
-            # XXX what should happen with the left-to-right mark here?
-            {"word": "ב\u200e", "roman": "b", "english": "beth"},
-        ]})
+        data = self.run_data(
+            "(other scripts) Β (B, “Beta”), Б (B, “Be”), "
+            "В (V, “Ve”), ב‎ (b, “beth”)"
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {
+                        "word": "Β",
+                        "roman": "B",
+                        "english": "Beta",
+                        "sense": "other scripts",
+                    },
+                    {"word": "Б", "roman": "B", "english": "Be"},
+                    {"word": "В", "roman": "V", "english": "Ve"},
+                    # XXX what should happen with the left-to-right mark here?
+                    {"word": "ב\u200e", "roman": "b", "english": "beth"},
+                ]
+            },
+        )
 
     def test_script6(self):
-        data = self.run_data("(Latin-script letters) letter; A a, B b, C c, "
-                             "D d, E e, F f, G g, H h, I i, J j, K k, L l, "
-                             "M m, N n, O o, P p, Q q, R r, S s, T t, U u, "
-                             "V v, W w, X x, Y y, Z z", lang="English")
-        self.assertEqual(data, {"related": [
-            {"tags": ["Latin", "letter"], "word": "letter"},
-            {"tags": ["Latin", "letter"], "word": "A"},
-            {"tags": ["Latin", "letter"], "word": "a"},
-            {"tags": ["Latin", "letter"], "word": "B"},
-            {"tags": ["Latin", "letter"], "word": "b"},
-            {"tags": ["Latin", "letter"], "word": "C"},
-            {"tags": ["Latin", "letter"], "word": "c"},
-            {"tags": ["Latin", "letter"], "word": "D"},
-            {"tags": ["Latin", "letter"], "word": "d"},
-            {"tags": ["Latin", "letter"], "word": "E"},
-            {"tags": ["Latin", "letter"], "word": "e"},
-            {"tags": ["Latin", "letter"], "word": "F"},
-            {"tags": ["Latin", "letter"], "word": "f"},
-            {"tags": ["Latin", "letter"], "word": "G"},
-            {"tags": ["Latin", "letter"], "word": "g"},
-            {"tags": ["Latin", "letter"], "word": "H"},
-            {"tags": ["Latin", "letter"], "word": "h"},
-            {"tags": ["Latin", "letter"], "word": "I"},
-            {"tags": ["Latin", "letter"], "word": "i"},
-            {"tags": ["Latin", "letter"], "word": "J"},
-            {"tags": ["Latin", "letter"], "word": "j"},
-            {"tags": ["Latin", "letter"], "word": "K"},
-            {"tags": ["Latin", "letter"], "word": "k"},
-            {"tags": ["Latin", "letter"], "word": "L"},
-            {"tags": ["Latin", "letter"], "word": "l"},
-            {"tags": ["Latin", "letter"], "word": "M"},
-            {"tags": ["Latin", "letter"], "word": "m"},
-            {"tags": ["Latin", "letter"], "word": "N"},
-            {"tags": ["Latin", "letter"], "word": "n"},
-            {"tags": ["Latin", "letter"], "word": "O"},
-            {"tags": ["Latin", "letter"], "word": "o"},
-            {"tags": ["Latin", "letter"], "word": "P"},
-            {"tags": ["Latin", "letter"], "word": "p"},
-            {"tags": ["Latin", "letter"], "word": "Q"},
-            {"tags": ["Latin", "letter"], "word": "q"},
-            {"tags": ["Latin", "letter"], "word": "R"},
-            {"tags": ["Latin", "letter"], "word": "r"},
-            {"tags": ["Latin", "letter"], "word": "S"},
-            {"tags": ["Latin", "letter"], "word": "s"},
-            {"tags": ["Latin", "letter"], "word": "T"},
-            {"tags": ["Latin", "letter"], "word": "t"},
-            {"tags": ["Latin", "letter"], "word": "U"},
-            {"tags": ["Latin", "letter"], "word": "u"},
-            {"tags": ["Latin", "letter"], "word": "V"},
-            {"tags": ["Latin", "letter"], "word": "v"},
-            {"tags": ["Latin", "letter"], "word": "W"},
-            {"tags": ["Latin", "letter"], "word": "w"},
-            {"tags": ["Latin", "letter"], "word": "X"},
-            {"tags": ["Latin", "letter"], "word": "x"},
-            {"tags": ["Latin", "letter"], "word": "Y"},
-            {"tags": ["Latin", "letter"], "word": "y"},
-            {"tags": ["Latin", "letter"], "word": "Z"},
-            {"tags": ["Latin", "letter"], "word": "z"},
-        ]})
+        data = self.run_data(
+            "(Latin-script letters) letter; A a, B b, C c, "
+            "D d, E e, F f, G g, H h, I i, J j, K k, L l, "
+            "M m, N n, O o, P p, Q q, R r, S s, T t, U u, "
+            "V v, W w, X x, Y y, Z z",
+            lang="English",
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"tags": ["Latin", "letter"], "word": "letter"},
+                    {"tags": ["Latin", "letter"], "word": "A"},
+                    {"tags": ["Latin", "letter"], "word": "a"},
+                    {"tags": ["Latin", "letter"], "word": "B"},
+                    {"tags": ["Latin", "letter"], "word": "b"},
+                    {"tags": ["Latin", "letter"], "word": "C"},
+                    {"tags": ["Latin", "letter"], "word": "c"},
+                    {"tags": ["Latin", "letter"], "word": "D"},
+                    {"tags": ["Latin", "letter"], "word": "d"},
+                    {"tags": ["Latin", "letter"], "word": "E"},
+                    {"tags": ["Latin", "letter"], "word": "e"},
+                    {"tags": ["Latin", "letter"], "word": "F"},
+                    {"tags": ["Latin", "letter"], "word": "f"},
+                    {"tags": ["Latin", "letter"], "word": "G"},
+                    {"tags": ["Latin", "letter"], "word": "g"},
+                    {"tags": ["Latin", "letter"], "word": "H"},
+                    {"tags": ["Latin", "letter"], "word": "h"},
+                    {"tags": ["Latin", "letter"], "word": "I"},
+                    {"tags": ["Latin", "letter"], "word": "i"},
+                    {"tags": ["Latin", "letter"], "word": "J"},
+                    {"tags": ["Latin", "letter"], "word": "j"},
+                    {"tags": ["Latin", "letter"], "word": "K"},
+                    {"tags": ["Latin", "letter"], "word": "k"},
+                    {"tags": ["Latin", "letter"], "word": "L"},
+                    {"tags": ["Latin", "letter"], "word": "l"},
+                    {"tags": ["Latin", "letter"], "word": "M"},
+                    {"tags": ["Latin", "letter"], "word": "m"},
+                    {"tags": ["Latin", "letter"], "word": "N"},
+                    {"tags": ["Latin", "letter"], "word": "n"},
+                    {"tags": ["Latin", "letter"], "word": "O"},
+                    {"tags": ["Latin", "letter"], "word": "o"},
+                    {"tags": ["Latin", "letter"], "word": "P"},
+                    {"tags": ["Latin", "letter"], "word": "p"},
+                    {"tags": ["Latin", "letter"], "word": "Q"},
+                    {"tags": ["Latin", "letter"], "word": "q"},
+                    {"tags": ["Latin", "letter"], "word": "R"},
+                    {"tags": ["Latin", "letter"], "word": "r"},
+                    {"tags": ["Latin", "letter"], "word": "S"},
+                    {"tags": ["Latin", "letter"], "word": "s"},
+                    {"tags": ["Latin", "letter"], "word": "T"},
+                    {"tags": ["Latin", "letter"], "word": "t"},
+                    {"tags": ["Latin", "letter"], "word": "U"},
+                    {"tags": ["Latin", "letter"], "word": "u"},
+                    {"tags": ["Latin", "letter"], "word": "V"},
+                    {"tags": ["Latin", "letter"], "word": "v"},
+                    {"tags": ["Latin", "letter"], "word": "W"},
+                    {"tags": ["Latin", "letter"], "word": "w"},
+                    {"tags": ["Latin", "letter"], "word": "X"},
+                    {"tags": ["Latin", "letter"], "word": "x"},
+                    {"tags": ["Latin", "letter"], "word": "Y"},
+                    {"tags": ["Latin", "letter"], "word": "y"},
+                    {"tags": ["Latin", "letter"], "word": "Z"},
+                    {"tags": ["Latin", "letter"], "word": "z"},
+                ]
+            },
+        )

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -497,6 +497,10 @@ foo
 {{head|ga|mutated noun}}
 
 1. Celtic
+
+====Translations====
+
+foo
             """
         )
         self.assertEqual(

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -429,3 +429,26 @@ foo
             data[0].get("senses"),
             [{"glosses": ["An adult castrated male of cattle."]}],
         )
+
+    @patch(
+        "wikitextprocessor.Wtp.get_page",
+        return_value=Page("test", 10, None, False, "", "wikitext"),
+    )
+    def test_ARF_page(self, mock_get_page) -> None:
+        """
+        test wikitext copied from page https://en.wiktionary.org/wiki/ARF
+        """
+        data = self.runpage(
+            """
+==English==
+
+===Phrase===
+{{head|en|phrase}}
+
+# {{lb|en|computing}} "[[abort|Abort]], [[retry|Retry]], [[fail|Fail]]?"
+            """
+        )
+        self.assertEqual(
+            data[0].get("senses", [{}])[0].get("glosses"),
+            ["\"Abort, Retry, Fail?\""]
+        )

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -452,3 +452,33 @@ foo
             data[0].get("senses", [{}])[0].get("glosses"),
             ["\"Abort, Retry, Fail?\""]
         )
+
+
+    @patch(
+        "wikitextprocessor.Wtp.get_page",
+        return_value=Page(
+            "Template:ux",
+            10,
+            None,
+            False,
+            "Name given to a number of one-piece attires",
+            "wikitext"
+        ),
+    )
+    def test_ux_template_in_gloss(self, mock_get_page) -> None:
+        """
+        test wikitext copied from page https://en.wiktionary.org/wiki/onesie
+        """
+        data = self.runpage(
+            """
+==English==
+
+===Noun===
+
+# {{ux|en|Name given to a number of one-piece attires}}
+            """
+        )
+        self.assertEqual(
+            data[0].get("senses", [{}])[0].get("glosses"),
+            ["Name given to a number of one-piece attires"]
+        )

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -7,125 +7,140 @@ import unittest
 
 from unittest.mock import patch
 
+
 from wikitextprocessor import Wtp, Page
 from wiktextract.config import WiktionaryConfig
 from wiktextract.page import parse_page
+from wiktextract.thesaurus import close_thesaurus_db
 from wiktextract.wxr_context import WiktextractContext
 
 
 class PageTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 20000
-        conf1 = WiktionaryConfig(capture_language_codes=None,
-                                 capture_translations=True,
-                                 capture_pronunciation=True,
-                                 capture_linkages=True,
-                                 capture_compounds=True,
-                                 capture_redirects=True,
-                                 capture_examples=True)
+        conf1 = WiktionaryConfig(
+            capture_language_codes=None,
+            capture_translations=True,
+            capture_pronunciation=True,
+            capture_linkages=True,
+            capture_compounds=True,
+            capture_redirects=True,
+            capture_examples=True,
+        )
         self.wxr = WiktextractContext(Wtp(), conf1)
         self.wxr.wtp.analyze_templates()
         self.wxr.wtp.start_page("testpage")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def runpage(self, text):
         assert isinstance(text, str)
         return parse_page(self.wxr, self.wxr.wtp.title, text)
 
     def test_page1(self):
-        lst = self.runpage("""
+        lst = self.runpage(
+            """
 ==Swedish==
 ===Noun===
 foo f
 
 # sense 1
 # sense 2
-""")
+"""
+        )
         # XXX should also capture examples
-        self.assertEqual(lst, [
-            {
-                "forms": [
-                    {
-                        "form": "foo",
-                        "tags": [
-                            "canonical",
-                            "feminine"
-                        ]
-                    }
-                ],
-                "lang": "Swedish",
-                "lang_code": "sv",
-                "pos": "noun",
-                "senses": [
-                    {
-                        "glosses": [
-                            "sense 1"
-                        ],
-                    },
-                    {
-                        "glosses": [
-                            "sense 2"
-                        ],
-                    }
-                ],
-                "word": "testpage"
-            }
-        ])
+        self.assertEqual(
+            lst,
+            [
+                {
+                    "forms": [
+                        {"form": "foo", "tags": ["canonical", "feminine"]}
+                    ],
+                    "lang": "Swedish",
+                    "lang_code": "sv",
+                    "pos": "noun",
+                    "senses": [
+                        {
+                            "glosses": ["sense 1"],
+                        },
+                        {
+                            "glosses": ["sense 2"],
+                        },
+                    ],
+                    "word": "testpage",
+                }
+            ],
+        )
 
     def test_page2(self):
-        lst = self.runpage("""
+        lst = self.runpage(
+            """
 ==Swedish==
 ===Noun===
 testpage f
 
 # sense 1
-""")
+"""
+        )
         # XXX should also capture examples
-        self.assertEqual(lst, [
-            {
-                "lang": "Swedish",
-                "lang_code": "sv",
-                "pos": "noun",
-                "senses": [
-                    {
-                        "glosses": ["sense 1"],
-                        "tags": ["feminine"],
-                    },
-                ],
-                "word": "testpage"
-            }
-        ])
+        self.assertEqual(
+            lst,
+            [
+                {
+                    "lang": "Swedish",
+                    "lang_code": "sv",
+                    "pos": "noun",
+                    "senses": [
+                        {
+                            "glosses": ["sense 1"],
+                            "tags": ["feminine"],
+                        },
+                    ],
+                    "word": "testpage",
+                }
+            ],
+        )
 
     def test_page3(self):
         self.wxr.wtp.start_page("Unsupported titles/C sharp")
-        lst = self.runpage("""
+        lst = self.runpage(
+            """
 ==Swedish==
 ===Noun===
 foo
 
 # sense 1
-""")
+"""
+        )
         # XXX should also capture examples
-        self.assertEqual(lst, [
-            {
-                "forms": [
-                    {"form": "foo", "tags": ["canonical"]},
-                ],
-                "lang": "Swedish",
-                "lang_code": "sv",
-                "pos": "noun",
-                "senses": [
-                    {
-                        "glosses": ["sense 1"],
-                    },
-                ],
-                "word": "C#"
-            }
-        ])
+        self.assertEqual(
+            lst,
+            [
+                {
+                    "forms": [
+                        {"form": "foo", "tags": ["canonical"]},
+                    ],
+                    "lang": "Swedish",
+                    "lang_code": "sv",
+                    "pos": "noun",
+                    "senses": [
+                        {
+                            "glosses": ["sense 1"],
+                        },
+                    ],
+                    "word": "C#",
+                }
+            ],
+        )
 
     def test_page4(self):
         self.wxr.wtp.start_page("foo")
-        lst = self.runpage("""
+        lst = self.runpage(
+            """
 ==English==
 
 ===Noun===
@@ -144,51 +159,68 @@ foo
 * (sense abc) zap
 * verbs: zip, zump
 
-""")
+"""
+        )
         print("RETURNED:", json.dumps(lst, indent=2, sort_keys=True))
         # XXX should also capture examples
-        self.assertEqual(lst, [
-            {
-                "lang": "English",
-                "lang_code": "en",
-                "pos": "noun",
-                "related": [
-                    {"sense": "sense abc", "word": "zap"},
-                    {"word": "zip", "tags": ["verb"]},
-                    {"word": "zump", "tags": ["verb"]},
-                ] ,
-                "senses": [
-                    {
-                        "glosses": ["sense 1"],
-                    },
-                    {
-                        "glosses": ["sense 2"],
-                    },
-                    {
-                        "glosses": ["mushroom"],
-                        "raw_glosses": ["(mycology) mushroom"],
-                        "topics": ["biology", "mycology","natural-sciences"],
-                    },
-                    {
-                        "glosses": ["one who foos"],
-                        "raw_glosses": ["(person) one who foos"],
-                        "tags": ["person"],
-                    },
-                ],
-                "translations": [
-                    {"word": "fuu", "lang": "Finnish", "code": "fi"},
-                    {"word": "bar", "lang": "Swedish", "code": "sv",
-                     "tags": ["masculine"]},
-                    {"word": "hop", "lang": "Swedish", "code": "sv",
-                     "tags": ["feminine"]},
-                ],
-                "word": "foo",
-            }
-        ])
+        self.assertEqual(
+            lst,
+            [
+                {
+                    "lang": "English",
+                    "lang_code": "en",
+                    "pos": "noun",
+                    "related": [
+                        {"sense": "sense abc", "word": "zap"},
+                        {"word": "zip", "tags": ["verb"]},
+                        {"word": "zump", "tags": ["verb"]},
+                    ],
+                    "senses": [
+                        {
+                            "glosses": ["sense 1"],
+                        },
+                        {
+                            "glosses": ["sense 2"],
+                        },
+                        {
+                            "glosses": ["mushroom"],
+                            "raw_glosses": ["(mycology) mushroom"],
+                            "topics": [
+                                "biology",
+                                "mycology",
+                                "natural-sciences",
+                            ],
+                        },
+                        {
+                            "glosses": ["one who foos"],
+                            "raw_glosses": ["(person) one who foos"],
+                            "tags": ["person"],
+                        },
+                    ],
+                    "translations": [
+                        {"word": "fuu", "lang": "Finnish", "code": "fi"},
+                        {
+                            "word": "bar",
+                            "lang": "Swedish",
+                            "code": "sv",
+                            "tags": ["masculine"],
+                        },
+                        {
+                            "word": "hop",
+                            "lang": "Swedish",
+                            "code": "sv",
+                            "tags": ["feminine"],
+                        },
+                    ],
+                    "word": "foo",
+                }
+            ],
+        )
 
     def test_page5(self):
         self.wxr.wtp.start_page("foo")
-        lst = self.runpage("""
+        lst = self.runpage(
+            """
 ==English==
 
 ===Noun===
@@ -215,107 +247,137 @@ foo
 * (sense abc) zap
 * verbs: zip, zump
 
-""")
+"""
+        )
         print("RETURNED:", json.dumps(lst, indent=2, sort_keys=True))
-        self.assertEqual(lst, [
-            {
-                "lang": "English",
-                "lang_code": "en",
-                "pos": "noun",
-                "related": [
-                    {"sense": "sense abc", "word": "zap"},
-                    {"word": "zip", "tags": ["verb"]},
-                    {"word": "zump", "tags": ["verb"]},
-                ] ,
-                "senses": [
-                    {
-                        "glosses": ["sense 1", "subsense 1"],
-                        "examples": [{"text": "subexample 1"}]
-                    },
-                    {
-                        "glosses": ["sense 1", "subsense 2"],
-                    },
-                    {
-                        "glosses": ["sense 1"],
-                        "examples": [{"text":
-                                    "example 1 causes sense 1 to get pushed"}]
-                    },
-                    {
-                        "glosses": ["sense 2"],
-                    },
-                    {
-                        "glosses": ["mushroom"],
-                        "raw_glosses": ["(mycology) mushroom"],
-                        "topics": ["biology", "mycology", "natural-sciences"],
-                        "examples": [{"text": "example 2"},
-                                     {"text": "example 3"}],
-                    },
-                    {
-                        "glosses": ["one who foos",
-                                    "one who foos more specifically"],
-                        "raw_glosses": ["(person) one who foos",
-                                    "one who foos more specifically"],
-                        "tags": ["person"],
-                    },
-                    {
-                        "glosses": ["one who foos",
-                                    "another one who foos"],
-                        "raw_glosses": ["(person) one who foos",
-                                    "another one who foos"],
-                        "tags": ["person"],
-                    },
-                ],
-                "translations": [
-                    {"word": "fuu", "lang": "Finnish", "code": "fi"},
-                    {"word": "bar", "lang": "Swedish", "code": "sv",
-                     "tags": ["masculine"]},
-                    {"word": "hop", "lang": "Swedish", "code": "sv",
-                     "tags": ["feminine"]},
-                ],
-                "word": "foo",
-            }
-        ])
+        self.assertEqual(
+            lst,
+            [
+                {
+                    "lang": "English",
+                    "lang_code": "en",
+                    "pos": "noun",
+                    "related": [
+                        {"sense": "sense abc", "word": "zap"},
+                        {"word": "zip", "tags": ["verb"]},
+                        {"word": "zump", "tags": ["verb"]},
+                    ],
+                    "senses": [
+                        {
+                            "glosses": ["sense 1", "subsense 1"],
+                            "examples": [{"text": "subexample 1"}],
+                        },
+                        {
+                            "glosses": ["sense 1", "subsense 2"],
+                        },
+                        {
+                            "glosses": ["sense 1"],
+                            "examples": [
+                                {
+                                    "text": "example 1 causes sense 1 to get pushed"
+                                }
+                            ],
+                        },
+                        {
+                            "glosses": ["sense 2"],
+                        },
+                        {
+                            "glosses": ["mushroom"],
+                            "raw_glosses": ["(mycology) mushroom"],
+                            "topics": [
+                                "biology",
+                                "mycology",
+                                "natural-sciences",
+                            ],
+                            "examples": [
+                                {"text": "example 2"},
+                                {"text": "example 3"},
+                            ],
+                        },
+                        {
+                            "glosses": [
+                                "one who foos",
+                                "one who foos more specifically",
+                            ],
+                            "raw_glosses": [
+                                "(person) one who foos",
+                                "one who foos more specifically",
+                            ],
+                            "tags": ["person"],
+                        },
+                        {
+                            "glosses": ["one who foos", "another one who foos"],
+                            "raw_glosses": [
+                                "(person) one who foos",
+                                "another one who foos",
+                            ],
+                            "tags": ["person"],
+                        },
+                    ],
+                    "translations": [
+                        {"word": "fuu", "lang": "Finnish", "code": "fi"},
+                        {
+                            "word": "bar",
+                            "lang": "Swedish",
+                            "code": "sv",
+                            "tags": ["masculine"],
+                        },
+                        {
+                            "word": "hop",
+                            "lang": "Swedish",
+                            "code": "sv",
+                            "tags": ["feminine"],
+                        },
+                    ],
+                    "word": "foo",
+                }
+            ],
+        )
 
     def test_page6(self):
-        lst = self.runpage("""
+        lst = self.runpage(
+            """
 ==Japanese==
 ===Verb===
 foo
 
 # sense 1
 #: <dl><dd><span class="Jpan" lang="ja"><a href="/wiki/%E3%81%94%E9%A3%AF#Japanese" title="ご飯">ご<ruby>飯<rp>(</rp><rt>はん</rt><rp>)</rp></ruby></a>を<b><ruby>食<rp>(</rp><rt>た</rt><rp>)</rp></ruby>べる</b></span><dl><dd><i>go-han o <b>taberu</b></i></dd><dd>to <b>eat</b> a meal</dd></dl></dd></dl>
-""")
-        self.assertEqual(lst, [
-            {
-                "forms": [
-                    {
-                        "form": "foo",
-                        "tags": [
-                            "canonical",
-                        ]
-                    }
-                ],
-                "lang": "Japanese",
-                "lang_code": "ja",
-                "pos": "verb",
-                "senses": [
-                    {
-                        "glosses": [
-                            "sense 1"
-                        ],
-                        "examples":
-                            [{"english": "to eat a meal",
-                              "roman": "go-han o taberu",
-                              "ruby": [
-                                       ('飯', 'はん'),
-                                       ('食', 'た')
-                                      ],
-                              "text": "ご飯を食べる"}],
-                    },
-                ],
-                "word": "testpage"
-            }
-        ])
+"""
+        )
+        self.assertEqual(
+            lst,
+            [
+                {
+                    "forms": [
+                        {
+                            "form": "foo",
+                            "tags": [
+                                "canonical",
+                            ],
+                        }
+                    ],
+                    "lang": "Japanese",
+                    "lang_code": "ja",
+                    "pos": "verb",
+                    "senses": [
+                        {
+                            "glosses": ["sense 1"],
+                            "examples": [
+                                {
+                                    "english": "to eat a meal",
+                                    "roman": "go-han o taberu",
+                                    "ruby": [("飯", "はん"), ("食", "た")],
+                                    "text": "ご飯を食べる",
+                                }
+                            ],
+                        },
+                    ],
+                    "word": "testpage",
+                }
+            ],
+        )
+
 
     @patch(
         "wikitextprocessor.Wtp.get_page",
@@ -342,4 +404,28 @@ foo
                     "word": "你们"
                 }
             ],
+        )
+
+    @patch(
+        "wikitextprocessor.Wtp.get_page",
+        return_value=Page(title="Template:test", namespace_id=10, body=""),
+    )
+    def test_catlangname_template_in_headword_line(self, mock_get_page) -> None:
+        """
+        gloss data should be extracted when template catlangname is in the
+        headword line, GitHub issue #285
+        test wikitext from page https://en.wiktionary.org/wiki/ox
+        """
+        data = self.runpage(
+            """
+==English==
+
+===Noun===
+{{en-noun|oxen|oxes|pl2qual=nonstandard}} {{catlangname|en|nouns with irregular plurals|two-letter words}}
+
+# An adult castrated male of cattle."""
+        )
+        self.assertEqual(
+            data[0].get("senses"),
+            [{"glosses": ["An adult castrated male of cattle."]}],
         )

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -7,7 +7,6 @@ import unittest
 
 from unittest.mock import patch
 
-
 from wikitextprocessor import Wtp, Page
 from wiktextract.config import WiktionaryConfig
 from wiktextract.page import parse_page

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -3,21 +3,27 @@
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.form_descriptions import parse_translation_desc
+from wiktextract.thesaurus import close_thesaurus_db
 from wiktextract.translations import parse_translation_item_text
+from wiktextract.wxr_context import WiktextractContext
 
 
 class TrTests(unittest.TestCase):
-
     def setUp(self):
         self.maxDiff = 20000
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("abolitionism")  # Note: some tests use last char
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def runtr(self, item, sense=None, pos_datas=None,
               lang=None, langcode=None, translations_from_template=None,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,19 +3,25 @@
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
 import unittest
-from wiktextract.wxr_context import WiktextractContext
+
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.datautils import split_slashes
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
 
 
 class UtilsTests(unittest.TestCase):
-
     def setUp(self):
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
-
         self.wxr.wtp.start_page("testpage")
         self.wxr.wtp.start_section("English")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def test_slashes1(self):
         ret = split_slashes(self.wxr, "foo ")
@@ -40,15 +46,16 @@ class UtilsTests(unittest.TestCase):
     def test_slashes6(self):
         ret = split_slashes(self.wxr, "foo/bar zap a/b")
         print("ret:", ret)
-        self.assertEqual(ret, ["bar zap a", "bar zap b",
-                               "foo zap a", "foo zap b"])
+        self.assertEqual(
+            ret, ["bar zap a", "bar zap b", "foo zap a", "foo zap b"]
+        )
 
     def test_slashes7(self):
         self.wxr.wtp.add_page("foo", 0, "x")
-        assert self.wxr.wtp.page_exists("foo")
+        self.assertTrue(self.wxr.wtp.page_exists("foo"))
         ret = split_slashes(self.wxr, "foo/bar zap a/b")
-        print("ret:", ret)
         # XXX this response is still perhaps not what we want with the page
         # existing
-        self.assertEqual(ret, ["bar zap a", "bar zap b",
-                               "foo zap a", "foo zap b"])
+        self.assertEqual(
+            ret, ["bar zap a", "bar zap b", "foo zap a", "foo zap b"]
+        )

--- a/tests/test_zh_headword.py
+++ b/tests/test_zh_headword.py
@@ -8,6 +8,15 @@ from wiktextract.wxr_context import WiktextractContext
 
 
 class TestHeadword(TestCase):
+    def setUp(self):
+        self.wxr = WiktextractContext(Wtp(lang_code="zh"), Mock())
+
+    def tearDown(self):
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
+
     @patch(
         "wikitextprocessor.Wtp.node_to_wikitext",
         return_value='<strong class="Latn headword" lang="en">manga</strong> ([[可數|可數]] & [[不可數|不可數]]，複數 <b class="Latn form-of lang-en p-form-of" lang="en"><strong class="selflink">manga</strong></b> <small>或</small> <b class="Latn form-of lang-en p-form-of" lang="en">[[mangas#英語|mangas]]</b>)',
@@ -19,12 +28,8 @@ class TestHeadword(TestCase):
         node = Mock()
         node.args = [["en-noun"]]
         page_data = [{}]
-        wtp = Wtp()
-        wtp.title = "manga"
-        wxr = WiktextractContext(wtp, Mock())
-        extract_headword_line(wxr, page_data, node, "en")
-        wtp.close_db_conn()
-        close_thesaurus_db(wxr.thesaurus_db_path, wxr.thesaurus_db_conn)
+        self.wxr.wtp.title = "manga"
+        extract_headword_line(self.wxr, page_data, node, "en")
         self.assertEqual(
             page_data,
             [
@@ -49,12 +54,8 @@ class TestHeadword(TestCase):
         node = Mock()
         node.args = [["nl-noun"]]
         page_data = [{}]
-        wtp = Wtp()
-        wtp.title = "manga"
-        wxr = WiktextractContext(wtp, Mock())
-        extract_headword_line(wxr, page_data, node, "nl")
-        wtp.close_db_conn()
-        close_thesaurus_db(wxr.thesaurus_db_path, wxr.thesaurus_db_conn)
+        self.wxr.wtp.title = "manga"
+        extract_headword_line(self.wxr, page_data, node, "nl")
         self.assertEqual(
             page_data,
             [
@@ -79,12 +80,8 @@ class TestHeadword(TestCase):
         node = Mock()
         node.args = [["head"]]
         page_data = [{}]
-        wtp = Wtp()
-        wtp.title = "-κρατίας"
-        wxr = WiktextractContext(wtp, Mock())
-        extract_headword_line(wxr, page_data, node, "grc")
-        wtp.close_db_conn()
-        close_thesaurus_db(wxr.thesaurus_db_path, wxr.thesaurus_db_conn)
+        self.wxr.wtp.title = "-κρατίας"
+        extract_headword_line(self.wxr, page_data, node, "grc")
         self.assertEqual(
             page_data,
             [

--- a/tests/test_zh_linkage.py
+++ b/tests/test_zh_linkage.py
@@ -2,8 +2,9 @@ import unittest
 
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
-from wiktextract.wxr_context import WiktextractContext
 from wiktextract.extractor.zh.linkage import extract_linkages
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
 
 
 class TestLinkage(unittest.TestCase):
@@ -14,6 +15,9 @@ class TestLinkage(unittest.TestCase):
 
     def tearDown(self):
         self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
 
     def test_sense_term_list(self):
         page_data = [

--- a/wiktextract/clean.py
+++ b/wiktextract/clean.py
@@ -1222,6 +1222,7 @@ def to_math(text):
     # print("math text final: {!r}".format(text))
     return text
 
+
 def bold_follows(parts, i):
     """Checks if there is a bold (''') in parts after parts[i].  We allow
     intervening italics ('')."""
@@ -1232,7 +1233,8 @@ def bold_follows(parts, i):
         if p.startswith("'''"):
             return True
     return False
-    
+
+
 def remove_italic_and_bold(text):
     """Based on token_iter in wikitextprocessor"""
     assert isinstance(text, str)
@@ -1350,8 +1352,10 @@ def clean_value(wxr, title, no_strip=False, no_html_strip=False):
     # title = re.sub(r"\{\{[^}]+\}\}", "", title)
     # Remove tables
     title = re.sub(r"(?s)\{\|.*?\|\}", "\n", title)
+    # Remove second reference tags (<ref name="ref_name"/>)
+    title = re.sub(r"<ref\s+name=\"[^\"]+\"\s*/>", "", title)
     # Remove references (<ref>...</ref>).
-    title = re.sub(r"(?is)<ref\b\s*[^>]*?>\s*.*?</ref\s*>", "", title)
+    title = re.sub(r"(?is)<ref\b\s*[^>/]*?>\s*.*?</ref\s*>", "", title)
     # Replace <span>...</span> by stripped content without newlines
     title = re.sub(r"(?is)<span\b\s*[^>]*?>(.*?)\s*</span\s*>",
                    lambda m: re.sub(r"\s+", " ", m.group(1)),

--- a/wiktextract/extractor/en/page.py
+++ b/wiktextract/extractor/en/page.py
@@ -1193,18 +1193,21 @@ def parse_language(wxr, langnode, language, lang_code):
     def process_gloss_without_list(
         nodes: List[Union[WikiNode, str]], pos_type: str, pos_data: Dict
     ) -> None:
-        # gloss text might not be inside a list
+        # gloss text might not inside a list
         header_nodes = []
         gloss_nodes = []
         for node in strip_nodes(nodes):
-            if isinstance(node, WikiNode) and node.kind == NodeKind.TEMPLATE:
-                template_name = node.args[0][0]
-                if (
-                    template_name == "head"
-                    or template_name.startswith(f"{lang_code}-")
-                ):
-                    header_nodes.append(node)
-                    continue
+            if isinstance(node, WikiNode):
+                if node.kind == NodeKind.TEMPLATE:
+                    template_name = node.args[0][0]
+                    if (
+                            template_name == "head"
+                            or template_name.startswith(f"{lang_code}-")
+                    ):
+                        header_nodes.append(node)
+                        continue
+                elif node.kind in LEVEL_KINDS:  # following nodes are not gloss
+                    break
             gloss_nodes.append(node)
 
         if len(header_nodes) > 0:

--- a/wiktextract/extractor/en/page.py
+++ b/wiktextract/extractor/en/page.py
@@ -1166,7 +1166,6 @@ def parse_language(wxr, langnode, language, lang_code):
                         common_data["head_nr"] = head_group
                     parse_sense_node(node, common_data, pos)
 
-
         # If there are no senses extracted, add a dummy sense.  We want to
         # keep tags extracted from the head for the dummy sense.
         push_sense()  # Make sure unfinished data pushed, and start clean sense
@@ -1646,6 +1645,10 @@ def parse_language(wxr, langnode, language, lang_code):
                         data_extend(wxr, sense_data, "tags", tags)
                         data_append(wxr, sense_data, "form_of", dt)
 
+        if len(sense_data) == 0:
+            if len(sense_base.get("tags")) == 0:
+                del sense_base["tags"]
+            sense_data.update(sense_base)
         if push_sense():
             # push_sense succeded in adding a sense to pos_data
             added = True

--- a/wiktextract/extractor/en/page.py
+++ b/wiktextract/extractor/en/page.py
@@ -1029,11 +1029,10 @@ def parse_language(wxr, langnode, language, lang_code):
                 # There's head_tag_re that seems like a regex meant
                 # to identify head templates. Too bad it's None.
 
-                # stop processing at {{category}}, {{cat}}... etc.
+                # ignore {{category}}, {{cat}}... etc.
                 if node.args[0][0] in stop_head_at_these_templates:
                     # we've reached a template that should be at the end,
-                    # just break without special processing
-                    break
+                    continue
 
                 # skip these templates; panel_templates is already used
                 # to skip certain templates else, but it also applies to
@@ -1766,7 +1765,7 @@ def parse_language(wxr, langnode, language, lang_code):
             # under "forms".
             if wxr.config.capture_inflections:
                 tablecontext = None
-                m = re.search("{{([^}{|]+)\|?", text)
+                m = re.search(r"{{([^}{|]+)\|?", text)
                 if m:
                     template_name = m.group(1)
                     tablecontext = TableContext(template_name)
@@ -2931,7 +2930,7 @@ def parse_language(wxr, langnode, language, lang_code):
                                      template_fn=usex_template_fn)
                 subtext = re.sub(r"\s*\(please add an English "
                                  r"translation of this "
-                                 "(example|usage example|quote)\)",
+                                 r"(example|usage example|quote)\)",
                                  "", subtext).strip()
                 subtext = re.sub(r"\^\([^)]*\)", "", subtext)
                 subtext = re.sub(r"\s*[―—]+$", "", subtext)

--- a/wiktextract/form_descriptions.py
+++ b/wiktextract/form_descriptions.py
@@ -938,7 +938,6 @@ def decode_tags(src, allow_any=False, no_unknown_starts=False):
             u = check_unknown(len(lst), max_last_i, len(lst))
             if u:
                 # print("end max_last_i={}".format(max_last_i))
-                last_paths = pos_paths[-1]
                 for path in list(paths):  # Copy in case it is the last pos
                     pos_paths[-1].append(u + path)
 


### PR DESCRIPTION
If we break at the category template, the gloss list nodes after it won't be processed. Fixes #285.