### PR TITLE
Fix `wiktextract.extractor` not found error when install from source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ wiktwords = "wiktextract.wiktwords:main"
 [project.urls]
 homepage = "https://github.com/tatuylonen/wiktextract"
 
-[tool.setuptools]
-packages = ["wiktextract"]
+[tool.setuptools.packages.find]
+exclude = ["languages", "overrides", "tests", "tools", "usertools"]
 
 [tool.setuptools.package-data]
 wiktextract = [


### PR DESCRIPTION
Set `tool.setuptools.packages` won't include subpackages. The correct fix is to using the
"src-layout"(https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#src-layout). Otherwise we'll have to add path to the `exclude` list when a new directory is created.