### PR TITLE
Fix 'parse_page' for French extractor

### DIFF
--- a/tests/test_fr_page.py
+++ b/tests/test_fr_page.py
@@ -1,0 +1,58 @@
+# Tests for parsing a page
+#
+# Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
+
+import unittest
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.fr.page import parse_page
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
+
+class FrPageTests(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+        conf1 = WiktionaryConfig(
+            dump_file_lang_code="fr",
+            capture_language_codes=None,
+            capture_translations=True,
+            capture_pronunciation=True,
+            capture_linkages=True,
+            capture_compounds=True,
+            capture_redirects=True,
+            capture_examples=True,
+        )
+        self.wxr = WiktextractContext(Wtp(lang_code="fr"), conf1)
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
+
+    def test_fr_parse_page(self):
+        self.wxr.wtp.add_page("Modèle:langue", 10, "Français")
+        self.wxr.wtp.add_page("Modèle:S", 10, "Nom commun")
+        lst = parse_page(
+            self.wxr,
+            "exemple",
+            """
+== {{langue|fr}} ==
+=== {{S|nom|fr}} ===
+'''exemple'''
+""",
+        )
+        self.assertEqual(
+            lst,
+            [
+                {
+                    "lang": "Français",
+                    "lang_code": "fr",
+                    "pos": "noun",
+                    "word": "exemple",
+                }
+            ],
+        )

--- a/wiktextract/extractor/fr/page.py
+++ b/wiktextract/extractor/fr/page.py
@@ -19,15 +19,15 @@ from .translation import extract_translation
 
 # Templates that are used to form panels on pages and that
 # should be ignored in various positions
-PANEL_TEMPLATES = {}
+PANEL_TEMPLATES = set()
 
 # Template name prefixes used for language-specific panel templates (i.e.,
 # templates that create side boxes or notice boxes or that should generally
 # be ignored).
-PANEL_PREFIXES = {}
+PANEL_PREFIXES = set()
 
 # Additional templates to be expanded in the pre-expand phase
-ADDITIONAL_EXPAND_TEMPLATES = {}
+ADDITIONAL_EXPAND_TEMPLATES = set()
 
 
 def parse_section(


### PR DESCRIPTION
While exploring the progress to the French extractor you've made recently (well, done already!), I wanted to run the script from the default entry point via `wiktwords.py` but quickly discovered that there are still problems in `fr/page.py`.

One I fixed already: 
- https://github.com/tatuylonen/wiktextract/commit/fd53cdd1dfc5b3fc2a84595ab23cb113525ca1d5: Originally, empty dicts were created  instead of empty sets.

The main problem: 
- In several places, the code makes use of the inexistent instance method `find_content` on objects of the `WikiNode` class, for example in https://github.com/tatuylonen/wiktextract/blob/05321e53017a175dd2c7a293e1b4f784764a81f7/wiktextract/extractor/fr/page.py#L217 This seems intentional but I'am unsure what to do about it. @xxyzz Does this rely on some not yet merged feature?

For easier testing, I've added a simple test suite for the `parse_page` function of the French extractor.

ToDo:
- [x] replace or implement non existent `Wikinode.find_content()` method
- [x] run test suite successfully 