### PR TITLE
Fix regex alerts

### DIFF
--- a/src/wiktextract/clean.py
+++ b/src/wiktextract/clean.py
@@ -1376,11 +1376,11 @@ def clean_value(wxr, title, no_strip=False, no_html_strip=False):
     # Remove <sup> with previewonly class (generated e.g. by {{taxlink|...}})
     title = re.sub(r'(?si)<sup\b[^>]*?\bclass="[^"<>]*?'
                    r'\bpreviewonly\b[^>]*?>'
-                   r'((<[^<>]>[^<>]*</[^<>]*>)|.)*?</sup\s*>',
+                   r'.+?</sup\s*>',
                    "", title)
     # Remove <strong class="error">...</strong>
     title = re.sub(r'(?si)<strong\b[^>]*?\bclass="[^"]*?\berror\b[^>]*?>'
-                   r'((<.*?</.[^>]>)|.)*?</strong\s*>',
+                   r'.+?</strong\s*>',
                    "", title)
     # Change <div> and </div> to newlines.  Ditto for tr, li, table, dl, ul, ol
     title = re.sub(r"(?si)</?(div|tr|li|table|dl|ul|ol)\b[^>]*>",

--- a/src/wiktextract/clean.py
+++ b/src/wiktextract/clean.py
@@ -1438,7 +1438,7 @@ def clean_value(wxr, title, no_strip=False, no_html_strip=False):
         )
         title = re.sub(r"(?s)\[\[\s*:?([^]|#<>]+?)\s*(#[^][|<>]*?)?\]\]",
                        repl_1, title)
-        title = re.sub(r"(?s)\[\[\s*(([a-zA-z0-9]+)\s*:)?\s*([^][#|<>]+?)"
+        title = re.sub(r"(?s)\[\[\s*(([a-zA-Z0-9]+)\s*:)?\s*([^][#|<>]+?)"
                        r"\s*(#[^][|]*?)?\|?\]\]",
                        repl_link, title)
         title = re.sub(r"(?s)\[\[\s*([^][|<>]+?)\s*\|"


### PR DESCRIPTION
This pr fixes all alerts in GitHub Code Scanning exception one alert of this regex pattern: https://github.com/tatuylonen/wiktextract/blob/08407b3a8031ec31482f2b457789e0896768ad07/src/wiktextract/clean.py#L1446

I don't know how to fix that pattern...