### PR TITLE
Add Containerfile

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,22 @@
+name: Publish container
+
+on:
+  workflow_run:
+    workflows: [test]
+    types:
+      - completed
+    branches:
+      - master
+
+jobs:
+  publish_container:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: podman login -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+      - run: podman build -t ghcr.io/${{ github.repository }} .
+      - run: podman push ghcr.io/${{ github.repository }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,7 @@
+FROM docker.io/python
+RUN apt update && apt install -y lbzip2
+COPY pyproject.toml README.md LICENSE .
+COPY src src
+RUN python -m pip install -U pip
+RUN python -m pip install --use-pep517 .
+ENTRYPOINT bash

--- a/Containerfile
+++ b/Containerfile
@@ -4,4 +4,4 @@ COPY pyproject.toml README.md LICENSE .
 COPY src src
 RUN python -m pip install -U pip
 RUN python -m pip install --use-pep517 .
-ENTRYPOINT bash
+ENTRYPOINT ["wiktwords"]

--- a/README.md
+++ b/README.md
@@ -304,8 +304,7 @@ word `thrill` as an English verb (only one part-of-speech is shown here):
 #### Use container:
 
 ```
-$ podman build -t wiktextract .
-$ podman run -it --rm wiktextract wiktwords --help
+$ podman run -it --rm ghcr.io/tatuylonen/wiktextract --help
 ```
 
 #### Install from source:

--- a/README.md
+++ b/README.md
@@ -301,11 +301,18 @@ word `thrill` as an English verb (only one part-of-speech is shown here):
 
 ### Installing
 
-Preparation: on Linux (example from Ubuntu 20.04), you may need to
+#### Use container:
+
+```
+$ podman build -t wiktextract .
+$ podman run -it --rm wiktextract wiktwords --help
+```
+
+#### Install from source:
+
+On Linux (example from Ubuntu 20.04), you may need to
 first install the `build-essential` and `python3-dev` packages
 with `apt update && apt install build-essential python3-dev python3-pip lbzip2`.
-
-Install `wiktextract` from source:
 
 ```
 git clone https://github.com/tatuylonen/wiktextract.git
@@ -314,12 +321,6 @@ python -m venv .venv
 source .venv/bin/activate
 python -m pip install -U pip
 python -m pip install --use-pep517 .
-```
-
-Alternatively, you can install the package from pypi.org:
-
-```
-python -m pip install wiktextract
 ```
 
 This software requires Python 3.


### PR DESCRIPTION
Run code in a container could solve all the environment errors. We could publish the container image to [GitHub Packages](https://github.com/tatuylonen/wiktextract/packages) so the users don't need to build the image. This could also relief the burden of compatible with older Python verisons.  