### PR TITLE
Add languages.json for Spanish Wiktionary

### DIFF
--- a/languages/get_data_de.py
+++ b/languages/get_data_de.py
@@ -5,15 +5,14 @@
 # python language_data.py de dewiktionary_dump_file [--languages languages_output_file]
 
 import argparse
-from wikitextprocessor import Wtp
-from wiktextract.config import WiktionaryConfig
-from wiktextract.wxr_context import WiktextractContext
-from wiktextract.page import clean_node
-from wikitextprocessor.dumpparser import process_dump
-from wikitextprocessor import NodeKind, WikiNode
-
 import json
 
+from wikitextprocessor import NodeKind, WikiNode, Wtp
+from wikitextprocessor.dumpparser import process_dump
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -21,12 +20,6 @@ if __name__ == "__main__":
     )
     parser.add_argument("lang_code", type=str, help="Dump file language code")
     parser.add_argument("dump", type=str, help="Wiktionary xml dump file path")
-    parser.add_argument(
-        "--languages",
-        type=str,
-        default="languages.json",
-        help="Language data output file path",
-    )
     args = parser.parse_args()
     wxr = WiktextractContext(Wtp(lang_code=args.lang_code), WiktionaryConfig())
 
@@ -40,7 +33,7 @@ if __name__ == "__main__":
     template_ns_id = wxr.wtp.NAMESPACE_DATA["Template"]["id"]
     process_dump(wxr.wtp, args.dump, {help_ns_id, template_ns_id})
 
-    # The page 'Hilfe:Sprachkürzel seems to be the only central collection of 
+    # The page 'Hilfe:Sprachkürzel seems to be the only central collection of
     # language codes and their German expansions. We will use this until we find
     #  perhaps a more authoritative source.
     sprachkuerzel = wxr.wtp.get_page("Hilfe:Sprachkürzel")
@@ -68,5 +61,9 @@ if __name__ == "__main__":
 
             languages[lang_code] = [clean_node(wxr, None, third_row_content)]
 
-    with open(args.languages, "w", encoding="utf-8") as fout:
+    with open(
+        f"src/wiktextract/data/{args.lang_code}/languages.json",
+        "w",
+        encoding="utf-8",
+    ) as fout:
         json.dump(languages, fout, indent=2, ensure_ascii=False, sort_keys=True)

--- a/languages/get_data_es.py
+++ b/languages/get_data_es.py
@@ -1,0 +1,60 @@
+# Export Spanish Wiktionary language data to JSON.
+#
+# Usage:
+#
+# python language_data.py de dewiktionary_dump_file [--languages languages_output_file]
+
+import argparse
+import json
+
+from wikitextprocessor import NodeKind, WikiNode, Wtp
+from wikitextprocessor.dumpparser import process_dump
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Export Wiktionary language data to JSON"
+    )
+    parser.add_argument("lang_code", type=str, help="Dump file language code")
+    parser.add_argument("dump", type=str, help="Wiktionary xml dump file path")
+    args = parser.parse_args()
+    wxr = WiktextractContext(Wtp(lang_code=args.lang_code), WiktionaryConfig())
+
+    wxr = WiktextractContext(
+        Wtp(
+            lang_code=args.lang_code, db_path="wikt-db_es_language_data_temp.db"
+        ),
+        WiktionaryConfig(),
+    )
+    appendix_ns_id = wxr.wtp.NAMESPACE_DATA["Appendix"]["id"]
+    process_dump(wxr.wtp, args.dump, {appendix_ns_id})
+
+    # https://es.wiktionary.org/wiki/Ap%C3%A9ndice:C%C3%B3digos_de_idioma
+    codigos_de_idioma = wxr.wtp.get_page("Apéndice:Códigos de idioma")
+
+    wxr.config.word = codigos_de_idioma.title
+    wxr.wtp.start_page(codigos_de_idioma.title)
+    tree = wxr.wtp.parse(
+        codigos_de_idioma.body,
+        pre_expand=True,
+    )
+    languages = {}
+    for table in tree.find_child_recursively(NodeKind.TABLE):
+        for table_row in table.find_child(NodeKind.TABLE_ROW):
+            lang_code_language = []
+            for table_cell in table_row.find_child(NodeKind.TABLE_CELL):
+                lang_code_language.append(table_cell.children[0])
+
+            if lang_code_language:
+                languages[clean_node(wxr, None, lang_code_language[0])] = [
+                    clean_node(wxr, None, lang_code_language[1])
+                ]
+    with open(
+        f"src/wiktextract/data/{args.lang_code}/languages.json",
+        "w",
+        encoding="utf-8",
+    ) as fout:
+        json.dump(languages, fout, indent=2, ensure_ascii=False, sort_keys=True)

--- a/src/wiktextract/data/es/config.json
+++ b/src/wiktextract/data/es/config.json
@@ -1,0 +1,4 @@
+{
+  "analyze_templates": false,
+  "extract_thesaurus_pages": false
+}

--- a/src/wiktextract/data/es/languages.json
+++ b/src/wiktextract/data/es/languages.json
@@ -1,0 +1,3638 @@
+{
+  "0hk": [
+    "darkinyung"
+  ],
+  "0hl": [
+    "dharug"
+  ],
+  "aa": [
+    "afar"
+  ],
+  "aan": [
+    "anambé"
+  ],
+  "aap": [
+    "arará"
+  ],
+  "ab": [
+    "abjaso"
+  ],
+  "abq": [
+    "abaza"
+  ],
+  "abs": [
+    "malayo ambonés"
+  ],
+  "abx": [
+    "inabacnum"
+  ],
+  "ace": [
+    "achenés"
+  ],
+  "ach": [
+    "acholi"
+  ],
+  "acv": [
+    "achumawi"
+  ],
+  "acw": [
+    "árabe hiyazí"
+  ],
+  "acy": [
+    "árabe chipriota"
+  ],
+  "ada": [
+    "adangme"
+  ],
+  "adw": [
+    "amundava"
+  ],
+  "ady": [
+    "adigués"
+  ],
+  "ae": [
+    "avéstico"
+  ],
+  "af": [
+    "afrikáans"
+  ],
+  "afa": [
+    "afroasiático"
+  ],
+  "afh": [
+    "afrihili"
+  ],
+  "agr": [
+    "aguaruna"
+  ],
+  "agu": [
+    "aguacateco"
+  ],
+  "agx": [
+    "aghul"
+  ],
+  "ain": [
+    "ainu"
+  ],
+  "aio": [
+    "aiton"
+  ],
+  "ait": [
+    "arikem"
+  ],
+  "ajp": [
+    "árabe levantino meridional"
+  ],
+  "ak": [
+    "acano"
+  ],
+  "akk": [
+    "acadio"
+  ],
+  "ako": [
+    "akurio"
+  ],
+  "akz": [
+    "alabama"
+  ],
+  "alc": [
+    "kawésqar"
+  ],
+  "ale": [
+    "aleutiano"
+  ],
+  "alg": [
+    "algonquiano"
+  ],
+  "aln": [
+    "albanés gheg"
+  ],
+  "alq": [
+    "algonquino"
+  ],
+  "als": [
+    "albanés tosco"
+  ],
+  "alt": [
+    "altay"
+  ],
+  "am": [
+    "amárico"
+  ],
+  "ama": [
+    "amanayé"
+  ],
+  "amc": [
+    "amahuaca"
+  ],
+  "amu": [
+    "amuzgo de Guerrero"
+  ],
+  "an": [
+    "aragonés"
+  ],
+  "ana": [
+    "protoanatolio"
+  ],
+  "anb": [
+    "andoa"
+  ],
+  "and": [
+    "andaquí"
+  ],
+  "ang": [
+    "inglés antiguo"
+  ],
+  "ani": [
+    "andi"
+  ],
+  "anp": [
+    "ánguico"
+  ],
+  "aoa": [
+    "criollo angolar"
+  ],
+  "aoc": [
+    "pemón"
+  ],
+  "aoz": [
+    "uab meto"
+  ],
+  "apa": [
+    "apache"
+  ],
+  "apb": [
+    "saa"
+  ],
+  "api": [
+    "apiacá"
+  ],
+  "apl": [
+    "lipán"
+  ],
+  "apy": [
+    "apalaí"
+  ],
+  "aqc": [
+    "archi"
+  ],
+  "ar": [
+    "árabe"
+  ],
+  "arc": [
+    "arameo"
+  ],
+  "arh": [
+    "arhuaco"
+  ],
+  "arl": [
+    "arabela"
+  ],
+  "arn": [
+    "mapuche"
+  ],
+  "arp": [
+    "arapaho"
+  ],
+  "arq": [
+    "árabe argelino"
+  ],
+  "ars": [
+    "árabe najdi"
+  ],
+  "art": [
+    "artificial"
+  ],
+  "arw": [
+    "arawak"
+  ],
+  "arx": [
+    "aruá"
+  ],
+  "ary": [
+    "árabe marroquí"
+  ],
+  "arz": [
+    "árabe egipcio"
+  ],
+  "as": [
+    "asamés"
+  ],
+  "ask": [
+    "ashkun"
+  ],
+  "asn": [
+    "xingú"
+  ],
+  "ast": [
+    "asturiano"
+  ],
+  "asu": [
+    "asuriní"
+  ],
+  "atc": [
+    "atsahuaca"
+  ],
+  "ath": [
+    "atapasca"
+  ],
+  "atr": [
+    "atruahí"
+  ],
+  "aus": [
+    "australiano"
+  ],
+  "auv": [
+    "auvernés"
+  ],
+  "av": [
+    "avar"
+  ],
+  "avc": [
+    "avéstico clásico"
+  ],
+  "avg": [
+    "avéstico gatha"
+  ],
+  "avk": [
+    "kotava"
+  ],
+  "avs": [
+    "aushiri"
+  ],
+  "avv": [
+    "avá canoero"
+  ],
+  "awa": [
+    "awadhi"
+  ],
+  "awb": [
+    "awá"
+  ],
+  "awe": [
+    "awetí"
+  ],
+  "awt": [
+    "araweté"
+  ],
+  "ay": [
+    "aimara"
+  ],
+  "ayr": [
+    "aimara central"
+  ],
+  "az": [
+    "azerí"
+  ],
+  "azd": [
+    "náhuatl de Durango"
+  ],
+  "azg": [
+    "amuzgo"
+  ],
+  "azn": [
+    "náhuatl de Nayarit"
+  ],
+  "azz": [
+    "náhuatl de la Sierra de Puebla"
+  ],
+  "ba": [
+    "baskir"
+  ],
+  "bad": [
+    "banda"
+  ],
+  "bai": [
+    "bamileke"
+  ],
+  "bal": [
+    "baluchi"
+  ],
+  "ban": [
+    "balinés"
+  ],
+  "bar": [
+    "bávaro"
+  ],
+  "bas": [
+    "basa"
+  ],
+  "bat": [
+    "protobáltico"
+  ],
+  "bbl": [
+    "bácico"
+  ],
+  "bcl": [
+    "bicolano central"
+  ],
+  "bdk": [
+    "budukh"
+  ],
+  "be": [
+    "bielorruso"
+  ],
+  "bej": [
+    "beya"
+  ],
+  "bem": [
+    "bemba"
+  ],
+  "ber": [
+    "bereber"
+  ],
+  "bg": [
+    "búlgaro"
+  ],
+  "bgc": [
+    "haryanví"
+  ],
+  "bh": [
+    "bihari"
+  ],
+  "bhb": [
+    "bhili"
+  ],
+  "bho": [
+    "bhojpuri"
+  ],
+  "bi": [
+    "bislama"
+  ],
+  "bih": [
+    "biharí"
+  ],
+  "bik": [
+    "bicolano"
+  ],
+  "bin": [
+    "edo"
+  ],
+  "bjj": [
+    "kanauji"
+  ],
+  "bjn": [
+    "banjar"
+  ],
+  "bjz": [
+    "baruga"
+  ],
+  "bkq": [
+    "bacairí"
+  ],
+  "bla": [
+    "pie negro"
+  ],
+  "bll": [
+    "biloxi"
+  ],
+  "blt": [
+    "tai dam"
+  ],
+  "bm": [
+    "bambara"
+  ],
+  "bmr": [
+    "muinane"
+  ],
+  "bn": [
+    "bengalí"
+  ],
+  "bni": [
+    "bangui"
+  ],
+  "bns": [
+    "bundeli"
+  ],
+  "bnt": [
+    "bantú"
+  ],
+  "bo": [
+    "tibetano"
+  ],
+  "boa": [
+    "bora"
+  ],
+  "bpy": [
+    "bishnupriya manipuri"
+  ],
+  "bqc": [
+    "boko"
+  ],
+  "br": [
+    "bretón"
+  ],
+  "bra": [
+    "brijbhasha"
+  ],
+  "brg": [
+    "bauré"
+  ],
+  "brn": [
+    "boruca"
+  ],
+  "brx": [
+    "bodo"
+  ],
+  "bs": [
+    "bosnio"
+  ],
+  "bsb": [
+    "bisaya"
+  ],
+  "bsn": [
+    "barasana"
+  ],
+  "btk": [
+    "batak"
+  ],
+  "bua": [
+    "buriato"
+  ],
+  "bug": [
+    "buguinés"
+  ],
+  "bvb": [
+    "bubi"
+  ],
+  "bvi": [
+    "Baybay"
+  ],
+  "bwu": [
+    "buli"
+  ],
+  "byf": [
+    "beté"
+  ],
+  "byn": [
+    "bilín"
+  ],
+  "bzd": [
+    "bribri"
+  ],
+  "ca": [
+    "catalán"
+  ],
+  "caa": [
+    "chortí"
+  ],
+  "cab": [
+    "garífuna"
+  ],
+  "cac": [
+    "chuj"
+  ],
+  "cad": [
+    "caddo"
+  ],
+  "cag": [
+    "nivaclé"
+  ],
+  "cah": [
+    "cahuarano"
+  ],
+  "cai": [
+    "lenguas centroamericanas"
+  ],
+  "cak": [
+    "cachiquel"
+  ],
+  "cal": [
+    "carolino"
+  ],
+  "cap": [
+    "chipaya"
+  ],
+  "car": [
+    "taíno"
+  ],
+  "cau": [
+    "lenguas caucásicas"
+  ],
+  "cax": [
+    "chiquitano"
+  ],
+  "cay": [
+    "cayuga"
+  ],
+  "cba": [
+    "protochibcha"
+  ],
+  "cbc": [
+    "karapaná"
+  ],
+  "cbd": [
+    "carijona"
+  ],
+  "cbg": [
+    "chimila"
+  ],
+  "cbi": [
+    "chachi"
+  ],
+  "cbk": [
+    "chabacano"
+  ],
+  "cbk-zam": [
+    "chabacano de Zamboanga"
+  ],
+  "cbr": [
+    "kashibo"
+  ],
+  "cbs": [
+    "cashinahua"
+  ],
+  "cbt": [
+    "shawi"
+  ],
+  "ccc": [
+    "chamicuro"
+  ],
+  "cco": [
+    "chinanteco serrano"
+  ],
+  "ccr": [
+    "cacaopera"
+  ],
+  "ccx": [
+    "chuan septentrional"
+  ],
+  "ccy": [
+    "chuan meridional"
+  ],
+  "cdo": [
+    "min dong"
+  ],
+  "cdz": [
+    "koda"
+  ],
+  "ce": [
+    "checheno"
+  ],
+  "ceb": [
+    "cebuano"
+  ],
+  "cel": [
+    "protocelta"
+  ],
+  "cel-bry": [
+    "protobritónico"
+  ],
+  "cel-gau": [
+    "galo"
+  ],
+  "cgg": [
+    "rukiga"
+  ],
+  "ch": [
+    "chamorro"
+  ],
+  "chb": [
+    "chibcha"
+  ],
+  "chc": [
+    "catabwa"
+  ],
+  "chd": [
+    "chontal de la zona alta de Oaxaca"
+  ],
+  "chf": [
+    "chontal de Tabasco"
+  ],
+  "chg": [
+    "chagatay"
+  ],
+  "chk": [
+    "chúquico"
+  ],
+  "chl": [
+    "cahuilla"
+  ],
+  "chm": [
+    "mari"
+  ],
+  "chn": [
+    "criollo chinook"
+  ],
+  "cho": [
+    "choctaw"
+  ],
+  "chono": [
+    "chono"
+  ],
+  "chp": [
+    "chipewa"
+  ],
+  "chr": [
+    "cheroqui"
+  ],
+  "chs": [
+    "chumash"
+  ],
+  "cht": [
+    "cholón"
+  ],
+  "chy": [
+    "cheyene"
+  ],
+  "cic": [
+    "chicasaw"
+  ],
+  "cid": [
+    "chimariko"
+  ],
+  "cin": [
+    "cinta larga"
+  ],
+  "cip": [
+    "chiapaneco"
+  ],
+  "ciy": [
+    "chaima"
+  ],
+  "cji": [
+    "chamalal"
+  ],
+  "cjp": [
+    "cabécar"
+  ],
+  "cjs": [
+    "shor"
+  ],
+  "cjy": [
+    "chino jìn"
+  ],
+  "ckb": [
+    "kurdo central"
+  ],
+  "ckt": [
+    "chukchi"
+  ],
+  "cku": [
+    "koasati"
+  ],
+  "ckv": [
+    "kavalan"
+  ],
+  "cld": [
+    "caldeo"
+  ],
+  "clm": [
+    "klallam"
+  ],
+  "clo": [
+    "tequistlateco bajo"
+  ],
+  "cmc": [
+    "chámico"
+  ],
+  "cmg": [
+    "mongol antiguo"
+  ],
+  "cmn": [
+    "mandarín"
+  ],
+  "cms": [
+    "mesapio"
+  ],
+  "cni": [
+    "asháninca"
+  ],
+  "cnx": [
+    "córnico medio"
+  ],
+  "co": [
+    "corso"
+  ],
+  "coc": [
+    "cucapá"
+  ],
+  "cod": [
+    "cocama"
+  ],
+  "cof": [
+    "colorado"
+  ],
+  "coj": [
+    "cochimí"
+  ],
+  "com": [
+    "comanche"
+  ],
+  "con": [
+    "cofán"
+  ],
+  "cop": [
+    "copto"
+  ],
+  "cov": [
+    "cao miao"
+  ],
+  "coz": [
+    "chocho"
+  ],
+  "cpg": [
+    "griego capadocio"
+  ],
+  "cqu": [
+    "quechua chileno"
+  ],
+  "cr": [
+    "cree"
+  ],
+  "crg": [
+    "michif"
+  ],
+  "crh": [
+    "tártaro de Crimea"
+  ],
+  "cri": [
+    "criollo santotomense"
+  ],
+  "crn": [
+    "cora"
+  ],
+  "cro": [
+    "crow"
+  ],
+  "crs": [
+    "criollo seychelense"
+  ],
+  "crz": [
+    "cruzeño"
+  ],
+  "cs": [
+    "checo"
+  ],
+  "csb": [
+    "casubio"
+  ],
+  "csi": [
+    "miwok costanoano"
+  ],
+  "csz": [
+    "coos"
+  ],
+  "cta": [
+    "chatino de Tataltepec"
+  ],
+  "ctm": [
+    "chitimacha"
+  ],
+  "ctp": [
+    "chatino central"
+  ],
+  "ctu": [
+    "chol"
+  ],
+  "ctz": [
+    "chatino de Zacatepec"
+  ],
+  "cu": [
+    "eslavo eclesiástico antiguo"
+  ],
+  "cub": [
+    "cubeo"
+  ],
+  "cui": [
+    "cuiba"
+  ],
+  "cuk": [
+    "kuna"
+  ],
+  "cuo": [
+    "cumanagoto"
+  ],
+  "cup": [
+    "cupeño"
+  ],
+  "cux": [
+    "cuicateco central"
+  ],
+  "cv": [
+    "chuvasio"
+  ],
+  "cy": [
+    "galés"
+  ],
+  "cya": [
+    "chatino de Nopala"
+  ],
+  "czn": [
+    "chatino de Zenzontepec"
+  ],
+  "da": [
+    "danés"
+  ],
+  "dak": [
+    "dakota"
+  ],
+  "dar": [
+    "darguano"
+  ],
+  "day": [
+    "dayaco"
+  ],
+  "ddo": [
+    "dido"
+  ],
+  "de": [
+    "alemán"
+  ],
+  "del": [
+    "delaware"
+  ],
+  "den": [
+    "awokanak"
+  ],
+  "dgr": [
+    "dogrib"
+  ],
+  "dhv": [
+    "drhu"
+  ],
+  "dih": [
+    "kumiai"
+  ],
+  "dih-tip": [
+    "tipai"
+  ],
+  "din": [
+    "dinka"
+  ],
+  "diq": [
+    "zazaki"
+  ],
+  "diu": [
+    "diriku"
+  ],
+  "djk": [
+    "ndyuka"
+  ],
+  "dlg": [
+    "dolgán"
+  ],
+  "dlm": [
+    "dálmata"
+  ],
+  "dog": [
+    "dogon"
+  ],
+  "doi": [
+    "dogri"
+  ],
+  "dra": [
+    "dravídico"
+  ],
+  "drc": [
+    "minderico"
+  ],
+  "dsb": [
+    "bajo sórabo"
+  ],
+  "dty": [
+    "doteli"
+  ],
+  "dua": [
+    "duala"
+  ],
+  "dum": [
+    "neerlandés medio"
+  ],
+  "dv": [
+    "dhivehi"
+  ],
+  "dyu": [
+    "diula"
+  ],
+  "dz": [
+    "dzongkha"
+  ],
+  "ee": [
+    "ewe"
+  ],
+  "efi": [
+    "efik"
+  ],
+  "egl": [
+    "emiliano"
+  ],
+  "egy": [
+    "egipcio antiguo"
+  ],
+  "eka": [
+    "acayo"
+  ],
+  "ekg": [
+    "ekari"
+  ],
+  "el": [
+    "griego"
+  ],
+  "elx": [
+    "elamita"
+  ],
+  "eme": [
+    "emerillon"
+  ],
+  "eml": [
+    "emiliano-romañolo"
+  ],
+  "emx": [
+    "erromintxela"
+  ],
+  "en": [
+    "inglés"
+  ],
+  "enm": [
+    "inglés medio"
+  ],
+  "eo": [
+    "esperanto"
+  ],
+  "eri": [
+    "ogea"
+  ],
+  "es": [
+    "español"
+  ],
+  "esh": [
+    "eshtehardi"
+  ],
+  "esu": [
+    "yupik central"
+  ],
+  "et": [
+    "estonio"
+  ],
+  "ett": [
+    "etrusco"
+  ],
+  "eu": [
+    "euskera"
+  ],
+  "euq": [
+    "protovasco"
+  ],
+  "evn": [
+    "evenki"
+  ],
+  "ewo": [
+    "ewondo"
+  ],
+  "ext": [
+    "extremeño"
+  ],
+  "fa": [
+    "persa"
+  ],
+  "fab": [
+    "annobonés"
+  ],
+  "fan": [
+    "fang"
+  ],
+  "fat": [
+    "fante"
+  ],
+  "fax": [
+    "fala"
+  ],
+  "fc": [
+    "franco-contés"
+  ],
+  "ff": [
+    "fula"
+  ],
+  "fi": [
+    "finés"
+  ],
+  "fil": [
+    "filipino"
+  ],
+  "fiu": [
+    "protougrofinés"
+  ],
+  "fj": [
+    "fiyiano"
+  ],
+  "fo": [
+    "feroés"
+  ],
+  "fon": [
+    "fon"
+  ],
+  "fr": [
+    "francés"
+  ],
+  "frk": [
+    "fráncico"
+  ],
+  "frm": [
+    "francés medio"
+  ],
+  "fro": [
+    "francés antiguo"
+  ],
+  "frp": [
+    "francoprovenzal"
+  ],
+  "frr": [
+    "frisón septentrional"
+  ],
+  "frs": [
+    "frisón oriental"
+  ],
+  "fry": [
+    "frisón occidental"
+  ],
+  "fur": [
+    "friulano"
+  ],
+  "fy": [
+    "frisón"
+  ],
+  "ga": [
+    "irlandés"
+  ],
+  "gaa": [
+    "ga"
+  ],
+  "gag": [
+    "gagauzo"
+  ],
+  "gal": [
+    "galoli"
+  ],
+  "gan": [
+    "gàn"
+  ],
+  "gay": [
+    "gayo"
+  ],
+  "gba": [
+    "gabaya"
+  ],
+  "gcf": [
+    "criollo de Guadalupe"
+  ],
+  "gd": [
+    "gaélico escocés"
+  ],
+  "gdm": [
+    "laal"
+  ],
+  "gdo": [
+    "ghodoberi"
+  ],
+  "gem-pro": [
+    "protogermánico"
+  ],
+  "gey": [
+    "enya"
+  ],
+  "gez": [
+    "yehén"
+  ],
+  "ghc": [
+    "gaélico clásico"
+  ],
+  "gil": [
+    "kiribasiano"
+  ],
+  "gin": [
+    "hinukh"
+  ],
+  "gis": [
+    "giziga septentrional"
+  ],
+  "giz": [
+    "giziga meridional"
+  ],
+  "gl": [
+    "gallego"
+  ],
+  "gme-cgo": [
+    "gótico de Crimea"
+  ],
+  "gmh": [
+    "alemán medio"
+  ],
+  "gml": [
+    "bajo alemán medio"
+  ],
+  "gmw": [
+    "germánico occidental"
+  ],
+  "gmy": [
+    "griego micénico"
+  ],
+  "gn": [
+    "guaraní"
+  ],
+  "gnc": [
+    "guanche"
+  ],
+  "gni": [
+    "gooniyandi"
+  ],
+  "goh": [
+    "alemán antiguo"
+  ],
+  "gon": [
+    "gondi"
+  ],
+  "gor": [
+    "gorontalo"
+  ],
+  "got": [
+    "gótico"
+  ],
+  "grb": [
+    "grebo"
+  ],
+  "grc": [
+    "griego antiguo"
+  ],
+  "gsc": [
+    "gascón"
+  ],
+  "gsw": [
+    "alemánico"
+  ],
+  "gu": [
+    "guyaratí"
+  ],
+  "gub": [
+    "guajajara"
+  ],
+  "guc": [
+    "guajiro"
+  ],
+  "gum": [
+    "guambiano"
+  ],
+  "gun": [
+    "mbyá"
+  ],
+  "guo": [
+    "guayabero"
+  ],
+  "guq": [
+    "aché"
+  ],
+  "gut": [
+    "guatuso"
+  ],
+  "gv": [
+    "manés"
+  ],
+  "gvc": [
+    "guanano"
+  ],
+  "gvj": [
+    "guajá"
+  ],
+  "gvo": [
+    "gavión de Jiparaná"
+  ],
+  "gwi": [
+    "kutchín"
+  ],
+  "gwj": [
+    "gǀwi"
+  ],
+  "gym": [
+    "ngabere"
+  ],
+  "gyr": [
+    "guarayú"
+  ],
+  "ha": [
+    "hausa"
+  ],
+  "hai": [
+    "haida"
+  ],
+  "hak": [
+    "hakka"
+  ],
+  "haw": [
+    "hawaiano"
+  ],
+  "hbo": [
+    "hebreo antiguo"
+  ],
+  "hch": [
+    "huichol"
+  ],
+  "he": [
+    "hebreo"
+  ],
+  "hi": [
+    "hindi"
+  ],
+  "hid": [
+    "hidatsa"
+  ],
+  "hif": [
+    "hindi de Fiji"
+  ],
+  "hil": [
+    "hiligainón"
+  ],
+  "him": [
+    "himachalí"
+  ],
+  "hit": [
+    "hitita"
+  ],
+  "hlu": [
+    "luvita jeroglífico"
+  ],
+  "hmn": [
+    "hmong"
+  ],
+  "hmr": [
+    "hmar"
+  ],
+  "hne": [
+    "chhattisgarhí"
+  ],
+  "ho": [
+    "hiri motu"
+  ],
+  "hop": [
+    "hopi"
+  ],
+  "hr": [
+    "croata"
+  ],
+  "hrx": [
+    "hunsrik"
+  ],
+  "hsb": [
+    "alto sórabo"
+  ],
+  "ht": [
+    "criollo haitiano"
+  ],
+  "hti": [
+    "hodi"
+  ],
+  "hto": [
+    "minica"
+  ],
+  "hu": [
+    "húngaro"
+  ],
+  "huh": [
+    "huilliche"
+  ],
+  "hup": [
+    "hupa"
+  ],
+  "hus": [
+    "huasteco"
+  ],
+  "huu": [
+    "murui"
+  ],
+  "huv": [
+    "huave"
+  ],
+  "hux": [
+    "nipode"
+  ],
+  "huz": [
+    "hunzib"
+  ],
+  "hwc": [
+    "criollo hawaiano"
+  ],
+  "hy": [
+    "armenio"
+  ],
+  "hz": [
+    "herero"
+  ],
+  "ia": [
+    "interlingua"
+  ],
+  "iba": [
+    "dayaco"
+  ],
+  "id": [
+    "indonesio"
+  ],
+  "idb": [
+    "indoportugués"
+  ],
+  "ie": [
+    "occidental"
+  ],
+  "ig": [
+    "igbo"
+  ],
+  "ii": [
+    "lolo de Sichuán"
+  ],
+  "iii": [
+    "yi de Sichuán"
+  ],
+  "iir": [
+    "protoindoiranio"
+  ],
+  "ijo": [
+    "iyo"
+  ],
+  "ik": [
+    "inupiaq"
+  ],
+  "ilb": [
+    "ila"
+  ],
+  "ilo": [
+    "ilocano"
+  ],
+  "inb": [
+    "quichua inga"
+  ],
+  "inc": [
+    "índic"
+  ],
+  "ine": [
+    "protoindoeuropeo"
+  ],
+  "inh": [
+    "inguso"
+  ],
+  "inz": [
+    "ineseño"
+  ],
+  "io": [
+    "ido"
+  ],
+  "iqu": [
+    "iquito"
+  ],
+  "ira": [
+    "iraní"
+  ],
+  "iro": [
+    "iroqués"
+  ],
+  "is": [
+    "islandés"
+  ],
+  "isc": [
+    "isconahua"
+  ],
+  "ist": [
+    "istrio"
+  ],
+  "it": [
+    "italiano"
+  ],
+  "itc": [
+    "protoitálico"
+  ],
+  "itc-ola": [
+    "latín antiguo"
+  ],
+  "ite": [
+    "itene"
+  ],
+  "itk": [
+    "judeoitaliano"
+  ],
+  "itz": [
+    "Itzá"
+  ],
+  "iu": [
+    "inuktitut"
+  ],
+  "ivv": [
+    "ibatán"
+  ],
+  "ixc": [
+    "ixcateco"
+  ],
+  "ixl": [
+    "ixil"
+  ],
+  "izh": [
+    "izoriano"
+  ],
+  "ja": [
+    "japonés"
+  ],
+  "jac": [
+    "jacalteco"
+  ],
+  "jam": [
+    "criollo jamaicano"
+  ],
+  "jao": [
+    "yanyuwa"
+  ],
+  "jbo": [
+    "lojban"
+  ],
+  "jiv": [
+    "jíbaro"
+  ],
+  "jje": [
+    "jeju"
+  ],
+  "jpr": [
+    "judeopersa"
+  ],
+  "jpx": [
+    "protojapónico"
+  ],
+  "jqr": [
+    "jacaru"
+  ],
+  "jrb": [
+    "judeoárabe"
+  ],
+  "jup": [
+    "judpa"
+  ],
+  "jv": [
+    "javanés"
+  ],
+  "ka": [
+    "georgiano"
+  ],
+  "kaa": [
+    "karakalpako"
+  ],
+  "kab": [
+    "cabil"
+  ],
+  "kac": [
+    "kachín"
+  ],
+  "kam": [
+    "kikamba"
+  ],
+  "kap": [
+    "bezhta"
+  ],
+  "kar": [
+    "karen"
+  ],
+  "kav": [
+    "katukina"
+  ],
+  "kaw": [
+    "cavi"
+  ],
+  "kay": [
+    "kamayurá"
+  ],
+  "kbc": [
+    "caduveo"
+  ],
+  "kbd": [
+    "cabardo"
+  ],
+  "kbh": [
+    "camsá"
+  ],
+  "kca": [
+    "janti"
+  ],
+  "kdr": [
+    "karaim"
+  ],
+  "kea": [
+    "caboverdiano"
+  ],
+  "kek": [
+    "kekchí"
+  ],
+  "keo": [
+    "kakwa"
+  ],
+  "kff": [
+    "koya"
+  ],
+  "kfk": [
+    "kinnauri"
+  ],
+  "kfp": [
+    "korwa"
+  ],
+  "kg": [
+    "kikongo"
+  ],
+  "kgk": [
+    "kaiwá"
+  ],
+  "kgm": [
+    "karipuna"
+  ],
+  "kha": [
+    "jasí"
+  ],
+  "khb": [
+    "tai lü"
+  ],
+  "khi": [
+    "joisano"
+  ],
+  "khn": [
+    "jandeshi"
+  ],
+  "kho": [
+    "jotanés"
+  ],
+  "khr": [
+    "jaria"
+  ],
+  "khw": [
+    "khowar"
+  ],
+  "ki": [
+    "kikuyu"
+  ],
+  "kic": [
+    "kikapú"
+  ],
+  "kim": [
+    "tofa"
+  ],
+  "kio": [
+    "kiowa"
+  ],
+  "kj": [
+    "ovambo"
+  ],
+  "kjb": [
+    "kanjobal"
+  ],
+  "kjh": [
+    "jakas"
+  ],
+  "kjj": [
+    "khinalug"
+  ],
+  "kk": [
+    "kazajo"
+  ],
+  "kky": [
+    "guugu yimidir"
+  ],
+  "kl": [
+    "groenlandés"
+  ],
+  "klb": [
+    "kiliwa"
+  ],
+  "kld": [
+    "gamilaraay"
+  ],
+  "klj": [
+    "jalaj"
+  ],
+  "km": [
+    "camboyano"
+  ],
+  "kmb": [
+    "quimbundo"
+  ],
+  "kms": [
+    "kamasau"
+  ],
+  "kmz": [
+    "jorasán"
+  ],
+  "kn": [
+    "kannada"
+  ],
+  "knd": [
+    "konda"
+  ],
+  "knj": [
+    "acateco"
+  ],
+  "knn": [
+    "konkani"
+  ],
+  "knt": [
+    "katukina"
+  ],
+  "ko": [
+    "coreano"
+  ],
+  "kog": [
+    "cogui"
+  ],
+  "koi": [
+    "komi permio"
+  ],
+  "kok": [
+    "konkani"
+  ],
+  "kos": [
+    "kosraeano"
+  ],
+  "kpe": [
+    "kpelle"
+  ],
+  "kpt": [
+    "karata"
+  ],
+  "kpv": [
+    "ciriano"
+  ],
+  "kr": [
+    "kanuri"
+  ],
+  "krc": [
+    "karachayo-bálkaro"
+  ],
+  "krl": [
+    "carelio"
+  ],
+  "kro": [
+    "kru"
+  ],
+  "kru": [
+    "curuj"
+  ],
+  "kry": [
+    "kryts"
+  ],
+  "ks": [
+    "cachemiro"
+  ],
+  "ksh": [
+    "fráncico ripuario"
+  ],
+  "ksi": [
+    "i'saka"
+  ],
+  "ktu": [
+    "kituba"
+  ],
+  "ku": [
+    "kurdo"
+  ],
+  "kum": [
+    "kumyko"
+  ],
+  "kus": [
+    "kusaal"
+  ],
+  "kut": [
+    "kutenai"
+  ],
+  "kuz": [
+    "kunza"
+  ],
+  "kv": [
+    "komi"
+  ],
+  "kva": [
+    "bagvalal"
+  ],
+  "kvn": [
+    "kuna"
+  ],
+  "kw": [
+    "córnico"
+  ],
+  "kxo": [
+    "kanoé"
+  ],
+  "kxu": [
+    "kui"
+  ],
+  "ky": [
+    "kirguís"
+  ],
+  "kyh": [
+    "karok"
+  ],
+  "kyj": [
+    "karao"
+  ],
+  "kyr": [
+    "kuruaya"
+  ],
+  "kyz": [
+    "kayabí"
+  ],
+  "kzg": [
+    "kikai"
+  ],
+  "la": [
+    "latín"
+  ],
+  "la-lat": [
+    "latín tardío"
+  ],
+  "la-med": [
+    "latín medieval"
+  ],
+  "la-neo": [
+    "neolatín"
+  ],
+  "la-vul": [
+    "latín vulgar"
+  ],
+  "lac": [
+    "lacandón"
+  ],
+  "lad": [
+    "judeoespañol"
+  ],
+  "lah": [
+    "landi"
+  ],
+  "lam": [
+    "lamba"
+  ],
+  "lb": [
+    "luxemburgués"
+  ],
+  "lbe": [
+    "lak"
+  ],
+  "len": [
+    "lenca"
+  ],
+  "lez": [
+    "lesguiano"
+  ],
+  "lfn": [
+    "lingua franca nova"
+  ],
+  "lg": [
+    "luganda"
+  ],
+  "li": [
+    "limburgués"
+  ],
+  "lij": [
+    "ligur"
+  ],
+  "lkt": [
+    "lakota"
+  ],
+  "lld": [
+    "ladino"
+  ],
+  "lmo": [
+    "lombardo"
+  ],
+  "ln": [
+    "lingala"
+  ],
+  "lng": [
+    "longobardo"
+  ],
+  "lo": [
+    "lao"
+  ],
+  "lol": [
+    "mongo"
+  ],
+  "lou": [
+    "criollo luisianés"
+  ],
+  "loz": [
+    "silozi"
+  ],
+  "lre": [
+    "laurenciano"
+  ],
+  "lt": [
+    "lituano"
+  ],
+  "ltc": [
+    "chino medieval"
+  ],
+  "ltg": [
+    "latgaliano"
+  ],
+  "lu": [
+    "tshiluba katanga"
+  ],
+  "lua": [
+    "tshiluba"
+  ],
+  "lug": [
+    "luganda"
+  ],
+  "lui": [
+    "luiseño"
+  ],
+  "lun": [
+    "chilunda"
+  ],
+  "luo": [
+    "luo"
+  ],
+  "lus": [
+    "lusai"
+  ],
+  "lut": [
+    "lushootseed"
+  ],
+  "luy": [
+    "luyia"
+  ],
+  "lv": [
+    "letón"
+  ],
+  "lym": [
+    "cochimí laymón"
+  ],
+  "lzz": [
+    "laz"
+  ],
+  "maa": [
+    "mazateco de Tecóatl"
+  ],
+  "mad": [
+    "madurés"
+  ],
+  "mag": [
+    "magadi"
+  ],
+  "mai": [
+    "maitili"
+  ],
+  "mak": [
+    "macasar"
+  ],
+  "mam": [
+    "mam"
+  ],
+  "man": [
+    "mandingo"
+  ],
+  "map": [
+    "austronesio"
+  ],
+  "mas": [
+    "masái"
+  ],
+  "mat": [
+    "matlatzinca"
+  ],
+  "mau": [
+    "mazateco de Huautla"
+  ],
+  "mav": [
+    "mawé"
+  ],
+  "maz": [
+    "mazahua central"
+  ],
+  "mcm": [
+    "criollo de Malaca"
+  ],
+  "mdf": [
+    "moksha"
+  ],
+  "mdh": [
+    "maguindánao"
+  ],
+  "mdr": [
+    "mandar"
+  ],
+  "mel": [
+    "melanau"
+  ],
+  "men": [
+    "mende"
+  ],
+  "mer": [
+    "kimeru"
+  ],
+  "mfe": [
+    "criollo mauriciano"
+  ],
+  "mfr": [
+    "marithiel"
+  ],
+  "mfy": [
+    "mayo"
+  ],
+  "mg": [
+    "malgache"
+  ],
+  "mga": [
+    "irlandés medio"
+  ],
+  "mh": [
+    "marshalés"
+  ],
+  "mhc": [
+    "mochó"
+  ],
+  "mhr": [
+    "mari oriental"
+  ],
+  "mi": [
+    "maorí"
+  ],
+  "mic": [
+    "micmac"
+  ],
+  "mig": [
+    "mixteco de San Miguel el Grande"
+  ],
+  "min": [
+    "minangkabau"
+  ],
+  "miq": [
+    "miskito"
+  ],
+  "mit": [
+    "mixteco del sur de Puebla"
+  ],
+  "mjc": [
+    "mixteco de San Juan Colorado"
+  ],
+  "mjw": [
+    "karbí"
+  ],
+  "mk": [
+    "macedonio"
+  ],
+  "mkh": [
+    "mon-jémer"
+  ],
+  "mkj": [
+    "mokilés"
+  ],
+  "ml": [
+    "malayalam"
+  ],
+  "mmc": [
+    "mazahua de Michoacán"
+  ],
+  "mmn": [
+    "mamanoá"
+  ],
+  "mn": [
+    "mongol"
+  ],
+  "mnc": [
+    "manchú"
+  ],
+  "mni": [
+    "manipuri"
+  ],
+  "mnk": [
+    "mandinga"
+  ],
+  "mno": [
+    "manobo"
+  ],
+  "mnw": [
+    "mon"
+  ],
+  "mo": [
+    "moldavo"
+  ],
+  "moc": [
+    "mocoví"
+  ],
+  "moe": [
+    "montañés"
+  ],
+  "moh": [
+    "mohawk"
+  ],
+  "mol": [
+    "molokano"
+  ],
+  "mop": [
+    "mopán"
+  ],
+  "mos": [
+    "mossi"
+  ],
+  "mpm": [
+    "mixteco de Yosondúa"
+  ],
+  "mqm": [
+    "marquesano del sur"
+  ],
+  "mr": [
+    "maratí"
+  ],
+  "mrc": [
+    "maricopa"
+  ],
+  "mrj": [
+    "mari occidental"
+  ],
+  "mrq": [
+    "marquesano del norte"
+  ],
+  "mrv": [
+    "mangarevano"
+  ],
+  "mrw": [
+    "maranao"
+  ],
+  "ms": [
+    "malayo"
+  ],
+  "msf": [
+    "mekwei"
+  ],
+  "mt": [
+    "maltés"
+  ],
+  "mtn": [
+    "matagalpa"
+  ],
+  "mto": [
+    "mixe de Totontepec"
+  ],
+  "mun": [
+    "munda"
+  ],
+  "mus": [
+    "maskoki"
+  ],
+  "mwl": [
+    "mirandés"
+  ],
+  "mwr": [
+    "marvari"
+  ],
+  "mxi": [
+    "mozárabe"
+  ],
+  "my": [
+    "birmano"
+  ],
+  "myn": [
+    "maya clásico"
+  ],
+  "myn-pro": [
+    "protomaya"
+  ],
+  "myp": [
+    "pirahã"
+  ],
+  "myv": [
+    "erzya"
+  ],
+  "myx": [
+    "masaba"
+  ],
+  "mza": [
+    "tacuate"
+  ],
+  "mzn": [
+    "mazandaraní"
+  ],
+  "mzp": [
+    "movima"
+  ],
+  "mzs": [
+    "macanés"
+  ],
+  "na": [
+    "nauruano"
+  ],
+  "nah": [
+    "náhuatl"
+  ],
+  "nai": [
+    "o'odham"
+  ],
+  "nai-miz-pro": [
+    "protomixe-zoque"
+  ],
+  "nam": [
+    "nangikurrunggurr"
+  ],
+  "nan": [
+    "min nan"
+  ],
+  "nap": [
+    "napolitano"
+  ],
+  "nay": [
+    "ngarinyeri"
+  ],
+  "naz": [
+    "náhuatl de Coatepec"
+  ],
+  "nbx": [
+    "naxi"
+  ],
+  "ncb": [
+    "nicobarés central"
+  ],
+  "nch": [
+    "náhuatl de la Huasteca central"
+  ],
+  "nci": [
+    "náhuatl clásico"
+  ],
+  "ncj": [
+    "náhuatl del norte de Puebla"
+  ],
+  "ncl": [
+    "náhuatl de Michoacán"
+  ],
+  "ncx": [
+    "náhuatl de Puebla central"
+  ],
+  "ncz": [
+    "natchez"
+  ],
+  "nd": [
+    "sindebele"
+  ],
+  "nds": [
+    "bajo alemán"
+  ],
+  "nds-nl": [
+    "bajo sajón neerlandés"
+  ],
+  "ne": [
+    "nepalés"
+  ],
+  "nea": [
+    "ngadha"
+  ],
+  "new": [
+    "newari"
+  ],
+  "nez": [
+    "nez percé"
+  ],
+  "nfr": [
+    "nafaanra"
+  ],
+  "ng": [
+    "ndonga"
+  ],
+  "ngu": [
+    "náhuatl de Guerrero"
+  ],
+  "nhc": [
+    "náhuatl de Tabasco"
+  ],
+  "nhd": [
+    "chiripá"
+  ],
+  "nhe": [
+    "náhuatl de la Huasteca oriental"
+  ],
+  "nhg": [
+    "náhuatl de Tetelcingo"
+  ],
+  "nhi": [
+    "náhuatl de Zacatlán"
+  ],
+  "nhj": [
+    "náhuatl de Tlalitzlipa"
+  ],
+  "nhk": [
+    "náhuatl de Cosoleacaque"
+  ],
+  "nhm": [
+    "náhuatl de Morelos"
+  ],
+  "nhn": [
+    "náhuatl central"
+  ],
+  "nhp": [
+    "náhuatl de Pajapan"
+  ],
+  "nht": [
+    "náhuatl de Ometepec"
+  ],
+  "nhv": [
+    "náhuatl de Temascaltepec"
+  ],
+  "nhw": [
+    "náhuatl de la Huasteca occidental"
+  ],
+  "nhx": [
+    "náhuatl de Mecayapan"
+  ],
+  "nhy": [
+    "náhuatl de Oaxaca"
+  ],
+  "nia": [
+    "nias"
+  ],
+  "nic": [
+    "níger-cordofano"
+  ],
+  "niu": [
+    "niuano"
+  ],
+  "nl": [
+    "neerlandés"
+  ],
+  "nlv": [
+    "náhuatl de Orizaba"
+  ],
+  "nmn": [
+    "ǃxóõ"
+  ],
+  "nn": [
+    "noruego nynorsk"
+  ],
+  "no": [
+    "noruego bokmål"
+  ],
+  "nod": [
+    "tailandés septentrional"
+  ],
+  "nog": [
+    "nogay"
+  ],
+  "non": [
+    "nórdico antiguo"
+  ],
+  "non-swe": [
+    "sueco antiguo"
+  ],
+  "nov": [
+    "novial"
+  ],
+  "nr": [
+    "nrebele"
+  ],
+  "nrf": [
+    "jerseyés y guerneseyés"
+  ],
+  "nsk": [
+    "naskapi"
+  ],
+  "nso": [
+    "sotho norteño"
+  ],
+  "nsu": [
+    "náhuatl de la Sierra Negra"
+  ],
+  "nto": [
+    "ntomba"
+  ],
+  "ntp": [
+    "tepehuano septentrional"
+  ],
+  "nub": [
+    "nubio"
+  ],
+  "nuc": [
+    "nukuini"
+  ],
+  "nuz": [
+    "náhuatl de Tlamacazapa"
+  ],
+  "nv": [
+    "navajo"
+  ],
+  "nwc": [
+    "newari clásico"
+  ],
+  "ny": [
+    "chewa"
+  ],
+  "nya": [
+    "ñanya"
+  ],
+  "nym": [
+    "nyamwezi"
+  ],
+  "nyn": [
+    "nyankole"
+  ],
+  "nyo": [
+    "runyoro"
+  ],
+  "nzi": [
+    "nzema"
+  ],
+  "oar": [
+    "arameo antiguo"
+  ],
+  "obt": [
+    "bretón antiguo"
+  ],
+  "oc": [
+    "occitano"
+  ],
+  "oca": [
+    "catalán antiguo"
+  ],
+  "oco": [
+    "córnico antiguo"
+  ],
+  "ocu": [
+    "tlahuica"
+  ],
+  "odt": [
+    "holandés antiguo"
+  ],
+  "ofs": [
+    "frisón antiguo"
+  ],
+  "oj": [
+    "ojibwe"
+  ],
+  "ojp": [
+    "japonés antiguo"
+  ],
+  "okm": [
+    "coreano medio"
+  ],
+  "oko": [
+    "coreano antiguo"
+  ],
+  "olt": [
+    "lituano antiguo"
+  ],
+  "om": [
+    "oromo"
+  ],
+  "omc": [
+    "mochica"
+  ],
+  "ona": [
+    "ona"
+  ],
+  "or": [
+    "oriya"
+  ],
+  "orv": [
+    "ruteno antiguo"
+  ],
+  "os": [
+    "oseta"
+  ],
+  "osa": [
+    "osage"
+  ],
+  "osc": [
+    "osco"
+  ],
+  "osp": [
+    "castellano antiguo"
+  ],
+  "osx": [
+    "sajón antiguo"
+  ],
+  "ota": [
+    "turco otomano"
+  ],
+  "ote": [
+    "otomí del Valle del Mezquital"
+  ],
+  "otk": [
+    "turco antiguo"
+  ],
+  "otm": [
+    "otomí de la Sierra"
+  ],
+  "oto": [
+    "protootomí"
+  ],
+  "otq": [
+    "otomí de Querétaro"
+  ],
+  "ots": [
+    "otomí central"
+  ],
+  "ott": [
+    "otomí de Temoaya"
+  ],
+  "otw": [
+    "ottawa"
+  ],
+  "otz": [
+    "otomí de Ixtenco"
+  ],
+  "owl": [
+    "galés antiguo"
+  ],
+  "oym": [
+    "wayampi"
+  ],
+  "pa": [
+    "panyabí"
+  ],
+  "paa": [
+    "papuano"
+  ],
+  "pad": [
+    "paumarí"
+  ],
+  "pag": [
+    "pangasinán"
+  ],
+  "pal": [
+    "persa medio"
+  ],
+  "pam": [
+    "pampango"
+  ],
+  "pap": [
+    "papiamento"
+  ],
+  "pau": [
+    "palauano"
+  ],
+  "pbb": [
+    "paez"
+  ],
+  "pcd": [
+    "picardo"
+  ],
+  "pdc": [
+    "alemán de Pensilvania"
+  ],
+  "pdt": [
+    "bajo alemán menonita"
+  ],
+  "pei": [
+    "chichimeca jonaz"
+  ],
+  "peo": [
+    "persa antiguo"
+  ],
+  "pez": [
+    "penan oriental"
+  ],
+  "pgl": [
+    "irlandés primitivo"
+  ],
+  "pgn": [
+    "peligno"
+  ],
+  "phi": [
+    "filipino"
+  ],
+  "phn": [
+    "fenicio"
+  ],
+  "php": [
+    "náhuatl de Pajapan"
+  ],
+  "pi": [
+    "pali"
+  ],
+  "pia": [
+    "pima bajo"
+  ],
+  "pie": [
+    "piro"
+  ],
+  "pih": [
+    "pitcairnés"
+  ],
+  "pim": [
+    "powhatán"
+  ],
+  "piu": [
+    "pintupí"
+  ],
+  "pjt": [
+    "pitjantjatjara"
+  ],
+  "pl": [
+    "polaco"
+  ],
+  "plg": [
+    "pilagá"
+  ],
+  "pln": [
+    "palenquero"
+  ],
+  "plo": [
+    "oluteco"
+  ],
+  "plq": [
+    "palaico"
+  ],
+  "pls": [
+    "popoloca de Tlacoyalco"
+  ],
+  "plu": [
+    "palikur"
+  ],
+  "pmq": [
+    "pame norteño"
+  ],
+  "pms": [
+    "piamontés"
+  ],
+  "pmt": [
+    "tuamotuano"
+  ],
+  "pnb": [
+    "panyabí occidental"
+  ],
+  "pnt": [
+    "póntico"
+  ],
+  "pon": [
+    "pehnpeiano"
+  ],
+  "pos": [
+    "sayulteco"
+  ],
+  "pot": [
+    "potawatomi"
+  ],
+  "pov": [
+    "criollo de Guinea-Bisáu"
+  ],
+  "pox": [
+    "polabio"
+  ],
+  "poz": [
+    "protomalayopolinesio"
+  ],
+  "poz-pol": [
+    "protopolinesio"
+  ],
+  "ppi": [
+    "paipai"
+  ],
+  "ppl": [
+    "pipil"
+  ],
+  "pra": [
+    "prácrito"
+  ],
+  "pre": [
+    "principense"
+  ],
+  "prg": [
+    "prusiano antiguo"
+  ],
+  "pro": [
+    "provenzal antiguo"
+  ],
+  "prq": [
+    "ashéninca"
+  ],
+  "prs": [
+    "persa oriental"
+  ],
+  "ps": [
+    "pastún"
+  ],
+  "psu": [
+    "śauraseni"
+  ],
+  "pt": [
+    "portugués"
+  ],
+  "pua": [
+    "purépecha"
+  ],
+  "pue": [
+    "puelche"
+  ],
+  "puq": [
+    "puquina"
+  ],
+  "pus": [
+    "pashto"
+  ],
+  "qbt": [
+    "allentiac"
+  ],
+  "qgb": [
+    "millcayac"
+  ],
+  "qgk": [
+    "griego medieval"
+  ],
+  "qu": [
+    "quechua"
+  ],
+  "qub": [
+    "quechua del Huallaga"
+  ],
+  "quc": [
+    "quiché"
+  ],
+  "qug": [
+    "quechua chimboracense"
+  ],
+  "quh": [
+    "quechua boliviano"
+  ],
+  "qup": [
+    "quechua del Pastaza"
+  ],
+  "qus": [
+    "quichua santiagueño"
+  ],
+  "quy": [
+    "quechua ayacuchano"
+  ],
+  "quz": [
+    "quechua cuzqueño"
+  ],
+  "qvi": [
+    "quechua imbabureño"
+  ],
+  "qwc": [
+    "quechua clásico"
+  ],
+  "qwh": [
+    "quechua de Huaylas"
+  ],
+  "qya": [
+    "quenya"
+  ],
+  "raj": [
+    "rayastaní"
+  ],
+  "rap": [
+    "rapa nui"
+  ],
+  "rar": [
+    "maorí de las Islas Cook"
+  ],
+  "rgn": [
+    "romañol"
+  ],
+  "rhg": [
+    "rohingya"
+  ],
+  "rm": [
+    "romanche"
+  ],
+  "rmc": [
+    "romaní de los Cárpatos"
+  ],
+  "rmf": [
+    "caló finés"
+  ],
+  "rml": [
+    "romaní báltico"
+  ],
+  "rmn": [
+    "romaní balcánico"
+  ],
+  "rmo": [
+    "romaní sinte"
+  ],
+  "rmq": [
+    "caló"
+  ],
+  "rmw": [
+    "romaní galés"
+  ],
+  "rmy": [
+    "romaní valaco"
+  ],
+  "rn": [
+    "kirundi"
+  ],
+  "ro": [
+    "rumano"
+  ],
+  "roa": [
+    "romance"
+  ],
+  "roa-brg": [
+    "borgoñón"
+  ],
+  "roa-gal": [
+    "galó"
+  ],
+  "roa-grn": [
+    "dgèrnésiais"
+  ],
+  "roa-jer": [
+    "jerseyés"
+  ],
+  "roa-leo": [
+    "leonés"
+  ],
+  "roa-oan": [
+    "navarro-aragonés"
+  ],
+  "roa-oit": [
+    "italiano antiguo"
+  ],
+  "roa-ole": [
+    "leonés antiguo"
+  ],
+  "roa-opt": [
+    "galaicoportugués"
+  ],
+  "roa-tal": [
+    "talian"
+  ],
+  "roa-tar": [
+    "tarentino"
+  ],
+  "rom": [
+    "romaní"
+  ],
+  "rtm": [
+    "rotumano"
+  ],
+  "ru": [
+    "ruso"
+  ],
+  "rue": [
+    "rusino"
+  ],
+  "rug": [
+    "roviana"
+  ],
+  "ruo": [
+    "istriorrumano"
+  ],
+  "rup": [
+    "arumano"
+  ],
+  "ruq": [
+    "meglenorrumano"
+  ],
+  "rw": [
+    "ruandés"
+  ],
+  "ryu": [
+    "okinawense"
+  ],
+  "sa": [
+    "sánscrito"
+  ],
+  "sad": [
+    "sandavés"
+  ],
+  "sah": [
+    "yakuto"
+  ],
+  "sai-chn": [
+    "chaná"
+  ],
+  "sai-chr": [
+    "charrúa"
+  ],
+  "sai-gue": [
+    "güenoa"
+  ],
+  "sal": [
+    "salishano"
+  ],
+  "sam": [
+    "arameo samaritano"
+  ],
+  "sas": [
+    "sasak"
+  ],
+  "sat": [
+    "santalí"
+  ],
+  "sbv": [
+    "sabino"
+  ],
+  "sc": [
+    "sardo"
+  ],
+  "scn": [
+    "siciliano"
+  ],
+  "sco": [
+    "escocés"
+  ],
+  "sd": [
+    "sindhi"
+  ],
+  "sdn": [
+    "gallurés"
+  ],
+  "se": [
+    "sami septentrional"
+  ],
+  "see": [
+    "seneca"
+  ],
+  "sei": [
+    "seri"
+  ],
+  "sel": [
+    "selkup"
+  ],
+  "sem": [
+    "protosemítico"
+  ],
+  "ses": [
+    "songhay oriental"
+  ],
+  "sg": [
+    "sango"
+  ],
+  "sga": [
+    "irlandés antiguo"
+  ],
+  "sgd": [
+    "surigaonon"
+  ],
+  "sgh": [
+    "sugní"
+  ],
+  "sgs": [
+    "samogitiano"
+  ],
+  "sh": [
+    "serbocroata"
+  ],
+  "shi": [
+    "tashelhit"
+  ],
+  "shn": [
+    "tai shai"
+  ],
+  "si": [
+    "cingalés"
+  ],
+  "sid": [
+    "sidamo"
+  ],
+  "simple": [
+    "inglés simple"
+  ],
+  "sio": [
+    "siux"
+  ],
+  "sit": [
+    "sino-tibetano"
+  ],
+  "six": [
+    "sumau"
+  ],
+  "sje": [
+    "saami pite"
+  ],
+  "sjn": [
+    "sindarin"
+  ],
+  "sk": [
+    "eslovaco"
+  ],
+  "sl": [
+    "esloveno"
+  ],
+  "sla": [
+    "protoeslavo"
+  ],
+  "sm": [
+    "samoano"
+  ],
+  "sma": [
+    "sami meridional"
+  ],
+  "sme": [
+    "lapón septentrional"
+  ],
+  "smi": [
+    "sami"
+  ],
+  "smj": [
+    "sami lule"
+  ],
+  "smn": [
+    "sami inari"
+  ],
+  "sms": [
+    "sami skolt"
+  ],
+  "sn": [
+    "shona"
+  ],
+  "sne": [
+    "Bau Bidayuh"
+  ],
+  "snk": [
+    "soninke"
+  ],
+  "so": [
+    "somalí"
+  ],
+  "sog": [
+    "sondián"
+  ],
+  "son": [
+    "songay"
+  ],
+  "sou": [
+    "tailandés meridional"
+  ],
+  "spx": [
+    "picénico"
+  ],
+  "sq": [
+    "albanés"
+  ],
+  "sqj": [
+    "protoalbanés"
+  ],
+  "sr": [
+    "serbio"
+  ],
+  "src": [
+    "sardo nuorés"
+  ],
+  "srm": [
+    "saramacano"
+  ],
+  "srn": [
+    "sranan tongo"
+  ],
+  "sro": [
+    "sardo campidanés"
+  ],
+  "srr": [
+    "serere"
+  ],
+  "ss": [
+    "swazi"
+  ],
+  "ssa": [
+    "nilo-sahariano"
+  ],
+  "st": [
+    "sesotho"
+  ],
+  "stp": [
+    "tepehuano sureño"
+  ],
+  "stq": [
+    "frisón oriental"
+  ],
+  "str": [
+    "samish de los estrechos septentrionales"
+  ],
+  "su": [
+    "sundanés"
+  ],
+  "suk": [
+    "sukuma"
+  ],
+  "sul": [
+    "surigaonon"
+  ],
+  "sum": [
+    "sumo-mayangna"
+  ],
+  "sus": [
+    "susu"
+  ],
+  "sux": [
+    "sumerio"
+  ],
+  "sv": [
+    "sueco"
+  ],
+  "sva": [
+    "svano"
+  ],
+  "sw": [
+    "swahili"
+  ],
+  "swg": [
+    "suabo"
+  ],
+  "syc": [
+    "siríaco"
+  ],
+  "syr": [
+    "siríaco"
+  ],
+  "szl": [
+    "silesiano"
+  ],
+  "ta": [
+    "tamil"
+  ],
+  "tac": [
+    "tarahumara del oeste"
+  ],
+  "tai": [
+    "prototai"
+  ],
+  "taq": [
+    "tamasheq"
+  ],
+  "tar": [
+    "tarahumara central"
+  ],
+  "tcf": [
+    "tlapaneco de Malinaltepec"
+  ],
+  "tdd": [
+    "tai nüa"
+  ],
+  "te": [
+    "telugú"
+  ],
+  "tee": [
+    "tepehua de Huehuetla"
+  ],
+  "teh": [
+    "tehuelche"
+  ],
+  "tem": [
+    "temné"
+  ],
+  "ter": [
+    "terena"
+  ],
+  "tet": [
+    "tetun"
+  ],
+  "tew": [
+    "tewa"
+  ],
+  "tfn": [
+    "dena'ina"
+  ],
+  "tg": [
+    "tayiko"
+  ],
+  "th": [
+    "tailandés"
+  ],
+  "thh": [
+    "tarahumara del norte"
+  ],
+  "thv": [
+    "tamahaq"
+  ],
+  "thz": [
+    "tayart"
+  ],
+  "ti": [
+    "tigriña"
+  ],
+  "tig": [
+    "tigre"
+  ],
+  "tip": [
+    "trimuris"
+  ],
+  "tiv": [
+    "tiv"
+  ],
+  "tk": [
+    "turcomano"
+  ],
+  "tkl": [
+    "tokelauano"
+  ],
+  "tl": [
+    "tagalo"
+  ],
+  "tlh": [
+    "klingon"
+  ],
+  "tli": [
+    "tlingit"
+  ],
+  "tlx": [
+    "khehek"
+  ],
+  "tmh": [
+    "tuareg"
+  ],
+  "tmr": [
+    "arameo"
+  ],
+  "tn": [
+    "setsuana"
+  ],
+  "tnq": [
+    "taíno"
+  ],
+  "to": [
+    "tongano"
+  ],
+  "tob": [
+    "toba qom"
+  ],
+  "tog": [
+    "xitsonga de Malawi"
+  ],
+  "toj": [
+    "tojolabal"
+  ],
+  "tok": [
+    "toki pona"
+  ],
+  "top": [
+    "totonaco de Papantla"
+  ],
+  "tpc": [
+    "tlapaneco de Azoyú"
+  ],
+  "tpi": [
+    "tok pisin"
+  ],
+  "tpn": [
+    "tupinambá"
+  ],
+  "tpt": [
+    "tepehua de Tlachichilco"
+  ],
+  "tpw": [
+    "tupí antiguo"
+  ],
+  "tqw": [
+    "tónkawa"
+  ],
+  "tr": [
+    "turco"
+  ],
+  "trans": [
+    "translingüístico"
+  ],
+  "trc": [
+    "triqui de Copala"
+  ],
+  "trk": [
+    "prototúrquico"
+  ],
+  "trq": [
+    "triqui de Itunyoso"
+  ],
+  "trs": [
+    "triqui de Chicahuaxtla"
+  ],
+  "ts": [
+    "xitsonga"
+  ],
+  "tsd": [
+    "tsakonio"
+  ],
+  "tsg": [
+    "joloano"
+  ],
+  "tsi": [
+    "tsimshian"
+  ],
+  "tsn": [
+    "tswana"
+  ],
+  "tt": [
+    "tártaro"
+  ],
+  "ttq": [
+    "tawallammat"
+  ],
+  "tum": [
+    "chitumbuka"
+  ],
+  "tup": [
+    "tupí"
+  ],
+  "tut": [
+    "altaico"
+  ],
+  "tvl": [
+    "tuvaluano"
+  ],
+  "tw": [
+    "twi"
+  ],
+  "twf": [
+    "tigua norteño"
+  ],
+  "txb": [
+    "tocario B"
+  ],
+  "txh": [
+    "tracio"
+  ],
+  "ty": [
+    "tahitiano"
+  ],
+  "tyv": [
+    "tuvano"
+  ],
+  "tzh": [
+    "tseltal"
+  ],
+  "tzj": [
+    "zutujil"
+  ],
+  "tzl": [
+    "talosano"
+  ],
+  "tzm": [
+    "tamazight del Atlas Central"
+  ],
+  "tzo": [
+    "tsotsil"
+  ],
+  "udi": [
+    "udí"
+  ],
+  "udm": [
+    "udmurto"
+  ],
+  "ug": [
+    "uigur"
+  ],
+  "uga": [
+    "ugarítico"
+  ],
+  "uk": [
+    "ucraniano"
+  ],
+  "ule": [
+    "lule"
+  ],
+  "ulk": [
+    "meriam"
+  ],
+  "umb": [
+    "umbundu"
+  ],
+  "umc": [
+    "marrucino"
+  ],
+  "umu": [
+    "munsee"
+  ],
+  "ur": [
+    "urdu"
+  ],
+  "urj": [
+    "protourálico"
+  ],
+  "ush": [
+    "ushojo"
+  ],
+  "usp": [
+    "uspanteco"
+  ],
+  "uz": [
+    "uzbeco"
+  ],
+  "vai": [
+    "vai"
+  ],
+  "val": [
+    "vehes"
+  ],
+  "var": [
+    "guarijío"
+  ],
+  "ve": [
+    "luvenda"
+  ],
+  "vec": [
+    "véneto"
+  ],
+  "vep": [
+    "vepsio"
+  ],
+  "vi": [
+    "vietnamita"
+  ],
+  "vil": [
+    "vilela"
+  ],
+  "vkp": [
+    "criollo de Korlai"
+  ],
+  "vls": [
+    "flamenco occidental"
+  ],
+  "vma": [
+    "martuthunira"
+  ],
+  "vo": [
+    "volapuk"
+  ],
+  "vot": [
+    "votio"
+  ],
+  "vro": [
+    "võro"
+  ],
+  "wa": [
+    "valón"
+  ],
+  "wak": [
+    "wakash"
+  ],
+  "wal": [
+    "wolaita"
+  ],
+  "war": [
+    "samareño"
+  ],
+  "was": [
+    "washo"
+  ],
+  "wba": [
+    "warao"
+  ],
+  "wbp": [
+    "warlpiri"
+  ],
+  "wen": [
+    "sórabo"
+  ],
+  "wit": [
+    "wintu"
+  ],
+  "wlm": [
+    "galés medio"
+  ],
+  "wo": [
+    "wolof"
+  ],
+  "woe": [
+    "woleyano"
+  ],
+  "wof": [
+    "wolof gambiano"
+  ],
+  "wrh": [
+    "wiradhuri"
+  ],
+  "wrz": [
+    "waray"
+  ],
+  "wuh": [
+    "wutunhua"
+  ],
+  "wuu": [
+    "wu"
+  ],
+  "wya": [
+    "hurón"
+  ],
+  "wym": [
+    "vilamoviciano"
+  ],
+  "xaa": [
+    "árabe hispánico"
+  ],
+  "xal": [
+    "calmuco"
+  ],
+  "xaq": [
+    "aquitano"
+  ],
+  "xbc": [
+    "bactriano"
+  ],
+  "xbm": [
+    "bretón medio"
+  ],
+  "xce": [
+    "celtíbero"
+  ],
+  "xcg": [
+    "galo cisalpino"
+  ],
+  "xcl": [
+    "armenio antiguo"
+  ],
+  "xeb": [
+    "eblaíta"
+  ],
+  "xfa": [
+    "falisco"
+  ],
+  "xga": [
+    "gálata"
+  ],
+  "xh": [
+    "xhosa"
+  ],
+  "xib": [
+    "ibero"
+  ],
+  "xil": [
+    "ilirio"
+  ],
+  "xlc": [
+    "licio"
+  ],
+  "xld": [
+    "lidio"
+  ],
+  "xlp": [
+    "lepóntico"
+  ],
+  "xlu": [
+    "luvita cuneiforme"
+  ],
+  "xmf": [
+    "megreliano"
+  ],
+  "xno": [
+    "anglonormando"
+  ],
+  "xpg": [
+    "frigio"
+  ],
+  "xpo": [
+    "pochuteco"
+  ],
+  "xpr": [
+    "parto"
+  ],
+  "xpu": [
+    "púnico"
+  ],
+  "xsc": [
+    "escita"
+  ],
+  "xsl": [
+    "slave"
+  ],
+  "xsv": [
+    "sudovio"
+  ],
+  "xta": [
+    "mixteco de Alcozauca"
+  ],
+  "xtb": [
+    "mixteco de Chazumba"
+  ],
+  "xtg": [
+    "galo transalpino"
+  ],
+  "xtl": [
+    "mixteco de Tijaltepec"
+  ],
+  "xtm": [
+    "mixteco de Magdalena Peñasco"
+  ],
+  "xto": [
+    "tocario A"
+  ],
+  "xum": [
+    "umbro"
+  ],
+  "xve": [
+    "venético"
+  ],
+  "xvi": [
+    "kamviri"
+  ],
+  "xvs": [
+    "vestino"
+  ],
+  "yag": [
+    "yagán"
+  ],
+  "yai": [
+    "yagnobi"
+  ],
+  "yao": [
+    "yao"
+  ],
+  "yap": [
+    "yapés"
+  ],
+  "yaq": [
+    "yaqui"
+  ],
+  "ydd": [
+    "yídish oriental"
+  ],
+  "yi": [
+    "yídish"
+  ],
+  "yih": [
+    "yídish occidental"
+  ],
+  "ymn": [
+    "maay"
+  ],
+  "ynn": [
+    "yana"
+  ],
+  "yo": [
+    "yoruba"
+  ],
+  "yoi": [
+    "yonaguni"
+  ],
+  "yox": [
+    "yoron"
+  ],
+  "ypk": [
+    "yupik"
+  ],
+  "yrl": [
+    "ñeengatú"
+  ],
+  "yua": [
+    "maya yucateco"
+  ],
+  "yua-pro": [
+    "protoyucateco"
+  ],
+  "yuc": [
+    "yuchi"
+  ],
+  "yuz": [
+    "yuracaré"
+  ],
+  "za": [
+    "chuan"
+  ],
+  "zad": [
+    "zapoteco de Cajonos"
+  ],
+  "zai": [
+    "zapoteco istmeño"
+  ],
+  "zap": [
+    "zapoteco"
+  ],
+  "zat": [
+    "zapoteco de Tabaá"
+  ],
+  "zaw": [
+    "zapoteco de Mitla"
+  ],
+  "zea": [
+    "zelandés"
+  ],
+  "zen": [
+    "zenaga"
+  ],
+  "zh-classical": [
+    "chino clásico"
+  ],
+  "zh-yue": [
+    "cantonés"
+  ],
+  "zkg": [
+    "goguryeo"
+  ],
+  "zlw-ocs": [
+    "checo antiguo"
+  ],
+  "zlw-opl": [
+    "polaco antiguo"
+  ],
+  "znd": [
+    "zande"
+  ],
+  "zoc": [
+    "zoque chiapaneco"
+  ],
+  "zoh": [
+    "zoque de Chimalapa"
+  ],
+  "zom": [
+    "Zou"
+  ],
+  "zoq": [
+    "ayapaneco"
+  ],
+  "zpq": [
+    "zapoteco de Zoogocho"
+  ],
+  "zpu": [
+    "zapoteco de Yalálag"
+  ],
+  "zpw": [
+    "papabuco"
+  ],
+  "zro": [
+    "záparo"
+  ],
+  "zrp": [
+    "judeofrancés"
+  ],
+  "zu": [
+    "zulú"
+  ],
+  "zun": [
+    "zuñi"
+  ],
+  "zza": [
+    "zazaki"
+  ]
+}

--- a/src/wiktextract/extractor/de/translation.py
+++ b/src/wiktextract/extractor/de/translation.py
@@ -152,7 +152,7 @@ def process_Üt_template(
 ):
     transcription = template_node.template_parameters.get(3)
     if transcription:
-        translation_data["roman"] = transcription
+        translation_data["roman"] = clean_node(wxr, {}, transcription)
     # Look for automatic transcription
     else:
         cleaned_node = clean_node(wxr, {}, template_node)


### PR DESCRIPTION
The Spanish Wiktionary doesn't use module data to define language codes. So I had to look for other sources of language data.

Fortunately, there seems to be a comprehensive, automatically-generated list of language codes with their corresponding Spanish names in the Appendix: [Apéndice:Códigos de idioma](https://es.wiktionary.org/wiki/Ap%C3%A9ndice:C%C3%B3digos_de_idioma)

There is probably a better way of organizing the get_data logic for different languages than by just adding another script file. But for more or less a one-time thing, this should suffice.