### PR TITLE
Ignore "Commun" header cell in the French Wiktionary "sv-nom-c-ar" template

### DIFF
--- a/src/wiktextract/extractor/fr/inflection.py
+++ b/src/wiktextract/extractor/fr/inflection.py
@@ -26,6 +26,7 @@ IGNORE_TABLE_HEADERS = frozenset(
         "forme",  # br-flex-adj
         "temps",  # en-conj-rég,
         "cas",  # lt_décl_as, ro-nom-tab(lower case)
+        "commun",  # sv-nom-c-ar
     }
 )
 IGNORE_TABLE_CELL = frozenset(
@@ -74,11 +75,11 @@ def process_inflection_table(
                 )
             )
             and row_node_child.attrs.get("style") != "display:none"
+            and "invisible" not in row_node_child.attrs.get("class", "")
         ]
         current_row_has_data_cell = any(
             isinstance(cell, WikiNode)
             and cell.kind == NodeKind.TABLE_CELL
-            and "invisible" not in cell.attrs.get("class", "")
             for cell in table_row_nodes
         )
         row_headers = []

--- a/src/wiktextract/extractor/fr/inflection.py
+++ b/src/wiktextract/extractor/fr/inflection.py
@@ -1,4 +1,5 @@
 from collections import defaultdict, deque
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Dict, List
 
@@ -145,7 +146,10 @@ def process_inflection_table(
                             table_cell_line != page_data[-1].get("word")
                             and table_cell_line not in IGNORE_TABLE_CELL
                         ):
-                            form_data["form"] = table_cell_line
+                            if "form" not in form_data:
+                                form_data["form"] = table_cell_line
+                            else:
+                                form_data["form"] += " " + table_cell_line
                     for colspan_header in colspan_headers:
                         if (
                             column_cell_index >= colspan_header.index
@@ -166,6 +170,9 @@ def process_inflection_table(
                     if len(row_headers) > 0:
                         form_data["tags"].extend(row_headers)
                     if "form" in form_data:
-                        page_data[-1]["forms"].append(form_data)
+                        for form in form_data["form"].split(" ou "):
+                            new_form_data = deepcopy(form_data)
+                            new_form_data["form"] = form
+                            page_data[-1]["forms"].append(new_form_data)
 
                     column_cell_index += int(table_cell.attrs.get("colspan", 1))

--- a/tests/test_fr_inflection.py
+++ b/tests/test_fr_inflection.py
@@ -343,3 +343,36 @@ class TestInflection(unittest.TestCase):
                 {"form": "fenililor", "tags": ["Pluriel", "Vocatif"]},
             ],
         )
+
+    @patch(
+        "wikitextprocessor.Wtp.node_to_wikitext",
+        return_value="""{| class="flextable flextable-sv"
+! class="invisible" |
+|-
+! Commun
+! Indéfini
+! Défini
+|-
+! Singulier
+| class="sing-indef" |<bdi lang="sv" xml:lang="sv" class="lang-sv">[[robot|robot]]</bdi>
+| class="sing-def" |<bdi lang="sv" xml:lang="sv" class="lang-sv">[[roboten#sv|roboten]]</bdi>
+|-
+! Pluriel
+| class="plur-indef" |<bdi lang="sv" xml:lang="sv" class="lang-sv">[[robotar#sv|robotar]]</bdi>
+| class="plur-def" |<bdi lang="sv" xml:lang="sv" class="lang-sv">[[robotarna#sv|robotarna]]</bdi>
+|}""",
+    )
+    def test_sv_nom_c_ar(self, mock_node_to_wikitext):
+        # https://fr.wiktionary.org/wiki/robot#Nom_commun_7
+        page_data = [defaultdict(list, {"word": "robot"})]
+        node = TemplateNode(0)
+        self.wxr.wtp.start_page("robot")
+        extract_inflection(self.wxr, page_data, node)
+        self.assertEqual(
+            page_data[-1].get("forms"),
+            [
+                {"form": "roboten", "tags": ["Défini", "Singulier"]},
+                {"form": "robotar", "tags": ["Indéfini", "Pluriel"]},
+                {"form": "robotarna", "tags": ["Défini", "Pluriel"]},
+            ],
+        )

--- a/tests/test_fr_inflection.py
+++ b/tests/test_fr_inflection.py
@@ -376,3 +376,30 @@ class TestInflection(unittest.TestCase):
                 {"form": "robotarna", "tags": ["Défini", "Pluriel"]},
             ],
         )
+
+    @patch(
+        "wikitextprocessor.Wtp.node_to_wikitext",
+        return_value="""{|class="flextable"
+|-
+!scope="col"| Cas<nowiki />
+!scope="col"| Singulier<nowiki />
+!scope="col"| Pluriel
+|-
+!scope="row"| Nominatif<nowiki />
+| [[robot#cs-nom|robot''' ''']]<nowiki />
+| [[roboti#cs-flex-nom|robot'''i ''']]<br /><small>''ou''</small> [[robotové#cs-flex-nom|robot'''ové ''']]<nowiki />
+|}""",
+    )
+    def test_cs_decl_nom_ma_dur(self, mock_node_to_wikitext):
+        # https://fr.wiktionary.org/wiki/robot#Nom_commun_1_2
+        page_data = [defaultdict(list, {"word": "robot"})]
+        node = TemplateNode(0)
+        self.wxr.wtp.start_page("robot")
+        extract_inflection(self.wxr, page_data, node)
+        self.assertEqual(
+            page_data[-1].get("forms"),
+            [
+                {"form": "roboti", "tags": ["Pluriel", "Nominatif"]},
+                {"form": "robotové", "tags": ["Pluriel", "Nominatif"]},
+            ],
+        )


### PR DESCRIPTION
and filter table row nodes that have "invisible" class