### PR TITLE
adjust json schema descriptions for language code

### DIFF
--- a/json_schema/fr.json
+++ b/json_schema/fr.json
@@ -6,11 +6,11 @@
   "type": "object",
   "properties": {
     "lang_name": {
-      "description": "Localized langauge name of the word",
+      "description": "Localized language name of the word",
       "type": "string"
     },
     "lang_code": {
-      "description": "ISO 639-1 language code",
+      "description": "Wiktionary language code",
       "type": "string"
     },
     "word": {
@@ -263,11 +263,11 @@
       "type": "object",
       "properties": {
         "lang_code": {
-          "description": "ISO 639-1 code of the translation term",
+          "description": "Wiktionary language code of the translation term",
           "type": "string"
         },
         "lang_name": {
-          "description": "Transation language name",
+          "description": "Translation language name",
           "type": "string"
         },
         "word": {
@@ -325,11 +325,11 @@
           "type": "integer"
         },
         "lang_name": {
-          "description": "Localized langauge name of the word, for the 'Dérivés dans d’autres langues' section",
+          "description": "Localized language name of the word, for the 'Dérivés dans d’autres langues' section",
           "type": "string"
         },
         "lang_code": {
-          "description": "ISO 639-1 language code, for the 'Dérivés dans d’autres langues' section",
+          "description": "Wiktionary language code, for the 'Dérivés dans d’autres langues' section",
           "type": "string"
         }
       }

--- a/json_schema/zh.json
+++ b/json_schema/zh.json
@@ -6,11 +6,11 @@
   "type": "object",
   "properties": {
     "lang_name": {
-      "description": "Localized langauge name of the word",
+      "description": "Localized language name of the word",
       "type": "string"
     },
     "lang_code": {
-      "description": "ISO 639-1 language code",
+      "description": "Wiktionary language code",
       "type": ["string", "null"]
     },
     "word": {
@@ -274,11 +274,11 @@
       "type": "object",
       "properties": {
         "lang_code": {
-          "description": "ISO 639-1 code of the translation term",
+          "description": "Wiktionary language code of the translation term",
           "type": ["string", "null"]
         },
         "lang_name": {
-          "description": "Transation language name",
+          "description": "Translation language name",
           "type": "string"
         },
         "word": {
@@ -326,7 +326,7 @@
       "type": "object",
       "properties": {
         "lang_code": {
-          "description": "ISO 639-1 code",
+          "description": "Wiktionary language code",
           "type": "string"
         },
         "lang_name": {


### PR DESCRIPTION
I noticed that the current schemas state that the language codes are ISO 639-1. But there are many codes that are not ISO 639-1. There are many ISO 639-3 codes. Also, there are many non-ISO codes that are used by conventions that depend on the specific language edition. For example, proto-languages in zh and en have codes like `afa-pro`, while in fr they have codes like `proto-afro-asiatique` -- but neither of these code types corresponds to ISO codes.