### PR TITLE
Make publish container image action manually triggerable

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,6 +1,7 @@
 name: Publish container
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: [test]
     types:


### PR DESCRIPTION
this could be used to update the wikitextprocessor package in the image