### PR TITLE
Extract French Wiktionary translation list

### DIFF
--- a/tests/test_fr_pronunciation.py
+++ b/tests/test_fr_pronunciation.py
@@ -34,7 +34,7 @@ class TestPronunciation(unittest.TestCase):
         ]
         self.wxr.wtp.start_page("")
         root = self.wxr.wtp.parse(
-            "=== Prononciation  ===\n* {{pron|bɔ̃.ʒuʁ|fr}}\n** {{écouter|France (Paris)|bõ.ʒuːʁ|audio=Fr-bonjour.ogg|lang=fr}}"
+            "=== Prononciation ===\n* {{pron|bɔ̃.ʒuʁ|fr}}\n** {{écouter|France (Paris)|bõ.ʒuːʁ|audio=Fr-bonjour.ogg|lang=fr}}"
         )
         extract_pronunciation(self.wxr, page_data, root.children[0])
         self.assertEqual(

--- a/tests/test_fr_translation.py
+++ b/tests/test_fr_translation.py
@@ -1,0 +1,105 @@
+import unittest
+from collections import defaultdict
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.fr.translation import extract_translation
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestTranslation(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="fr"), WiktionaryConfig(dump_file_lang_code="fr")
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
+
+    def test_italic_tag(self):
+        self.wxr.wtp.start_page("")
+        self.wxr.wtp.add_page("Modèle:T", 10, body="Albanais")
+        root = self.wxr.wtp.parse(
+            "=== Traductions ===\n* {{trad-début|Formule pour saluer}}\n* {{T|sq}} : {{trad+|sq|mirëdita}}, {{trad-|sq|mirë mëngjes}} ''(le matin)''"
+        )
+        page_data = [defaultdict(list)]
+        extract_translation(self.wxr, page_data, root.children[0])
+        self.assertEqual(
+            page_data,
+            [
+                {
+                    "translations": [
+                        {
+                            "code": "sq",
+                            "lang": "Albanais",
+                            "word": "mirëdita",
+                            "sense": "Formule pour saluer",
+                        },
+                        {
+                            "code": "sq",
+                            "lang": "Albanais",
+                            "word": "mirë mëngjes",
+                            "sense": "Formule pour saluer",
+                            "tags": ["le matin"],
+                        },
+                    ]
+                }
+            ],
+        )
+
+    def test_template_tag(self):
+        self.wxr.wtp.start_page("")
+        self.wxr.wtp.add_page("Modèle:T", 10, body="Arabe")
+        self.wxr.wtp.add_page("Modèle:transliterator", 10, body="mrḥbā")
+        self.wxr.wtp.add_page("Modèle:informel", 10, body="(Informel)")
+        root = self.wxr.wtp.parse(
+            "=== Traductions ===\n* {{T|ar}} : {{trad+|ar|مرحبا|dif=مرحبًا|tr={{transliterator|ar|مرحبا}}}} {{informel|nocat=1}}"
+        )
+        page_data = [defaultdict(list)]
+        extract_translation(self.wxr, page_data, root.children[0])
+        self.assertEqual(
+            page_data,
+            [
+                {
+                    "translations": [
+                        {
+                            "code": "ar",
+                            "lang": "Arabe",
+                            "word": "مرحبا",
+                            "roman": "mrḥbā",
+                            "tags": ["Informel"],
+                        },
+                    ]
+                }
+            ],
+        )
+
+    def test_traditional_writing(self):
+        self.wxr.wtp.start_page("")
+        self.wxr.wtp.add_page("Modèle:T", 10, body="Mongol")
+        root = self.wxr.wtp.parse(
+            "=== Traductions ===\n* {{T|mn}} : {{trad+|mn|сайн байна уу|tr=sain baina uu|tradi=ᠰᠠᠶᠢᠨ ᠪᠠᠶᠢᠨ᠎ᠠ ᠤᠤ}}"
+        )
+        page_data = [defaultdict(list)]
+        extract_translation(self.wxr, page_data, root.children[0])
+        self.assertEqual(
+            page_data,
+            [
+                {
+                    "translations": [
+                        {
+                            "code": "mn",
+                            "lang": "Mongol",
+                            "word": "сайн байна уу",
+                            "roman": "sain baina uu",
+                            "traditional_writing": "ᠰᠠᠶᠢᠨ ᠪᠠᠶᠢᠨ᠎ᠠ ᠤᠤ",
+                        },
+                    ]
+                }
+            ],
+        )

--- a/wiktextract/extractor/fr/page.py
+++ b/wiktextract/extractor/fr/page.py
@@ -14,6 +14,7 @@ from .form_line import extract_form_line
 from .gloss import extract_gloss, process_exemple_template
 from .inflection import extract_inflection
 from .pronunciation import extract_pronunciation
+from .translation import extract_translation
 
 # Templates that are used to form panels on pages and that
 # should be ignored in various positions
@@ -83,7 +84,7 @@ def parse_section(
                     and section_type
                     in wxr.config.OTHER_SUBTITLES["translations"]
                 ):
-                    pass
+                    extract_translation(wxr, page_data, level_node)
                 elif (
                     wxr.config.capture_inflections
                     and section_type

--- a/wiktextract/extractor/fr/translation.py
+++ b/wiktextract/extractor/fr/translation.py
@@ -1,0 +1,110 @@
+from collections import defaultdict
+from typing import Dict, List
+
+from wikitextprocessor import NodeKind, WikiNode
+from wikitextprocessor.parser import TemplateNode
+
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
+
+
+def extract_translation(
+    wxr: WiktextractContext, page_data: List[Dict], level_node: WikiNode
+) -> None:
+    base_translation_data = defaultdict(list)
+    for level_node_child in level_node.filter_empty_str_child():
+        if isinstance(level_node_child, WikiNode):
+            if level_node_child.kind == NodeKind.TEMPLATE:
+                # get sense from "trad-début" template
+                process_translation_templates(
+                    wxr, level_node_child, page_data, base_translation_data
+                )
+            elif level_node_child.kind == NodeKind.LIST:
+                for list_item_node in level_node_child.find_child(
+                    NodeKind.LIST_ITEM
+                ):
+                    previous_node = None
+                    for child_node in list_item_node.filter_empty_str_child():
+                        if isinstance(child_node, WikiNode):
+                            if child_node.kind == NodeKind.TEMPLATE:
+                                process_translation_templates(
+                                    wxr,
+                                    child_node,
+                                    page_data,
+                                    base_translation_data,
+                                )
+                            elif child_node.kind == NodeKind.ITALIC:
+                                process_italic_node(
+                                    wxr, child_node, previous_node, page_data
+                                )
+                            previous_node = child_node
+
+
+def process_italic_node(
+    wxr: WiktextractContext,
+    italic_node: WikiNode,
+    previous_node: WikiNode,
+    page_data: List[Dict],
+) -> None:
+    # add italic text after a "trad" template as a tag
+    tag = clean_node(wxr, None, italic_node)
+    if (
+        tag.startswith("(")
+        and tag.endswith(")")
+        and previous_node.kind == NodeKind.TEMPLATE
+        and previous_node.template_name.startswith("trad")
+    ):
+        page_data[-1]["translations"][-1]["tags"].append(tag.strip("()"))
+
+
+def process_translation_templates(
+    wxr: WiktextractContext,
+    template_node: TemplateNode,
+    page_data: List[Dict],
+    base_translation_data: Dict[str, str],
+) -> None:
+    if template_node.template_name == "trad-début":
+        # translation box start: https://fr.wiktionary.org/wiki/Modèle:trad-début
+        translation_sense_wikitext = template_node.template_parameters.get(
+            1, ""
+        )
+        if len(translation_sense_wikitext) > 0:
+            base_translation_data["sense"] = clean_node(
+                wxr, None, translation_sense_wikitext
+            )
+    elif template_node.template_name == "T":
+        # Translation language: https://fr.wiktionary.org/wiki/Modèle:T
+        base_translation_data["code"] = template_node.template_parameters.get(1)
+        base_translation_data["lang"] = clean_node(
+            wxr, page_data[-1], template_node
+        )
+    elif template_node.template_name.startswith("trad"):
+        # Translation term: https://fr.wiktionary.org/wiki/Modèle:trad
+        translation_term = clean_node(
+            wxr, None, template_node.template_parameters.get(2)
+        )
+        translation_roman = clean_node(
+            wxr,
+            None,
+            (
+                template_node.template_parameters.get(
+                    "tr", template_node.template_parameters.get("R", "")
+                )
+            ),
+        )
+        # traditional writing of Chinese and Korean word
+        translation_traditional_writing = clean_node(
+            wxr, None, template_node.template_parameters.get("tradi", "")
+        )
+        translation_data = base_translation_data.copy()
+        translation_data["word"] = translation_term
+        if len(translation_roman) > 0:
+            translation_data["roman"] = translation_roman
+        if len(translation_traditional_writing) > 0:
+            translation_data[
+                "traditional_writing"
+            ] = translation_traditional_writing
+        page_data[-1]["translations"].append(translation_data)
+    else:
+        tag = clean_node(wxr, None, template_node).strip("()")
+        page_data[-1]["translations"][-1]["tags"].append(tag)


### PR DESCRIPTION
Tested with page https://fr.wiktionary.org/wiki/bonjour Only the "Amazighe standard marocain" language's translation text got removed by `clean_node()`.