### PR TITLE
Apply WikiNode.args -> .sarg/.largs in Wikitextprocessor

### DIFF
--- a/tests/test_zh_headword.py
+++ b/tests/test_zh_headword.py
@@ -28,7 +28,7 @@ class TestHeadword(TestCase):
         # wikitext: {{en-noun|~|manga|s}}
         # expanded text: manga (可數 & 不可數，複數 manga 或 mangas)
         node = Mock()
-        node.args = [["en-noun"]]
+        node.largs = [["en-noun"]]
         page_data = [defaultdict(list)]
         self.wxr.wtp.title = "manga"
         extract_headword_line(self.wxr, page_data, node, "en")
@@ -54,7 +54,7 @@ class TestHeadword(TestCase):
         # wikitext: {{nl-noun|m|-'s|mangaatje}}
         # expanded text: manga m (複數 manga's，指小詞 mangaatje n)
         node = Mock()
-        node.args = [["nl-noun"]]
+        node.largs = [["nl-noun"]]
         page_data = [defaultdict(list)]
         self.wxr.wtp.title = "manga"
         extract_headword_line(self.wxr, page_data, node, "nl")
@@ -80,7 +80,7 @@ class TestHeadword(TestCase):
         # wikitext: {{head|grc|後綴變格形|g=f|head=-κρατίᾱς}}
         # expanded text: -κρατίᾱς (-kratíās) f
         node = Mock()
-        node.args = [["head"]]
+        node.largs = [["head"]]
         page_data = [defaultdict(list)]
         self.wxr.wtp.title = "-κρατίας"
         extract_headword_line(self.wxr, page_data, node, "grc")

--- a/wiktextract/extractor/en/thesaurus.py
+++ b/wiktextract/extractor/en/thesaurus.py
@@ -128,7 +128,7 @@ def extract_thesaurus_data(wxr: WiktextractContext) -> None:
                         thesaurus.extend(x_result)
                 return thesaurus
             if not isinstance(contents, WikiNode):
-                return
+                return None
             kind = contents.kind
             if kind == NodeKind.LIST and not contains_list(contents.children):
                 if lang is None:
@@ -233,14 +233,16 @@ def extract_thesaurus_data(wxr: WiktextractContext) -> None:
                 return thesaurus
             if kind not in LEVEL_KINDS:
                 thesaurus = []
-                args_thesaurus = recurse(contents.args)
+                args_thesaurus = recurse(contents.sarg if contents.sarg
+                                                else contents.largs)
                 if args_thesaurus is not None:
                     thesaurus.extend(args_thesaurus)
                 children_thesaurus = recurse(contents.children)
                 if children_thesaurus is not None:
                     thesaurus.extend(children_thesaurus)
                 return thesaurus
-            subtitle = wxr.wtp.node_to_text(contents.args)
+            subtitle = wxr.wtp.node_to_text(contents.sarg if contents.sarg
+                                            else contents.largs)
             if subtitle in wxr.config.LANGUAGES_BY_NAME:
                 lang = subtitle
                 pos = None
@@ -284,7 +286,7 @@ def extract_thesaurus_data(wxr: WiktextractContext) -> None:
             logging.debug(
                 f"{title=} {lang=} {pos=} {sense=} UNHANDLED SUBTITLE: "
                 + "subtitle "
-                + str(contents.args)
+                + str(contents.sarg if contents.sarg else contents.largs)
             )
             return recurse(contents.children)
 

--- a/wiktextract/extractor/fr/inflection.py
+++ b/wiktextract/extractor/fr/inflection.py
@@ -78,7 +78,7 @@ def extract_fr_accord(
                         if (
                             isinstance(table_cell_child, WikiNode)
                             and table_cell_child.kind == NodeKind.HTML
-                            and table_cell_child.args == "br"
+                            and table_cell_child.sarg == "br"
                         ):
                             br_tag_index = cell_child_index
                             break

--- a/wiktextract/extractor/fr/page.py
+++ b/wiktextract/extractor/fr/page.py
@@ -40,14 +40,14 @@ def parse_section(
     if not isinstance(node, WikiNode):
         return
     if node.kind in LEVEL_KINDS:
-        level_node = node.args[0][0]
+        level_node = node.largs[0][0]
         if level_node.kind == NodeKind.TEMPLATE:
-            level_template_name, *level_template_args = level_node.args
+            level_template_name, *level_template_args = level_node.largs
             if level_template_name == ["S"]:
                 # https://fr.wiktionary.org/wiki/Modèle:S
                 # https://fr.wiktionary.org/wiki/Wiktionnaire:Liste_des_sections
                 section_type = level_template_args[0][0]
-                subtitle = clean_node(wxr, page_data[-1], node.args)
+                subtitle = clean_node(wxr, page_data[-1], node.largs)
                 wxr.wtp.start_subsection(subtitle)
                 if (
                     section_type
@@ -111,7 +111,7 @@ def process_pos_block(
     for index, child in enumerate(child_nodes):
         if isinstance(child, WikiNode):
             if child.kind == NodeKind.TEMPLATE:
-                template_name = child.args[0][0]
+                template_name = child.largs[0][0]
                 lang_code = base_data.get("lang_code")
                 if template_name.startswith(f"{lang_code}-"):
                     extract_inflection(wxr, page_data, child, template_name)
@@ -170,7 +170,7 @@ def parse_page(
     for node in filter(lambda n: isinstance(n, WikiNode), tree.children):
         # ignore link created by `voir` template at the page top
         if node.kind == NodeKind.TEMPLATE:
-            template_name = node.args[0][0]
+            template_name = node.largs[0][0]
             if template_name in {"voir", "voir2"} or template_name.startswith(
                 "voir/"
             ):
@@ -182,9 +182,9 @@ def parse_page(
             )
             continue
 
-        level_node = node.args[0][0]
+        level_node = node.largs[0][0]
         if level_node.kind == NodeKind.TEMPLATE:
-            level_template_name, *level_template_args = level_node.args
+            level_template_name, *level_template_args = level_node.largs
             # https://fr.wiktionary.org/wiki/Modèle:langue
             # https://fr.wiktionary.org/wiki/Wiktionnaire:Liste_des_langues
             if level_template_name == ["langue"]:

--- a/wiktextract/extractor/ruby.py
+++ b/wiktextract/extractor/ruby.py
@@ -18,10 +18,10 @@ def parse_ruby(
         if (
             not isinstance(child, WikiNode)
             or child.kind != NodeKind.HTML
-            or child.args not in {"rp", "rt"}
+            or child.sarg not in {"rp", "rt"}
         ):
             ruby_nodes.append(child)
-        elif child.args == "rt":
+        elif child.sarg == "rt":
             furi_nodes.append(child)
     ruby_kanji = clean_node(wxr, None, ruby_nodes).strip()
     furigana = clean_node(wxr, None, furi_nodes).strip()
@@ -51,7 +51,7 @@ def extract_ruby(
     if not isinstance(contents, WikiNode):
         return [], [contents]
     # Check if this content should be extracted
-    if contents.kind == NodeKind.HTML and contents.args == "ruby":
+    if contents.kind == NodeKind.HTML and contents.sarg == "ruby":
         rb = parse_ruby(wxr, contents)
         if rb is not None:
             return [rb], [rb[0]]
@@ -68,13 +68,12 @@ def extract_ruby(
         NodeKind.LINK,
     }:
         # Process args and children
-        assert isinstance(contents.args, (list, tuple))
         new_args = []
-        for arg in contents.args:
+        for arg in contents.largs:
             e1, c1 = extract_ruby(wxr, arg)
             new_args.append(c1)
             extracted.extend(e1)
-        new_node.args = new_args
+        new_node.largs = new_args
         e1, c1 = extract_ruby(wxr, contents.children)
         extracted.extend(e1)
         new_node.children = c1
@@ -98,7 +97,7 @@ def extract_ruby(
         pass
     elif kind in (NodeKind.LIST, NodeKind.LIST_ITEM):
         # Keep args as-is, process children
-        new_node.args = contents.args
+        new_node.sarg = contents.sarg
         e1, c1 = extract_ruby(wxr, contents.children)
         extracted.extend(e1)
         new_node.children = c1
@@ -110,15 +109,15 @@ def extract_ruby(
     }:
         # Process only args
         new_args = []
-        for arg in contents.args:
+        for arg in contents.largs:
             e1, c1 = extract_ruby(wxr, arg)
             new_args.append(c1)
             extracted.extend(e1)
-        new_node.args = new_args
+        new_node.largs = new_args
     elif kind == NodeKind.HTML:
         # Keep attrs and args as-is, process children
         new_node.attrs = contents.attrs
-        new_node.args = contents.args
+        new_node.sarg = contents.sarg
         e1, c1 = extract_ruby(wxr, contents.children)
         extracted.extend(e1)
         new_node.children = c1

--- a/wiktextract/extractor/share.py
+++ b/wiktextract/extractor/share.py
@@ -18,7 +18,8 @@ def contains_list(
     kind = contents.kind
     if kind == NodeKind.LIST:
         return True
-    return contains_list(contents.children) or contains_list(contents.args)
+    return contains_list(contents.children) or contains_list(contents.sarg if
+                                            contents.sarg else contents.largs)
 
 
 def strip_nodes(

--- a/wiktextract/extractor/zh/example.py
+++ b/wiktextract/extractor/zh/example.py
@@ -32,7 +32,7 @@ def extract_examples(
                         isinstance(child, WikiNode)
                         and child.kind == NodeKind.TEMPLATE
                     ):
-                        template_name = child.args[0][0].strip()
+                        template_name = child.largs[0][0].strip()
                         if template_name.startswith(("quote-", "RQ:")):
                             extract_quote_templates(wxr, child, example_data)
                         elif template_name in {"ja-x", "ja-usex"}:
@@ -82,7 +82,7 @@ def extract_quote_templates(
             key = "text"
         elif line_num == 2 and any(
             template_arg[0].startswith("transliteration=")
-            for template_arg in node.args
+            for template_arg in node.largs
             if len(template_arg) > 0 and isinstance(template_arg[0], str)
         ):
             key = "roman"

--- a/wiktextract/extractor/zh/gloss.py
+++ b/wiktextract/extractor/zh/gloss.py
@@ -47,7 +47,7 @@ def extract_gloss(
             for child_node in filter_child_wikinodes(
                 list_item_node, NodeKind.LIST
             ):
-                if child_node.args.endswith("#"):  # nested gloss
+                if child_node.sarg.endswith("#"):  # nested gloss
                     has_nested_gloss = True
                     extract_gloss(wxr, page_data, child_node, new_gloss_data)
                 else:  # example list

--- a/wiktextract/extractor/zh/headword_line.py
+++ b/wiktextract/extractor/zh/headword_line.py
@@ -71,7 +71,7 @@ def extract_headword_line(
     node: WikiNode,
     lang_code: str,
 ) -> None:
-    template_name = node.args[0][0]
+    template_name = node.largs[0][0]
     if template_name != "head" and not template_name.startswith(
         f"{lang_code}-"
     ):
@@ -83,11 +83,11 @@ def extract_headword_line(
     forms_start_index = 0
     for index, child in enumerate(expanded_node.children):
         if isinstance(child, WikiNode) and child.kind == NodeKind.HTML:
-            if child.args == "strong" and "headword" in child.attrs.get(
+            if child.sarg == "strong" and "headword" in child.attrs.get(
                 "class", ""
             ):
                 forms_start_index = index + 1
-            elif child.args == "span":
+            elif child.sarg == "span":
                 class_names = child.attrs.get("class", "")
                 if "headword-tr" in class_names:
                     forms_start_index = index + 1
@@ -103,7 +103,7 @@ def extract_headword_line(
                     for abbr_tag in filter(
                         lambda x: isinstance(x, WikiNode)
                         and x.kind == NodeKind.HTML
-                        and x.args == "abbr",
+                        and x.sarg == "abbr",
                         child.children,
                     ):
                         gender = abbr_tag.children[0]
@@ -115,7 +115,7 @@ def extract_headword_line(
                         child, NodeKind.HTML
                     ):
                         if (
-                            span_child.args == "strong"
+                            span_child.sarg == "strong"
                             and "headword" in span_child.attrs.get("class", "")
                         ):
                             ruby_data, node_without_ruby = extract_ruby(
@@ -130,7 +130,7 @@ def extract_headword_line(
                                     "tags": ["canonical"],
                                 }
                             )
-            elif child.args == "b":
+            elif child.sarg == "b":
                 # this is a form <b> tag, already inside form parentheses
                 break
 
@@ -167,7 +167,7 @@ def process_forms_text(
     lang_code = page_data[-1].get("lang_code")
     for index, node in enumerate(striped_nodes):
         if isinstance(node, WikiNode) and node.kind == NodeKind.HTML:
-            if node.args == "b":
+            if node.sarg == "b":
                 has_forms = True
                 ruby_data = None
                 if lang_code == "ja":
@@ -184,7 +184,7 @@ def process_forms_text(
                     if (
                         isinstance(next_node, WikiNode)
                         and next_node.kind == NodeKind.HTML
-                        and next_node.args == "span"
+                        and next_node.sarg == "span"
                         and "gender" in next_node.attrs.get("class", "")
                     ):
                         gender = clean_node(wxr, None, next_node)
@@ -197,7 +197,7 @@ def process_forms_text(
                 if ruby_data is not None:
                     form_data["ruby"] = ruby_data
                 page_data[-1]["forms"].append(form_data)
-            elif node.args == "span" and "tr" in node.attrs.get("class", ""):
+            elif node.sarg == "span" and "tr" in node.attrs.get("class", ""):
                 # romanization of the previous form <b> tag
                 page_data[-1]["forms"][-1]["roman"] = clean_node(
                     wxr, None, node

--- a/wiktextract/extractor/zh/inflection.py
+++ b/wiktextract/extractor/zh/inflection.py
@@ -29,7 +29,7 @@ def extract_inflections(
 ) -> None:
     for child in node.children:
         if isinstance(child, WikiNode) and child.kind == NodeKind.TEMPLATE:
-            template_name = child.args[0][0].lower()
+            template_name = child.largs[0][0].lower()
             if template_name.startswith(JAPANESE_INFLECTION_TEMPLATE_PREFIXES):
                 expanded_table = wxr.wtp.parse(
                     wxr.wtp.node_to_wikitext(node), expand_all=True

--- a/wiktextract/extractor/zh/linkage.py
+++ b/wiktextract/extractor/zh/linkage.py
@@ -42,7 +42,7 @@ def extract_linkages(
                         isinstance(item_child, WikiNode)
                         and item_child.kind == NodeKind.TEMPLATE
                     ):
-                        template_name = item_child.args[0][0].lower()
+                        template_name = item_child.largs[0][0].lower()
                         if template_name in sense_template_names:
                             not_term_indexes.add(index)
                             sense = clean_node(wxr, None, item_child).strip(
@@ -86,7 +86,7 @@ def extract_linkages(
                             ] = variant_type
                         append_to[linkage_type].append(final_linkage_data)
             elif node.kind == NodeKind.TEMPLATE:
-                template_name = node.args[0][0].lower()
+                template_name = node.largs[0][0].lower()
                 if template_name in sense_template_names:
                     sense = clean_node(wxr, None, node).strip(strip_sense_chars)
                 elif template_name.endswith("-saurus"):
@@ -135,6 +135,7 @@ def extract_linkages(
                     if len(returned_sense) > 0:
                         sense = returned_sense
                         append_to = returned_append_target
+    return None
 
 
 def extract_saurus_template(
@@ -152,7 +153,7 @@ def extract_saurus_template(
     """
     from wiktextract.thesaurus import search_thesaurus
 
-    thesaurus_page_title = node.args[-1][0]
+    thesaurus_page_title = node.largs[-1][0]
     for thesaurus in search_thesaurus(
         wxr.thesaurus_db_conn,
         thesaurus_page_title,

--- a/wiktextract/extractor/zh/page.py
+++ b/wiktextract/extractor/zh/page.py
@@ -136,7 +136,7 @@ def parse_section(
     if not isinstance(node, WikiNode):
         return
     if node.kind in LEVEL_KINDS:
-        subtitle = clean_node(wxr, page_data[-1], node.args)
+        subtitle = clean_node(wxr, page_data[-1], node.largs)
         # remove number suffix from subtitle
         subtitle = re.sub(r"\s*(?:（.+）|\d+)$", "", subtitle)
         wxr.wtp.start_subsection(subtitle)
@@ -268,7 +268,7 @@ def parse_page(
     for node in filter(lambda n: isinstance(n, WikiNode), tree.children):
         # ignore link created by `also` template at the page top
         # also ignore "character info" templates
-        if node.kind == NodeKind.TEMPLATE and node.args[0][0].lower() in {
+        if node.kind == NodeKind.TEMPLATE and node.largs[0][0].lower() in {
             "also",
             "see also",
             "亦",
@@ -285,7 +285,7 @@ def parse_page(
             continue
 
         categories_and_links = defaultdict(list)
-        lang_name = clean_node(wxr, categories_and_links, node.args)
+        lang_name = clean_node(wxr, categories_and_links, node.largs)
         if lang_name not in wxr.config.LANGUAGES_BY_NAME:
             wxr.wtp.warning(
                 f"Unrecognized language name at top-level {lang_name}",

--- a/wiktextract/extractor/zh/pronunciation.py
+++ b/wiktextract/extractor/zh/pronunciation.py
@@ -185,7 +185,7 @@ def extract_pronunciation_item(
             lambda x: isinstance(x, WikiNode) and x.kind == NodeKind.TEMPLATE,
             node_children,
         ):
-            template_name, *template_args = child.args
+            template_name, *template_args = child.largs
             if template_name[0] == "audio":
                 audio_filename = template_args[1][0]
                 return audio_filename

--- a/wiktextract/extractor/zh/thesaurus.py
+++ b/wiktextract/extractor/zh/thesaurus.py
@@ -161,7 +161,7 @@ def recursive_parse(
         return
 
     if node.kind == NodeKind.LEVEL2:
-        lang_name = clean_node(wxr, None, node.args)
+        lang_name = clean_node(wxr, None, node.largs)
         lang_code = wxr.config.LANGUAGES_BY_NAME.get(lang_name)
         if lang_code is None:
             logging.warning(
@@ -171,9 +171,9 @@ def recursive_parse(
             wxr, entry, lang_code, None, None, None, node.children
         )
     elif node.kind == NodeKind.LEVEL3:
-        local_pos_name = clean_node(wxr, None, node.args)
+        local_pos_name = clean_node(wxr, None, node.largs)
         if local_pos_name in IGNORED_LEVEL3_SUBTITLES:
-            return
+            return None
         english_pos = wxr.config.POS_SUBTITLES.get(local_pos_name, {}).get(
             "pos"
         )
@@ -187,13 +187,13 @@ def recursive_parse(
             wxr, entry, lang_code, english_pos, None, None, node.children
         )
     elif node.kind == NodeKind.LEVEL4:
-        sense = clean_node(wxr, None, node.args)
+        sense = clean_node(wxr, None, node.largs)
         sense = sense.removeprefix(SENSE_SUBTITLE_PREFIX)
         return recursive_parse(
             wxr, entry, lang_code, pos, sense, None, node.children
         )
     elif node.kind == NodeKind.LEVEL5:
-        local_linkage_name = clean_node(wxr, None, node.args)
+        local_linkage_name = clean_node(wxr, None, node.largs)
         english_linkage = wxr.config.LINKAGE_SUBTITLES.get(local_linkage_name)
         if english_linkage is None:
             logging.warning(
@@ -220,6 +220,7 @@ def recursive_parse(
         return recursive_parse(
             wxr, entry, lang_code, pos, sense, linkage, node.children
         )
+    return None
 
 
 def extract_thesaurus_data(wxr: WiktextractContext) -> None:

--- a/wiktextract/extractor/zh/translation.py
+++ b/wiktextract/extractor/zh/translation.py
@@ -23,17 +23,17 @@ def extract_translation(
     for child in node.children:
         if isinstance(child, WikiNode):
             if child.kind == NodeKind.TEMPLATE:
-                template_name = child.args[0][0].lower()
+                template_name = child.largs[0][0].lower()
                 if (
                     template_name in {"trans-top", "翻譯-頂", "trans-top-also"}
-                    and len(child.args) > 1
+                    and len(child.largs) > 1
                 ):
-                    sense_text = clean_node(wxr, None, child.args[1][0])
+                    sense_text = clean_node(wxr, None, child.largs[1][0])
                     append_to = find_similar_gloss(page_data, sense_text)
                 elif template_name == "checktrans-top":
                     return
                 elif template_name == "see translation subpage":
-                    translation_subpage(wxr, page_data, child.args[1:])
+                    translation_subpage(wxr, page_data, child.largs[1:])
             elif child.kind == NodeKind.LIST:
                 for list_item_node in filter_child_wikinodes(
                     child, NodeKind.LIST_ITEM
@@ -180,7 +180,7 @@ def find_subpage_section(
 ) -> Optional[WikiNode]:
     if isinstance(node, WikiNode):
         if node.kind in LEVEL_KINDS:
-            section_title = clean_node(wxr, None, node.args)
+            section_title = clean_node(wxr, None, node.largs)
             if (
                 isinstance(target_section, str)
                 and section_title == target_section
@@ -196,3 +196,4 @@ def find_subpage_section(
             returned_node = find_subpage_section(wxr, child, target_section)
             if returned_node is not None:
                 return returned_node
+    return None

--- a/wiktextract/inflection.py
+++ b/wiktextract/inflection.py
@@ -2528,7 +2528,7 @@ def determine_header(wxr, tablecontext, lang, word, pos,
           " + " not in titletext and  # For "avoir + blah blah"?
           not any(isinstance(x, WikiNode) and
                   x.kind == NodeKind.HTML and
-                  x.args == "span" and
+                  x.sarg == "span" and
                   x.attrs.get("lang") in ("az",)
                   for x in col.children)):
         is_title = True
@@ -2611,7 +2611,7 @@ def handle_wikitext_or_html_table(wxr, word, lang, pos,
     assert isinstance(data, dict)
     assert isinstance(tree, WikiNode)
     assert (tree.kind == NodeKind.TABLE or
-           (tree.kind == NodeKind.HTML and tree.args == "table"))
+           (tree.kind == NodeKind.HTML and tree.sarg == "table"))
     assert isinstance(titles, list)
     assert isinstance(source, str)
     for x in titles:
@@ -2657,7 +2657,7 @@ def handle_wikitext_or_html_table(wxr, word, lang, pos,
             if not isinstance(node, WikiNode):
                 continue
             if node.kind == NodeKind.HTML:
-                kind = node.args
+                kind = node.sarg
             else:
                 kind = node.kind
             
@@ -2685,7 +2685,7 @@ def handle_wikitext_or_html_table(wxr, word, lang, pos,
                         # indexing or counting or looping.
                         continue
                     if col.kind == NodeKind.HTML:
-                        kind = col.args
+                        kind = col.sarg
                     else:
                         kind = col.kind
                     if kind not in (NodeKind.TABLE_HEADER_CELL,
@@ -2734,7 +2734,7 @@ def handle_wikitext_or_html_table(wxr, word, lang, pos,
                                                        and
                                                        (x.kind == NodeKind.TABLE
                                                        or
-                                                       x.args == "table"))
+                                                       x.sarg == "table"))
     
                     # Clean the rest of the cell.
                     celltext = clean_node(wxr, None, rest)
@@ -2977,7 +2977,7 @@ def parse_inflection_section(wxr, data,
             if kind == NodeKind.TABLE:
                 tables.append(["wikitext", node, titles, []])
                 return
-            elif kind == NodeKind.HTML and node.args == "table":
+            elif kind == NodeKind.HTML and node.sarg == "table":
                 classes = node.attrs.get("class", ())
                 if "audiotable" in classes:
                     return
@@ -2986,15 +2986,15 @@ def parse_inflection_section(wxr, data,
             elif kind in (NodeKind.LEVEL2, NodeKind.LEVEL3, NodeKind.LEVEL4,
                           NodeKind.LEVEL5, NodeKind.LEVEL6):
                 return  # Skip subsections
-            if (kind == NodeKind.HTML and node.args == "div" and
+            if (kind == NodeKind.HTML and node.sarg == "div" and
                 "NavFrame" in node.attrs.get("class", "").split()):
                 recurse_navframe(node, titles)
                 return
         if kind == NodeKind.LINK:
-            if len(node.args) > 1:
-                recurse(node.args[1:], titles, navframe)
+            if len(node.largs) > 1:
+                recurse(node.largs[1:], titles, navframe)
             else:
-                recurse(node.args[0], titles, navframe)
+                recurse(node.largs[0], titles, navframe)
             return
         for x in node.children:
             recurse(x, titles, navframe)

--- a/wiktextract/page.py
+++ b/wiktextract/page.py
@@ -81,13 +81,12 @@ def recursively_extract(
     new_contents.append(new_node)
     if kind in LEVEL_KINDS or kind == NodeKind.LINK:
         # Process args and children
-        assert isinstance(contents.args, (list, tuple))
         new_args = []
-        for arg in contents.args:
+        for arg in contents.largs:
             e1, c1 = recursively_extract(arg, fn)
             new_args.append(c1)
             extracted.extend(e1)
-        new_node.args = new_args
+        new_node.largs = new_args
         e1, c1 = recursively_extract(contents.children, fn)
         extracted.extend(e1)
         new_node.children = c1
@@ -111,7 +110,7 @@ def recursively_extract(
         pass
     elif kind in (NodeKind.LIST, NodeKind.LIST_ITEM):
         # Keep args as-is, process children
-        new_node.args = contents.args
+        new_node.sarg = contents.sarg
         e1, c1 = recursively_extract(contents.children, fn)
         extracted.extend(e1)
         new_node.children = c1
@@ -123,15 +122,15 @@ def recursively_extract(
     }:
         # Process only args
         new_args = []
-        for arg in contents.args:
+        for arg in contents.largs:
             e1, c1 = recursively_extract(arg, fn)
             new_args.append(c1)
             extracted.extend(e1)
-        new_node.args = new_args
+        new_node.largs = new_args
     elif kind == NodeKind.HTML:
         # Keep attrs and args as-is, process children
         new_node.attrs = contents.attrs
-        new_node.args = contents.args
+        new_node.sarg = contents.sarg
         e1, c1 = recursively_extract(contents.children, fn)
         extracted.extend(e1)
         new_node.children = c1
@@ -305,7 +304,7 @@ def remove_duplicate_data(page_data: Dict) -> None:
 def clean_node(
     wxr: WiktextractContext,
     sense_data: Optional[Dict],
-    value: Union[str, WikiNode, List[WikiNode]],
+    value: Union[str, WikiNode, List[Union[str, WikiNode, List]]],
     template_fn: Optional[Callable[[str, Dict], str]] = None,
     post_template_fn: Optional[Callable[[str, Dict, str], str]] = None,
     collect_links: bool = False,

--- a/wiktextract/pronunciations.py
+++ b/wiktextract/pronunciations.py
@@ -54,7 +54,7 @@ def parse_pronunciation(wxr, node, data, etym_data,
         for l in contents:
             if (isinstance(l, WikiNode) and
                l.kind == NodeKind.TEMPLATE and
-               l.args[0][0].strip() != "zh-pron"):
+               l.largs[0][0].strip() != "zh-pron"):
                 temp = wxr.wtp.node_to_wikitext(l)
                 temp = wxr.wtp.expand(temp)
                 temp = wxr.wtp.parse(temp)
@@ -355,9 +355,9 @@ def parse_pronunciation(wxr, node, data, etym_data,
             for item in contents.children:
                 parse_chinese_pron(item, unknown_header_tags)
             return
-        if (len(contents.args[0]) == 1 and
-           isinstance(contents.args[0][0], str) and
-           contents.args[0][0].strip() == "zh-pron"):
+        if (len(contents.largs[0]) == 1 and
+           isinstance(contents.largs[0][0], str) and
+           contents.largs[0][0].strip() == "zh-pron"):
 
             src = wxr.wtp.node_to_wikitext(contents)
             expanded = wxr.wtp.expand(src, templates_to_expand={"zh-pron"})
@@ -397,7 +397,7 @@ def parse_pronunciation(wxr, node, data, etym_data,
                 else:
                     new_children.append(child)
             node.children = new_children
-            node.args = "*"
+            node.sarg = "*"
             yield node
             if sublist:
                 yield from flattened_tree1(sublist)


### PR DESCRIPTION
This implements the changes in https://github.com/tatuylonen/wikitextprocessor/pull/87

Basically, I got really annoyed with type-checking WikiNode.args, because .args can be either a string OR a list of lists containing argument stuff... This also makes it more readable, hopefully.