### PR TITLE
Add support for "capture_language_codes" in de and fr extractors

### DIFF
--- a/src/wiktextract/extractor/de/page.py
+++ b/src/wiktextract/extractor/de/page.py
@@ -335,6 +335,11 @@ def parse_page(
                         sortid="extractor/de/page/parse_page/76",
                     )
                     continue
+                if (
+                    wxr.config.capture_language_codes
+                    and lang_code not in wxr.config.capture_language_codes
+                ):
+                    continue
 
                 base_data = defaultdict(
                     list,

--- a/src/wiktextract/extractor/fr/page.py
+++ b/src/wiktextract/extractor/fr/page.py
@@ -162,6 +162,11 @@ def parse_page(
             if subtitle_template.template_name == "langue":
                 categories_and_links = defaultdict(list)
                 lang_code = subtitle_template.template_parameters.get(1)
+                if (
+                    wxr.config.capture_language_codes
+                    and lang_code not in wxr.config.capture_language_codes
+                ):
+                    continue
                 lang_name = clean_node(
                     wxr, categories_and_links, subtitle_template
                 )

--- a/tests/test_de_page.py
+++ b/tests/test_de_page.py
@@ -19,8 +19,8 @@ class DePageTests(unittest.TestCase):
     def setUp(self):
         conf1 = WiktionaryConfig(
             dump_file_lang_code="de",
-            # capture_language_codes=None,
-            # capture_translations=True,
+            capture_language_codes=None,
+            capture_translations=True,
             # capture_pronunciation=True,
             # capture_linkages=True,
             # capture_compounds=True,


### PR DESCRIPTION
Currently the German and French extractors don't make use of the "capture_language_codes" configuration and capture all languages by default.

This commit adds support for this feature.