### PR TITLE
Add French WIktionary extractor code

### DIFF
--- a/wiktextract/clean.py
+++ b/wiktextract/clean.py
@@ -1422,11 +1422,20 @@ def clean_value(wxr, title, no_strip=False, no_html_strip=False):
     # Remove any edit links to local pages
     title = re.sub(r"\[//[^]\s]+\s+edit\s*\]", "", title)
     # Replace links by their text
+
+    catagory_ns_data = wxr.wtp.NAMESPACE_DATA.get("Category", {})
+    category_ns_names = {catagory_ns_data.get("name")} | set(
+        catagory_ns_data.get("aliases")
+    )
+    catagory_names_pattern = rf"(?:{'|'.join(category_ns_names)})"
     while True:
         # Links may be nested, so keep replacing until there is no more change.
         orig = title
-        title = re.sub(r"(?si)\[\[\s*Category\s*:\s*([^]]+?)\s*\]\]",
-                       r"", title)
+        title = re.sub(
+            rf"(?si)\[\[\s*{catagory_names_pattern}\s*:\s*([^]]+?)\s*\]\]",
+            "",
+            title,
+        )
         title = re.sub(r"(?s)\[\[\s*:?([^]|#<>]+?)\s*(#[^][|<>]*?)?\]\]",
                        repl_1, title)
         title = re.sub(r"(?s)\[\[\s*(([a-zA-z0-9]+)\s*:)?\s*([^][#|<>]+?)"

--- a/wiktextract/data/fr/languages.json
+++ b/wiktextract/data/fr/languages.json
@@ -551,6 +551,9 @@
   "alc": [
     "Kawésqar"
   ],
+  "alchuka": [
+    "Alchuka"
+  ],
   "ald": [
     "Alladian"
   ],
@@ -1370,6 +1373,9 @@
   "bal": [
     "Baloutche"
   ],
+  "bala (Chine)": [
+    "Bala (Chine)"
+  ],
   "ban": [
     "Balinais"
   ],
@@ -1960,6 +1966,9 @@
   ],
   "bkn": [
     "Beketan"
+  ],
+  "bko": [
+    "Kwa’"
   ],
   "bkq": [
     "Bakairí"
@@ -5792,6 +5801,9 @@
   "gwu": [
     "Guwamu"
   ],
+  "gwx": [
+    "Gua"
+  ],
   "gya": [
     "Gbaya du Nord-Ouest"
   ],
@@ -5849,6 +5861,9 @@
   "hac": [
     "Gurani"
   ],
+  "hachijo": [
+    "Hachijō"
+  ],
   "had": [
     "Hatam"
   ],
@@ -5896,6 +5911,9 @@
   ],
   "hay": [
     "Haya"
+  ],
+  "hayato": [
+    "Hayato"
   ],
   "haz": [
     "Hazara"
@@ -7358,6 +7376,9 @@
   "khe": [
     "Korowai"
   ],
+  "khf": [
+    "Khuen"
+  ],
   "khg": [
     "Kham"
   ],
@@ -8267,6 +8288,9 @@
   "kya": [
     "Kwaya"
   ],
+  "kyakala": [
+    "Kyakala"
+  ],
   "kyc": [
     "Kyaka"
   ],
@@ -8503,6 +8527,9 @@
   ],
   "ldi": [
     "Laari"
+  ],
+  "ldm": [
+    "Landuma"
   ],
   "ldn": [
     "Láadan"
@@ -10061,8 +10088,17 @@
   "moyen danois": [
     "Moyen danois"
   ],
+  "moyen japonais": [
+    "Moyen japonais"
+  ],
   "moyen khmer": [
     "Moyen khmer"
+  ],
+  "moyen môn": [
+    "Moyen môn"
+  ],
+  "moyen okinawaïen": [
+    "Moyen okinawaïen"
   ],
   "moyen polonais": [
     "Moyen polonais"
@@ -10736,6 +10772,9 @@
   "navarro-aragonais": [
     "Navarro-aragonais"
   ],
+  "naw": [
+    "Nawuri"
+  ],
   "nay": [
     "Ngarrindjeri"
   ],
@@ -10762,6 +10801,9 @@
   ],
   "nbh": [
     "Ngamo"
+  ],
+  "nbi": [
+    "Mao"
   ],
   "nbk": [
     "Nake"
@@ -10995,7 +11037,7 @@
     "Ngando (République centrafricaine)"
   ],
   "nge": [
-    "Ngemba"
+    "Mankon"
   ],
   "ngf": [
     "Langues trans-néo-guinéennes"
@@ -11198,6 +11240,9 @@
   "njm": [
     "Angami"
   ],
+  "njn": [
+    "Liangmai"
+  ],
   "njo": [
     "Ao"
   ],
@@ -11220,7 +11265,7 @@
     "Khezha"
   ],
   "nki": [
-    "Naga de Thangal"
+    "Thangal"
   ],
   "nkj": [
     "Nakai"
@@ -11293,6 +11338,9 @@
   ],
   "nmf": [
     "Tangkhul naga"
+  ],
+  "nmh": [
+    "Monsang"
   ],
   "nmk": [
     "Namakura"
@@ -11634,7 +11682,7 @@
     "Nyole"
   ],
   "nuk": [
-    "Nuu-chah-nulth"
+    "Nuuchahnulth"
   ],
   "nul": [
     "Nusa laut"
@@ -12980,6 +13028,9 @@
   "proto-altaïque": [
     "Proto-altaïque"
   ],
+  "proto-aslien": [
+    "Proto-aslien"
+  ],
   "proto-athapascan": [
     "Proto-athapascan"
   ],
@@ -13016,6 +13067,9 @@
   "proto-basque": [
     "Proto-basque"
   ],
+  "proto-berbère": [
+    "Proto-berbère"
+  ],
   "proto-bodique oriental": [
     "Proto-bodique oriental"
   ],
@@ -13042,6 +13096,9 @@
   ],
   "proto-dura": [
     "Proto-dura"
+  ],
+  "proto-eskimo": [
+    "Proto-eskimo"
   ],
   "proto-fennique": [
     "Proto-fennique"
@@ -13088,17 +13145,26 @@
   "proto-japonique insulaire": [
     "Proto-japonique insulaire"
   ],
+  "proto-japono-coréanique": [
+    "Proto-japono-coréanique"
+  ],
   "proto-katuique": [
     "Proto-katuique"
   ],
   "proto-keresan": [
     "Proto-keresan"
   ],
+  "proto-khanty": [
+    "Proto-khanty"
+  ],
   "proto-khasique": [
     "Proto-khasique"
   ],
   "proto-khmer": [
     "Proto-khmer"
+  ],
+  "proto-khmuique": [
+    "Proto-khmuique"
   ],
   "proto-kiowa-tanoan": [
     "Proto-kiowa-tanoan"
@@ -13127,6 +13193,12 @@
   "proto-malaïque": [
     "Proto-malaïque"
   ],
+  "proto-mansi": [
+    "Proto-mansi"
+  ],
+  "proto-mari": [
+    "Proto-mari"
+  ],
   "proto-masa": [
     "Proto-masa"
   ],
@@ -13141,6 +13213,15 @@
   ],
   "proto-mongol": [
     "Proto-mongol"
+  ],
+  "proto-mordve": [
+    "Proto-mordve"
+  ],
+  "proto-munda": [
+    "Proto-munda"
+  ],
+  "proto-munda du Nord": [
+    "Proto-munda du Nord"
   ],
   "proto-murutique": [
     "Proto-murutique"
@@ -13196,6 +13277,9 @@
   "proto-paman": [
     "Proto-paman"
   ],
+  "proto-permien": [
+    "Proto-permien"
+  ],
   "proto-polynésien": [
     "Proto-polynésien"
   ],
@@ -13205,8 +13289,14 @@
   "proto-pong": [
     "Proto-pong"
   ],
+  "proto-pramique": [
+    "Proto-pramique"
+  ],
   "proto-pwo": [
     "Proto-pwo"
+  ],
+  "proto-péarique": [
+    "Proto-péarique"
   ],
   "proto-ryūkyū": [
     "Proto-ryūkyū"
@@ -13219,6 +13309,9 @@
   ],
   "proto-same": [
     "Proto-same"
+  ],
+  "proto-samoyède": [
+    "Proto-samoyède"
   ],
   "proto-sangirien": [
     "Proto-sangirien"
@@ -13244,6 +13337,9 @@
   "proto-sémitique": [
     "Proto-sémitique"
   ],
+  "proto-sénoïque": [
+    "Proto-sénoïque"
+  ],
   "proto-sérère-peul": [
     "Proto-sérère-peul"
   ],
@@ -13264,6 +13360,9 @@
   ],
   "proto-toungouse": [
     "Proto-toungouse"
+  ],
+  "proto-toungouse du Nord": [
+    "Proto-toungouse du Nord"
   ],
   "proto-trans-néo-guinéen": [
     "Proto-trans-néo-guinéen"
@@ -13309,6 +13408,9 @@
   ],
   "prx": [
     "Purki"
+  ],
+  "pré-ancien japonais": [
+    "Pré-ancien japonais"
   ],
   "ps": [
     "Pachto"
@@ -14351,6 +14453,9 @@
   "sgn": [
     "Langues des signes"
   ],
+  "sgp": [
+    "Singpho"
+  ],
   "sgr": [
     "Sangesari"
   ],
@@ -14800,6 +14905,9 @@
   ],
   "sol": [
     "Solos"
+  ],
+  "solon": [
+    "Solon"
   ],
   "solrésol": [
     "Solrésol"
@@ -15470,6 +15578,9 @@
   "tch": [
     "Créole anglais des îles Turques-et-Caïques"
   ],
+  "tcl": [
+    "Taman"
+  ],
   "tcp": [
     "Tawr"
   ],
@@ -15994,6 +16105,9 @@
   ],
   "tnx": [
     "Tanema"
+  ],
+  "tnz": [
+    "Maniq"
   ],
   "to": [
     "Tongien"
@@ -16973,6 +17087,9 @@
   "vieux khmer pré-angkorien": [
     "Vieux khmer pré-angkorien"
   ],
+  "vieux mandarin": [
+    "Vieux mandarin"
+  ],
   "vieux norvégien": [
     "Vieux norvégien"
   ],
@@ -17773,6 +17890,9 @@
   ],
   "xin": [
     "Xinca"
+  ],
+  "xiong-nu": [
+    "Xiong-nu"
   ],
   "xiy": [
     "Xipaya"

--- a/wiktextract/data/fr/other_subtitles.json
+++ b/wiktextract/data/fr/other_subtitles.json
@@ -1,0 +1,44 @@
+{
+  "compounds": [
+    "composés",
+    "compos"
+  ],
+  "etymology": [
+    "étymologie",
+    "étym",
+    "etym"
+  ],
+  "ignored_sections": [
+    "anagrammes",
+    "anagramme",
+    "anagr",
+    "références",
+    "référence",
+    "réf",
+    "ref",
+    "sources",
+    "src",
+    "bibliographie",
+    "bib",
+    "citations",
+    "cit"
+  ],
+  "inflection_sections": [
+    "déclinaison",
+    "décl",
+    "conjugaison",
+    "conjug"
+  ],
+  "pronunciation": [
+    "prononciation",
+    "pron",
+    "prononciations"
+  ],
+  "translations": [
+    "traductions",
+    "trad",
+    "traductions à trier",
+    "trad-trier",
+    "trad trier"
+  ]
+}

--- a/wiktextract/data/fr/pos_subtitles.json
+++ b/wiktextract/data/fr/pos_subtitles.json
@@ -1,0 +1,779 @@
+{
+  "adj": {
+    "pos": "adj"
+  },
+  "adj-dém": {
+    "pos": "adj",
+    "tags": [
+      "demonstrative"
+    ]
+  },
+  "adj-excl": {
+    "pos": "adj",
+    "tags": [
+      "exclamatory"
+    ]
+  },
+  "adj-indéf": {
+    "pos": "adj",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "adj-int": {
+    "pos": "adj",
+    "tags": [
+      "interrogative"
+    ]
+  },
+  "adj-num": {
+    "pos": "adj",
+    "tags": [
+      "numeral"
+    ]
+  },
+  "adj-pos": {
+    "pos": "adj",
+    "tags": [
+      "possessive"
+    ]
+  },
+  "adj-rel": {
+    "pos": "adj",
+    "tags": [
+      "relative"
+    ]
+  },
+  "adjectif": {
+    "pos": "adj"
+  },
+  "adjectif dém": {
+    "pos": "adj",
+    "tags": [
+      "demonstrative"
+    ]
+  },
+  "adjectif démonstratif": {
+    "pos": "adj",
+    "tags": [
+      "demonstrative"
+    ]
+  },
+  "adjectif exc": {
+    "pos": "adj",
+    "tags": [
+      "exclamatory"
+    ]
+  },
+  "adjectif exclamatif": {
+    "pos": "adj",
+    "tags": [
+      "exclamatory"
+    ]
+  },
+  "adjectif ind": {
+    "pos": "adj",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "adjectif indéfini": {
+    "pos": "adj",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "adjectif int": {
+    "pos": "adj",
+    "tags": [
+      "interrogative"
+    ]
+  },
+  "adjectif interrogatif": {
+    "pos": "adj",
+    "tags": [
+      "interrogative"
+    ]
+  },
+  "adjectif num": {
+    "pos": "adj",
+    "tags": [
+      "numeral"
+    ]
+  },
+  "adjectif numéral": {
+    "pos": "adj",
+    "tags": [
+      "numeral"
+    ]
+  },
+  "adjectif pos": {
+    "pos": "adj",
+    "tags": [
+      "possessive"
+    ]
+  },
+  "adjectif possessif": {
+    "pos": "adj",
+    "tags": [
+      "possessive"
+    ]
+  },
+  "adjectif qualificatif": {
+    "pos": "adj"
+  },
+  "adjectif rel": {
+    "pos": "adj",
+    "tags": [
+      "relative"
+    ]
+  },
+  "adjectif relatif": {
+    "pos": "adj",
+    "tags": [
+      "relative"
+    ]
+  },
+  "adv": {
+    "pos": "adv"
+  },
+  "adv-ind": {
+    "pos": "adv",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "adv-int": {
+    "pos": "adv",
+    "tags": [
+      "interrogative"
+    ]
+  },
+  "adv-pron": {
+    "pos": "adv"
+  },
+  "adv-rel": {
+    "pos": "adv",
+    "tags": [
+      "relative"
+    ]
+  },
+  "adverbe": {
+    "pos": "adv"
+  },
+  "adverbe ind": {
+    "pos": "adv",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "adverbe indéfini": {
+    "pos": "adv",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "adverbe int": {
+    "pos": "adv",
+    "tags": [
+      "interrogative"
+    ]
+  },
+  "adverbe interrogatif": {
+    "pos": "adv",
+    "tags": [
+      "interrogative"
+    ]
+  },
+  "adverbe pro": {
+    "pos": "adv"
+  },
+  "adverbe pronominal": {
+    "pos": "adv"
+  },
+  "adverbe rel": {
+    "pos": "adv",
+    "tags": [
+      "relative"
+    ]
+  },
+  "adverbe relatif": {
+    "pos": "adv",
+    "tags": [
+      "relative"
+    ]
+  },
+  "aff": {
+    "pos": "affix"
+  },
+  "affixe": {
+    "pos": "affix"
+  },
+  "art": {
+    "pos": "article"
+  },
+  "art-déf": {
+    "pos": "article",
+    "tags": [
+      "definite"
+    ]
+  },
+  "art-indéf": {
+    "pos": "article",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "art-part": {
+    "pos": "article",
+    "tags": [
+      "partial"
+    ]
+  },
+  "article": {
+    "pos": "article"
+  },
+  "article déf": {
+    "pos": "article",
+    "tags": [
+      "definite"
+    ]
+  },
+  "article défini": {
+    "pos": "article",
+    "tags": [
+      "definite"
+    ]
+  },
+  "article ind": {
+    "pos": "article",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "article indéfini": {
+    "pos": "article",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "article par": {
+    "pos": "article",
+    "tags": [
+      "partial"
+    ]
+  },
+  "article partitif": {
+    "pos": "article",
+    "tags": [
+      "partial"
+    ]
+  },
+  "circon": {
+    "pos": "circumfix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "circonf": {
+    "pos": "circumfix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "circonfixe": {
+    "pos": "circumfix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "class": {
+    "pos": "classifier"
+  },
+  "classif": {
+    "pos": "classifier"
+  },
+  "classificateur": {
+    "pos": "classifier"
+  },
+  "conj": {
+    "pos": "conj"
+  },
+  "conj-coord": {
+    "pos": "conj",
+    "tags": [
+      "coordinating"
+    ]
+  },
+  "conjonction": {
+    "pos": "conj"
+  },
+  "conjonction coo": {
+    "pos": "conj",
+    "tags": [
+      "coordinating"
+    ]
+  },
+  "conjonction de coordination": {
+    "pos": "conj",
+    "tags": [
+      "coordinating"
+    ]
+  },
+  "copule": {
+    "pos": "conj"
+  },
+  "dét": {
+    "pos": "det"
+  },
+  "déterminant": {
+    "pos": "det"
+  },
+  "encl": {
+    "pos": "suffix",
+    "tags": [
+      "clitic"
+    ]
+  },
+  "enclitique": {
+    "pos": "suffix",
+    "tags": [
+      "clitic"
+    ]
+  },
+  "gismu": {
+    "pos": "verb",
+    "tags": [
+      "gismu"
+    ]
+  },
+  "idéophone": {
+    "pos": "noun",
+    "tags": [
+      "ideophone"
+    ]
+  },
+  "inf": {
+    "pos": "infix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "infixe": {
+    "pos": "infix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "interf": {
+    "pos": "interfix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "interfixe": {
+    "pos": "interfix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "interj": {
+    "pos": "intj"
+  },
+  "interjection": {
+    "pos": "intj"
+  },
+  "lettre": {
+    "pos": "character",
+    "tags": [
+      "letter"
+    ]
+  },
+  "loc": {
+    "pos": "phrase"
+  },
+  "loc-phr": {
+    "pos": "phrase"
+  },
+  "locution": {
+    "pos": "phrase"
+  },
+  "locution phrase": {
+    "pos": "phrase"
+  },
+  "locution-phrase": {
+    "pos": "phrase"
+  },
+  "nom": {
+    "pos": "noun"
+  },
+  "nom commun": {
+    "pos": "noun"
+  },
+  "nom de famille": {
+    "pos": "name",
+    "tags": [
+      "surename"
+    ]
+  },
+  "nom propre": {
+    "pos": "name"
+  },
+  "nom scientifique": {
+    "pos": "name",
+    "tags": [
+      "scientific"
+    ]
+  },
+  "nom-fam": {
+    "pos": "name",
+    "tags": [
+      "surename"
+    ]
+  },
+  "nom-pr": {
+    "pos": "name"
+  },
+  "num": {
+    "pos": "num"
+  },
+  "numér": {
+    "pos": "num"
+  },
+  "numéral": {
+    "pos": "num"
+  },
+  "onom": {
+    "pos": "onomatopoeia"
+  },
+  "onoma": {
+    "pos": "onomatopoeia"
+  },
+  "onomatopée": {
+    "pos": "onomatopoeia"
+  },
+  "part": {
+    "pos": "particle"
+  },
+  "part-num": {
+    "pos": "particle",
+    "tags": [
+      "numeral"
+    ]
+  },
+  "particule": {
+    "pos": "particle"
+  },
+  "particule num": {
+    "pos": "particle",
+    "tags": [
+      "numeral"
+    ]
+  },
+  "particule numérale": {
+    "pos": "particle",
+    "tags": [
+      "numeral"
+    ]
+  },
+  "patronyme": {
+    "pos": "name",
+    "tags": [
+      "surename"
+    ]
+  },
+  "phrase": {
+    "pos": "phrase"
+  },
+  "post": {
+    "pos": "postp"
+  },
+  "postpos": {
+    "pos": "postp"
+  },
+  "postposition": {
+    "pos": "postp"
+  },
+  "procl": {
+    "pos": "prefix",
+    "tags": [
+      "clitic"
+    ]
+  },
+  "proclitique": {
+    "pos": "prefix",
+    "tags": [
+      "clitic"
+    ]
+  },
+  "pronom": {
+    "pos": "pron"
+  },
+  "pronom dém": {
+    "pos": "pron",
+    "tags": [
+      "demonstrative"
+    ]
+  },
+  "pronom démonstratif": {
+    "pos": "pron",
+    "tags": [
+      "demonstrative"
+    ]
+  },
+  "pronom ind": {
+    "pos": "pron",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "pronom indéfini": {
+    "pos": "pron",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "pronom int": {
+    "pos": "pron",
+    "tags": [
+      "interrogative"
+    ]
+  },
+  "pronom interrogatif": {
+    "pos": "pron",
+    "tags": [
+      "interrogative"
+    ]
+  },
+  "pronom personnel": {
+    "pos": "pron",
+    "tags": [
+      "person"
+    ]
+  },
+  "pronom pos": {
+    "pos": "pron",
+    "tags": [
+      "possessive"
+    ]
+  },
+  "pronom possessif": {
+    "pos": "pron",
+    "tags": [
+      "possessive"
+    ]
+  },
+  "pronom rel": {
+    "pos": "pron",
+    "tags": [
+      "relative"
+    ]
+  },
+  "pronom relatif": {
+    "pos": "pron",
+    "tags": [
+      "relative"
+    ]
+  },
+  "pronom réf": {
+    "pos": "pron",
+    "tags": [
+      "person"
+    ]
+  },
+  "pronom réfléchi": {
+    "pos": "pron",
+    "tags": [
+      "person"
+    ]
+  },
+  "pronom-adj": {
+    "pos": "pron",
+    "tags": [
+      "adjective"
+    ]
+  },
+  "pronom-adjectif": {
+    "pos": "pron",
+    "tags": [
+      "adjective"
+    ]
+  },
+  "pronom-dém": {
+    "pos": "pron",
+    "tags": [
+      "demonstrative"
+    ]
+  },
+  "pronom-indéf": {
+    "pos": "pron",
+    "tags": [
+      "indefinite"
+    ]
+  },
+  "pronom-int": {
+    "pos": "pron",
+    "tags": [
+      "interrogative"
+    ]
+  },
+  "pronom-per": {
+    "pos": "pron",
+    "tags": [
+      "person"
+    ]
+  },
+  "pronom-pers": {
+    "pos": "pron",
+    "tags": [
+      "person"
+    ]
+  },
+  "pronom-pos": {
+    "pos": "pron",
+    "tags": [
+      "possessive"
+    ]
+  },
+  "pronom-rel": {
+    "pos": "pron",
+    "tags": [
+      "relative"
+    ]
+  },
+  "pronom-réfl": {
+    "pos": "pron",
+    "tags": [
+      "person"
+    ]
+  },
+  "prov": {
+    "pos": "proverb"
+  },
+  "proverbe": {
+    "pos": "proverb"
+  },
+  "pré-nom": {
+    "pos": "name",
+    "tags": [
+      "first name"
+    ]
+  },
+  "pré-verbe": {
+    "pos": "preverb"
+  },
+  "préf": {
+    "pos": "prefix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "préfixe": {
+    "pos": "prefix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "prénom": {
+    "pos": "name",
+    "tags": [
+      "first name"
+    ]
+  },
+  "prép": {
+    "pos": "prep"
+  },
+  "préposition": {
+    "pos": "prep"
+  },
+  "quantif": {
+    "pos": "quantifier"
+  },
+  "quantificateur": {
+    "pos": "quantifier"
+  },
+  "racine": {
+    "pos": "root",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "rad": {
+    "pos": "root",
+    "tags": [
+      "radical"
+    ]
+  },
+  "radical": {
+    "pos": "root",
+    "tags": [
+      "radical"
+    ]
+  },
+  "rafsi": {
+    "pos": "affix",
+    "tags": [
+      "rafsi"
+    ]
+  },
+  "substantif": {
+    "pos": "noun"
+  },
+  "suf": {
+    "pos": "suffix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "suff": {
+    "pos": "suffix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "suffixe": {
+    "pos": "suffix",
+    "tags": [
+      "morpheme"
+    ]
+  },
+  "symb": {
+    "pos": "symbol"
+  },
+  "symbole": {
+    "pos": "symbol"
+  },
+  "var-typo": {
+    "pos": "typographic variant"
+  },
+  "variante par contrainte typographique": {
+    "pos": "typographic variant"
+  },
+  "variante typo": {
+    "pos": "typographic variant"
+  },
+  "variante typographique": {
+    "pos": "typographic variant"
+  },
+  "verb pr": {
+    "pos": "verb",
+    "tags": [
+      "pronominal"
+    ]
+  },
+  "verb-pr": {
+    "pos": "verb",
+    "tags": [
+      "pronominal"
+    ]
+  },
+  "verbe": {
+    "pos": "verb"
+  },
+  "verbe pronominal": {
+    "pos": "verb",
+    "tags": [
+      "pronominal"
+    ]
+  }
+}

--- a/wiktextract/datautils.py
+++ b/wiktextract/datautils.py
@@ -1,6 +1,7 @@
 # Utilities for manipulating word data structures
 #
 # Copyright (c) 2018-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
+import copy
 import re
 from collections import defaultdict
 from functools import lru_cache, partial
@@ -172,7 +173,7 @@ def split_slashes(wxr, text):
             words = []
             for ws in divs:
                 assert isinstance(ws, tuple)
-                exists = wxr.wtp.page_exists(" ".join(ws))
+                # exists = wxr.wtp.page_exists(" ".join(ws))
                 words.extend(ws)
                 score += 100
                 score += 1 / len(ws)
@@ -247,3 +248,17 @@ def find_similar_gloss(page_data: List[Dict], gloss: str) -> Dict:
         return page_data[-1]["senses"][match_result[2]]
 
     return page_data[-1]
+
+
+def append_base_data(
+    page_data: List[Dict], field: str, value: Any, base_data: Dict
+) -> None:
+    if page_data[-1].get(field) is not None:
+        if len(page_data[-1]["senses"]) > 0:
+            # append new dictionary if the last dictionary has sense data and
+            # also has the same key
+            page_data.append(copy.deepcopy(base_data))
+        elif isinstance(page_data[-1].get(field), list):
+            page_data[-1][field] += value
+    else:
+        page_data[-1][field] = value

--- a/wiktextract/extractor/fr/gloss.py
+++ b/wiktextract/extractor/fr/gloss.py
@@ -1,0 +1,27 @@
+from collections import defaultdict
+from typing import Dict, List
+
+from wikitextprocessor import NodeKind, WikiNode
+
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
+
+from ..share import filter_child_wikinodes
+
+
+def extract_gloss(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    list_node: WikiNode,
+) -> None:
+    lang_code = page_data[-1].get("lang_code")
+    for list_item_node in filter_child_wikinodes(list_node, NodeKind.LIST_ITEM):
+        gloss_nodes = [
+            child
+            for child in list_item_node.children
+            if not isinstance(child, WikiNode) or child.kind != NodeKind.LIST
+        ]
+        gloss_data = defaultdict(list)
+        raw_gloss_text = clean_node(wxr, gloss_data, gloss_nodes)
+        gloss_data["glosses"] = [raw_gloss_text]
+        page_data[-1]["senses"].append(gloss_data)

--- a/wiktextract/extractor/fr/page.py
+++ b/wiktextract/extractor/fr/page.py
@@ -1,0 +1,195 @@
+import copy
+import logging
+from collections import defaultdict
+from typing import Dict, List, Union
+
+from wikitextprocessor import NodeKind, WikiNode
+
+from wiktextract.datautils import append_base_data
+from wiktextract.page import LEVEL_KINDS, clean_node
+from wiktextract.wxr_context import WiktextractContext
+
+from ..share import strip_nodes
+from .gloss import extract_gloss
+
+# Templates that are used to form panels on pages and that
+# should be ignored in various positions
+PANEL_TEMPLATES = {}
+
+# Template name prefixes used for language-specific panel templates (i.e.,
+# templates that create side boxes or notice boxes or that should generally
+# be ignored).
+PANEL_PREFIXES = {}
+
+# Additional templates to be expanded in the pre-expand phase
+ADDITIONAL_EXPAND_TEMPLATES = {}
+
+
+def parse_section(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    base_data: Dict,
+    node: Union[WikiNode, List[Union[WikiNode, str]]],
+) -> None:
+    if isinstance(node, list):
+        for x in node:
+            parse_section(wxr, page_data, base_data, x)
+        return
+    if not isinstance(node, WikiNode):
+        return
+    if node.kind in LEVEL_KINDS:
+        level_node = node.args[0][0]
+        if level_node.kind == NodeKind.TEMPLATE:
+            level_template_name, *level_template_args = level_node.args
+            if level_template_name == ["S"]:
+                # https://fr.wiktionary.org/wiki/Modèle:S
+                # https://fr.wiktionary.org/wiki/Wiktionnaire:Liste_des_sections
+                section_type = level_template_args[0][0]
+                subtitle = clean_node(wxr, page_data[-1], node.args)
+                wxr.wtp.start_subsection(subtitle)
+                if (
+                    section_type
+                    in wxr.config.OTHER_SUBTITLES["ignored_sections"]
+                ):
+                    pass
+                # https://fr.wiktionary.org/wiki/Wiktionnaire:Liste_des_sections_de_types_de_mots
+                elif section_type in wxr.config.POS_SUBTITLES:
+                    process_pos_block(
+                        wxr, page_data, base_data, node, section_type
+                    )
+                elif (
+                    wxr.config.capture_etymologies
+                    and section_type in wxr.config.OTHER_SUBTITLES["etymology"]
+                ):
+                    extract_etymology(wxr, page_data, base_data, node.children)
+                elif (
+                    wxr.config.capture_pronunciation
+                    and section_type
+                    in wxr.config.OTHER_SUBTITLES["pronunciation"]
+                ):
+                    pass
+                elif (
+                    wxr.config.capture_linkages
+                    and section_type in wxr.config.LINKAGE_SUBTITLES
+                ):
+                    pass
+                elif (
+                    wxr.config.capture_translations
+                    and section_type
+                    in wxr.config.OTHER_SUBTITLES["translations"]
+                ):
+                    pass
+                elif (
+                    wxr.config.capture_inflections
+                    and section_type
+                    in wxr.config.OTHER_SUBTITLES["inflection_sections"]
+                ):
+                    pass
+                else:
+                    pass
+                # wxr.wtp.debug(
+                #     f"Unhandled section type: {subtitle}",
+                #     sortid="extractor/fr/page/parse_section/192",
+                # )
+
+
+def process_pos_block(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    base_data: Dict,
+    node: WikiNode,
+    pos_argument: str,
+):
+    pos_type = wxr.config.POS_SUBTITLES[pos_argument]["pos"]
+    base_data["pos"] = pos_type
+    append_base_data(page_data, "pos", pos_type, base_data)
+    for index, child in enumerate(strip_nodes(node.children)):
+        if isinstance(child, WikiNode):
+            if index == 0 and child.kind == NodeKind.TEMPLATE:
+                pass
+                # lang_code = base_data.get("lang_code")
+                # extract_headword_line(wxr, page_data, child, lang_code)
+            elif child.kind == NodeKind.LIST:
+                extract_gloss(wxr, page_data, child)
+            elif child.kind in LEVEL_KINDS:
+                parse_section(wxr, page_data, base_data, child)
+        else:
+            parse_section(wxr, page_data, base_data, child)
+
+
+def extract_etymology(
+    wxr: WiktextractContext,
+    page_data: List[Dict],
+    base_data: Dict,
+    nodes: List[Union[WikiNode, str]],
+) -> None:
+    level_node_index = -1
+    for index, node in enumerate(nodes):
+        if isinstance(node, WikiNode) and node.kind in LEVEL_KINDS:
+            level_node_index = index
+            break
+    if level_node_index != -1:
+        etymology = clean_node(wxr, page_data[-1], nodes[:index])
+    else:
+        etymology = clean_node(wxr, page_data[-1], nodes)
+    base_data["etymology_text"] = etymology
+    append_base_data(page_data, "etymology_text", etymology, base_data)
+    if level_node_index != -1:
+        parse_section(wxr, page_data, base_data, nodes[level_node_index:])
+
+
+def parse_page(
+    wxr: WiktextractContext, page_title: str, page_text: str
+) -> List[Dict[str, str]]:
+    if wxr.config.verbose:
+        logging.info(f"Parsing page: {page_title}")
+
+    wxr.config.word = page_title
+    wxr.wtp.start_page(page_title)
+
+    # Parse the page, pre-expanding those templates that are likely to
+    # influence parsing
+    tree = wxr.wtp.parse(
+        page_text,
+        pre_expand=True,
+        additional_expand=ADDITIONAL_EXPAND_TEMPLATES,
+    )
+
+    page_data = []
+    for node in filter(lambda n: isinstance(n, WikiNode), tree.children):
+        # ignore link created by `voir` template at the page top
+        if node.kind == NodeKind.TEMPLATE and node.args[0][0].lower() in {
+            "voir",
+            "voir2",
+        }:
+            continue
+        if node.kind != NodeKind.LEVEL2:
+            wxr.wtp.warning(
+                f"Unexpected top-level node: {node}",
+                sortid="extractor/fr/page/parse_page/94",
+            )
+            continue
+
+        level_node = node.args[0][0]
+        if level_node.kind == NodeKind.TEMPLATE:
+            level_template_name, *level_template_args = level_node.args
+            # https://fr.wiktionary.org/wiki/Modèle:langue
+            # https://fr.wiktionary.org/wiki/Wiktionnaire:Liste_des_langues
+            if level_template_name == ["langue"]:
+                categories_and_links = defaultdict(list)
+                lang_code = level_template_args[0][0]
+                lang_name = clean_node(wxr, categories_and_links, level_node)
+                wxr.wtp.start_section(lang_name)
+                base_data = defaultdict(
+                    list,
+                    {
+                        "lang": lang_name,
+                        "lang_code": lang_code,
+                        "word": wxr.wtp.title,
+                    },
+                )
+                base_data.update(categories_and_links)
+                page_data.append(copy.deepcopy(base_data))
+                parse_section(wxr, page_data, base_data, node.children)
+
+    return page_data

--- a/wiktextract/extractor/zh/page.py
+++ b/wiktextract/extractor/zh/page.py
@@ -2,10 +2,11 @@ import copy
 import logging
 import re
 from collections import defaultdict
-from typing import Any, Dict, List, Union
+from typing import Dict, List, Union
 
 from wikitextprocessor import NodeKind, WikiNode
 
+from wiktextract.datautils import append_base_data
 from wiktextract.page import LEVEL_KINDS, clean_node
 from wiktextract.wxr_context import WiktextractContext
 
@@ -122,20 +123,6 @@ ADDITIONAL_EXPAND_TEMPLATES = {
 }
 
 
-def append_page_data(
-    page_data: List[Dict], field: str, value: Any, base_data: Dict
-) -> None:
-    if page_data[-1].get(field) is not None:
-        if len(page_data[-1]["senses"]) > 0:
-            # append new dictionary if the last dictionary has sense data and
-            # also has the same key
-            page_data.append(copy.deepcopy(base_data))
-        elif isinstance(page_data[-1].get(field), list):
-            page_data[-1][field] += value
-    else:
-        page_data[-1][field] = value
-
-
 def parse_section(
     wxr: WiktextractContext,
     page_data: List[Dict],
@@ -204,7 +191,7 @@ def process_pos_block(
 ):
     pos_type = wxr.config.POS_SUBTITLES[pos_text]["pos"]
     base_data["pos"] = pos_type
-    append_page_data(page_data, "pos", pos_type, base_data)
+    append_base_data(page_data, "pos", pos_type, base_data)
     for index, child in enumerate(strip_nodes(node.children)):
         if isinstance(child, WikiNode):
             if index == 0 and child.kind == NodeKind.TEMPLATE:
@@ -234,7 +221,7 @@ def extract_etymology(
     else:
         etymology = clean_node(wxr, page_data[-1], nodes)
     base_data["etymology_text"] = etymology
-    append_page_data(page_data, "etymology_text", etymology, base_data)
+    append_base_data(page_data, "etymology_text", etymology, base_data)
     if level_node_index != -1:
         parse_section(wxr, page_data, base_data, nodes[level_node_index:])
 

--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -394,7 +394,7 @@ def clean_node(
                     data_append(wxr, sense_data, "categories", cat)
         else:
             for m in re.finditer(
-                r"(?is)\[\[:?(\s*([^][|:]+):)?\s*([^]|]+)" r"(\|([^]|]+))?\]\]",
+                r"(?is)\[\[:?(\s*([^][|:]+):)?\s*([^]|]+)(\|([^]|]+))?\]\]",
                 v,
             ):
                 # Add here other stuff different "Something:restofthelink"

--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -138,7 +138,8 @@ def recursively_extract(
 
 def process_page_data(wxr: WiktextractContext, data: List[Dict]) -> Dict:
     inject_linkages(wxr, data)
-    process_categories(wxr, data)
+    if wxr.config.dump_file_lang_code == "en":
+        process_categories(wxr, data)
     remove_duplicate_data(data)
     return data
 


### PR DESCRIPTION
The code in `fr/page.py` are mostly copied from `zh/page.py` and it only extract the raw etymology and gloss text.