### PR TITLE
Fix deploy page action timeout error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
           python -m pip install -U pip
           python -m pip install --use-pep517 '.[dev]'
       - run: make test
+      - name: Remove huge file taxondata_py.html
+        run: rm -f htmlcov/*_taxondata_py.html
       - uses: actions/upload-pages-artifact@v2
         if: github.ref_name == 'master' && matrix.python-version == '3.11'
         with:


### PR DESCRIPTION
The 20M "taxondata.py" file creates a ridiculous 143M coverage HTML file, which makes the deploy action failed after the default 10m timeout.