### PR TITLE
Process French Wiktionary "zh-mot*" templates in form line

### DIFF
--- a/tests/test_fr_form_line.py
+++ b/tests/test_fr_form_line.py
@@ -5,7 +5,10 @@ from unittest.mock import patch
 from wikitextprocessor import Wtp
 
 from wiktextract.config import WiktionaryConfig
-from wiktextract.extractor.fr.form_line import extract_form_line
+from wiktextract.extractor.fr.form_line import (
+    extract_form_line,
+    process_zh_mot_template,
+)
 from wiktextract.thesaurus import close_thesaurus_db
 from wiktextract.wxr_context import WiktextractContext
 
@@ -57,6 +60,26 @@ class TestFormLine(unittest.TestCase):
                         {"form": "autrice", "tags": ["pour une femme"]},
                         {"form": "auteure", "tags": ["pour une femme"]},
                         {"form": "auteuse", "tags": ["pour une femme"]},
+                    ]
+                }
+            ],
+        )
+
+    def test_zh_mot(self):
+        self.wxr.wtp.start_page("")
+        self.wxr.wtp.add_page("Modèle:zh-mot", 10, body="{{lang}} {{pron}}")
+        self.wxr.wtp.add_page("Modèle:lang", 10, body="mǎ")
+        self.wxr.wtp.add_page("Modèle:pron", 10, body="\\ma̠˨˩˦\\")
+        root = self.wxr.wtp.parse("{{zh-mot|马|mǎ}}")
+        page_data = [defaultdict(list)]
+        process_zh_mot_template(self.wxr, root.children[0], page_data)
+        self.assertEqual(
+            page_data,
+            [
+                {
+                    "sounds": [
+                        {"tags": ["Pinyin"], "zh-pron": "mǎ"},
+                        {"ipa": "\\ma̠˨˩˦\\"},
                     ]
                 }
             ],

--- a/tests/test_fr_gloss.py
+++ b/tests/test_fr_gloss.py
@@ -141,7 +141,7 @@ class TestFormLine(unittest.TestCase):
                                 }
                             ],
                         }
-                    ]
+                    ],
                 }
             ],
         )

--- a/wiktextract/extractor/fr/form_line.py
+++ b/wiktextract/extractor/fr/form_line.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Union
 
 from wikitextprocessor import NodeKind, WikiNode
+from wikitextprocessor.parser import TemplateNode
 
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
@@ -26,12 +27,16 @@ def extract_form_line(
                 )
             elif node.template_name == "équiv-pour":
                 process_equiv_pour_template(node, page_data)
+            elif node.template_name.startswith("zh-mot"):
+                process_zh_mot_template(wxr, node, page_data)
             else:
-                tag = clean_node(wxr, None, node)  # category
+                tag = clean_node(wxr, page_data[-1], node)
                 page_data[-1]["tags"].append(tag)
 
 
-def process_equiv_pour_template(node: WikiNode, page_data: List[Dict]) -> None:
+def process_equiv_pour_template(
+    node: TemplateNode, page_data: List[Dict]
+) -> None:
     # equivalent form: https://fr.wiktionary.org/wiki/Modèle:équiv-pour
     form_type = node.template_parameters.get(1)
     for template_arg_index in range(2, 8):
@@ -39,4 +44,30 @@ def process_equiv_pour_template(node: WikiNode, page_data: List[Dict]) -> None:
         if form is not None:
             page_data[-1]["forms"].append(
                 {"form": form, "tags": [f"pour {form_type}"]}
+            )
+
+
+def process_zh_mot_template(
+    wxr: WiktextractContext,
+    node: TemplateNode,
+    page_data: List[Dict],
+) -> None:
+    # zh-mot, zh-mot-s, zh-mot-t
+    # https://fr.wiktionary.org/wiki/Modèle:zh-mot
+    node = wxr.wtp.parse(
+        wxr.wtp.node_to_wikitext(node),
+        pre_expand=True,
+        additional_expand={node.template_name},
+    )
+    for template_node in node.find_child(NodeKind.TEMPLATE):
+        if template_node.template_name == "lang":
+            page_data[-1]["sounds"].append(
+                {
+                    "zh-pron": clean_node(wxr, None, template_node),
+                    "tags": ["Pinyin"],
+                }
+            )
+        elif template_node.template_name == "pron":
+            page_data[-1]["sounds"].append(
+                {"ipa": clean_node(wxr, None, template_node)}
             )


### PR DESCRIPTION
Chinese word might use a single "zh-mot" template in form line