### PR TITLE
Fix sqlite error

### DIFF
--- a/wiktextract/extractor/zh/pronunciation.py
+++ b/wiktextract/extractor/zh/pronunciation.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Union
 
 from wikitextprocessor import NodeKind, WikiNode
 
+from wiktextract.datautils import append_base_data
 from wiktextract.extractor.share import WIKIMEDIA_COMMONS_URL, contains_list
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
@@ -17,8 +18,6 @@ def extract_pronunciation_recursively(
     node: Union[WikiNode, List[Union[WikiNode, str]]],
     tags: List[str],
 ) -> None:
-    from .page import append_page_data
-
     if isinstance(node, list):
         for x in node:
             extract_pronunciation_recursively(
@@ -58,7 +57,7 @@ def extract_pronunciation_recursively(
                         create_audio_url_dict(data)
                     )
         elif isinstance(data, dict):
-            append_page_data(
+            append_base_data(
                 page_data,
                 "sounds",
                 [data],


### PR DESCRIPTION
I'm confused about this sqlite error, if it's about the connection can't be used in forked worker process then I should see the same error of the `Wtp.db_conn`. Maybe it's because how these variables are passed.

`Wtp` is copied to a global variable `_global_ctx` in `wikitextprocessor.core.py`: https://github.com/tatuylonen/wikitextprocessor/blob/ba5e92f3972dff924d142f470088590ae0a2b9c8/wikitextprocessor/core.py#L1835-L1837

but `WiktextractContext` is passed in a callback function : https://github.com/tatuylonen/wiktextract/blob/c9567026e1d12f694c15b1676c22bcaf7949ee1b/wiktextract/wiktionary.py#L122-L123