### PR TITLE
Extract pronunciation from Spanish Wiktionary

### DIFF
--- a/json_schema/es.json
+++ b/json_schema/es.json
@@ -56,6 +56,143 @@
       ],
       "title": "Sense",
       "type": "object"
+    },
+    "Sound": {
+      "properties": {
+        "audio": {
+          "default": [],
+          "description": "Audio file name",
+          "items": {
+            "type": "string"
+          },
+          "title": "Audio",
+          "type": "array"
+        },
+        "flac_url": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Flac Url",
+          "type": "array"
+        },
+        "ipa": {
+          "default": [],
+          "description": "International Phonetic Alphabet",
+          "items": {
+            "type": "string"
+          },
+          "title": "Ipa",
+          "type": "array"
+        },
+        "mp3_url": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Mp3 Url",
+          "type": "array"
+        },
+        "ogg_url": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Ogg Url",
+          "type": "array"
+        },
+        "phonetic_transcription": {
+          "default": [],
+          "description": "Phonetic transcription, less exact than IPA.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Phonetic Transcription",
+          "type": "array"
+        },
+        "roman": {
+          "default": [],
+          "description": "Translitaration to Roman characters",
+          "items": {
+            "type": "string"
+          },
+          "title": "Roman",
+          "type": "array"
+        },
+        "syllabic": {
+          "default": [],
+          "description": "Syllabic transcription",
+          "items": {
+            "type": "string"
+          },
+          "title": "Syllabic",
+          "type": "array"
+        },
+        "tag": {
+          "default": [],
+          "description": "Specifying the variant of the pronunciation",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tag",
+          "type": "array"
+        },
+        "wav_url": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Wav Url",
+          "type": "array"
+        }
+      },
+      "title": "Sound",
+      "type": "object"
+    },
+    "Spelling": {
+      "properties": {
+        "alternative": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Alternative spelling with same pronunciation",
+          "title": "Alternative"
+        },
+        "note": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Note regarding alternative spelling",
+          "title": "Note"
+        },
+        "same_pronunciation": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whether the alternative spelling has the same pronunciation as the default spelling",
+          "title": "Same Pronunciation"
+        }
+      },
+      "title": "Spelling",
+      "type": "object"
     }
   },
   "$id": "https://kaikki.org/es.json",
@@ -113,6 +250,36 @@
       ],
       "default": [],
       "title": "Senses"
+    },
+    "sounds": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Sound"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Sounds"
+    },
+    "spellings": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Spelling"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Spellings"
     },
     "word": {
       "description": "word string",

--- a/src/wiktextract/extractor/es/models.py
+++ b/src/wiktextract/extractor/es/models.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.json_schema import GenerateJsonSchema
@@ -64,6 +64,42 @@ class Sense(LoggingExtraFieldsModel):
     )
 
 
+class Spelling(LoggingExtraFieldsModel):
+    alternative: Optional[str] = Field(
+        default=None, description="Alternative spelling with same pronunciation"
+    )
+    note: Optional[str] = Field(
+        default=None, description="Note regarding alternative spelling"
+    )
+    same_pronunciation: Optional[bool] = Field(
+        default=None,
+        description="Whether the alternative spelling has the same pronunciation as the default spelling",
+    )
+
+
+class Sound(LoggingExtraFieldsModel):
+    ipa: List[str] = Field(
+        default=[], description="International Phonetic Alphabet"
+    )
+    phonetic_transcription: List[str] = Field(
+        default=[], description="Phonetic transcription, less exact than IPA."
+    )
+    audio: List[str] = Field(default=[], description="Audio file name")
+    wav_url: List[str] = Field(default=[])
+    ogg_url: List[str] = Field(default=[])
+    mp3_url: List[str] = Field(default=[])
+    flac_url: List[str] = Field(default=[])
+    roman: List[str] = Field(
+        default=[], description="Translitaration to Roman characters"
+    )
+    syllabic: List[str] = Field(
+        default=[], description="Syllabic transcription"
+    )
+    tag: List[str] = Field(
+        default=[], description="Specifying the variant of the pronunciation"
+    )
+
+
 class WordEntry(LoggingExtraFieldsModel):
     """WordEntry is a dictionary containing lexical information of a single word extracted from Wiktionary with wiktextract."""
 
@@ -81,6 +117,8 @@ class WordEntry(LoggingExtraFieldsModel):
         default=[],
         description="list of non-disambiguated categories for the word",
     )
+    sounds: Optional[list[Sound]] = []
+    spellings: Optional[list[Spelling]] = []
 
 
 if __name__ == "__main__":

--- a/src/wiktextract/extractor/es/page.py
+++ b/src/wiktextract/extractor/es/page.py
@@ -6,7 +6,7 @@ from wikitextprocessor import NodeKind, WikiNode
 
 from wiktextract.extractor.es.gloss import extract_gloss
 from wiktextract.extractor.es.models import PydanticLogger, WordEntry
-from wiktextract.extractor.es.pronunciation import extract_pronunciation
+from wiktextract.extractor.es.pronunciation import process_pron_graf_template
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 
@@ -140,8 +140,11 @@ def parse_page(
                         and not_level3_node.kind == NodeKind.TEMPLATE
                         and not_level3_node.template_name == "pron-graf"
                     ):
-                        if wxr.config.capture_pronunciation:
-                            extract_pronunciation(
+                        if (
+                            wxr.config.capture_pronunciation
+                            and len(page_data) > 0
+                        ):
+                            process_pron_graf_template(
                                 wxr, page_data[-1], not_level3_node
                             )
                     else:

--- a/src/wiktextract/extractor/es/pronunciation.py
+++ b/src/wiktextract/extractor/es/pronunciation.py
@@ -1,9 +1,103 @@
-from wiktextract.wxr_context import WiktextractContext
-from typing import Dict, List
+import re
+import string
+from collections import defaultdict
+from typing import List
+
 from wikitextprocessor import WikiNode
 
+from wiktextract.extractor.es.models import Sound, Spelling, WordEntry
+from wiktextract.extractor.share import create_audio_url_dict
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
 
-def extract_pronunciation(
-    wxr: WiktextractContext, page_data: List[Dict], template_node: WikiNode
+
+def group_and_subgroup_keys(data):
+    pattern = re.compile(r"(\d*)(\D+)(\d*)")
+
+    grouped = defaultdict(lambda: defaultdict(list))
+
+    for key in data.copy().keys():
+        if isinstance(key, str):
+            match = pattern.match(key)
+            if match:
+                initial_digit = match.group(1) or "0"
+                last_digit = match.group(3) or "1"
+                grouped[initial_digit][last_digit].append(key)
+
+        elif isinstance(key, int) and key == 1:
+            data["fone"] = data[key]
+            grouped["0"]["1"].append("fone")
+
+    return grouped
+
+
+def process_pron_graf_template(
+    wxr: WiktextractContext, word_entry: WordEntry, template_node: WikiNode
 ) -> None:
-    pass
+    # https://es.wiktionary.org/wiki/Plantilla:pron-graf
+    sound_data: List[Sound] = []
+    spelling_data: List[Spelling] = []
+
+    sound_keys_grouped = group_and_subgroup_keys(
+        template_node.template_parameters
+    )
+
+    for sound_keys in sound_keys_grouped.values():
+        sound = Sound()
+        for variant_keys in sound_keys.values():
+            spelling_g = Spelling(
+                same_pronunciation=True
+            )  # Collect different grafía
+            spelling_v = Spelling(
+                same_pronunciation=False
+            )  # Collect different variants
+            for key in variant_keys:
+                key_plain = key.strip(string.digits)
+                value_raw = template_node.template_parameters.get(key)
+                value = clean_node(wxr, {}, value_raw).strip()
+                if key_plain == "fone" and value != "...":
+                    sound.ipa.append(value)
+                elif key_plain == "fono":
+                    sound.phonetic_transcription.append(value)
+                elif key_plain == "tl":
+                    sound.roman.append(value)
+                elif key_plain == "ts":
+                    sound.syllabic.append(value)
+                elif key_plain == "pron":
+                    if value != "no":
+                        sound.tag.append(value)
+
+                elif key_plain == "audio":
+                    audio_url_dict = create_audio_url_dict(value)
+
+                    for dict_key, dict_value in audio_url_dict.items():
+                        if dict_value and dict_key in sound.model_fields:
+                            getattr(sound, dict_key).append(dict_value)
+
+                elif key_plain in ["g", "ga", "grafía alternativa"]:
+                    spelling_g.alternative = value
+                elif key_plain == "gnota":
+                    spelling_g.note = value
+                elif key_plain in ["v", "variante"]:
+                    spelling_v.alternative = value
+
+                elif key_plain == "vnota":
+                    spelling_v.note = value
+                elif not key in ["leng"]:
+                    wxr.wtp.debug(
+                        f"Skipped extracting key {key} from pron-graf template",
+                        sortid="wiktextract/extractor/es/pronunciation/extract_pronunciation/77",
+                    )
+
+            if len(spelling_g.dict(exclude_defaults=True)) > 1:
+                spelling_data.append(spelling_g)
+
+            if len(spelling_v.dict(exclude_defaults=True)) > 1:
+                spelling_data.append(spelling_v)
+        if sound.dict(exclude_defaults=True):
+            sound_data.append(sound)
+
+    if sound_data:
+        word_entry.sounds = sound_data
+    if spelling_data:
+        word_entry.spellings = spelling_data

--- a/src/wiktextract/extractor/es/pronunciation.py
+++ b/src/wiktextract/extractor/es/pronunciation.py
@@ -1,10 +1,8 @@
 import re
 import string
 from collections import defaultdict
-from typing import List
 
 from wikitextprocessor import WikiNode
-
 from wiktextract.extractor.es.models import Sound, Spelling, WordEntry
 from wiktextract.extractor.share import create_audio_url_dict
 from wiktextract.page import clean_node
@@ -35,8 +33,8 @@ def process_pron_graf_template(
     wxr: WiktextractContext, word_entry: WordEntry, template_node: WikiNode
 ) -> None:
     # https://es.wiktionary.org/wiki/Plantilla:pron-graf
-    sound_data: List[Sound] = []
-    spelling_data: List[Spelling] = []
+    sound_data: list[Sound] = []
+    spelling_data: list[Spelling] = []
 
     sound_keys_grouped = group_and_subgroup_keys(
         template_node.template_parameters
@@ -66,38 +64,34 @@ def process_pron_graf_template(
                 elif key_plain == "pron":
                     if value != "no":
                         sound.tag.append(value)
-
                 elif key_plain == "audio":
                     audio_url_dict = create_audio_url_dict(value)
-
                     for dict_key, dict_value in audio_url_dict.items():
                         if dict_value and dict_key in sound.model_fields:
                             getattr(sound, dict_key).append(dict_value)
-
                 elif key_plain in ["g", "ga", "grafía alternativa"]:
                     spelling_g.alternative = value
                 elif key_plain == "gnota":
                     spelling_g.note = value
                 elif key_plain in ["v", "variante"]:
                     spelling_v.alternative = value
-
                 elif key_plain == "vnota":
                     spelling_v.note = value
-                elif not key in ["leng"]:
+                elif key not in ["leng"]:
                     wxr.wtp.debug(
                         f"Skipped extracting key {key} from pron-graf template",
                         sortid="wiktextract/extractor/es/pronunciation/extract_pronunciation/77",
                     )
 
-            if len(spelling_g.dict(exclude_defaults=True)) > 1:
+            if len(spelling_g.model_dump(exclude_defaults=True)) > 1:
                 spelling_data.append(spelling_g)
-
-            if len(spelling_v.dict(exclude_defaults=True)) > 1:
+            if len(spelling_v.model_dump(exclude_defaults=True)) > 1:
                 spelling_data.append(spelling_v)
-        if sound.dict(exclude_defaults=True):
+
+        if len(sound.model_dump(exclude_defaults=True)) > 0:
             sound_data.append(sound)
 
-    if sound_data:
+    if len(sound_data) > 0:
         word_entry.sounds = sound_data
-    if spelling_data:
+    if len(spelling_data) > 0:
         word_entry.spellings = spelling_data

--- a/tests/test_es_gloss.py
+++ b/tests/test_es_gloss.py
@@ -1,11 +1,11 @@
-from typing import List
 import unittest
+from typing import List
 
 from wikitextprocessor import Wtp
-from wiktextract.extractor.es.gloss import extract_gloss
-from wiktextract.extractor.es.models import WordEntry
 
 from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.es.gloss import extract_gloss
+from wiktextract.extractor.es.models import WordEntry
 from wiktextract.wxr_context import WiktextractContext
 
 

--- a/tests/test_es_pronunciation.py
+++ b/tests/test_es_pronunciation.py
@@ -1,0 +1,149 @@
+import unittest
+from typing import List
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.es.models import WordEntry
+from wiktextract.extractor.es.pronunciation import process_pron_graf_template
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestESPronunciation(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="es"), WiktionaryConfig(dump_file_lang_code="es")
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def get_default_page_data(self) -> List[WordEntry]:
+        return [WordEntry(word="test", lang_code="es", lang_name="Language")]
+
+    def test_es_extract_pronunciation(self):
+        # Test cases taken from https://es.wiktionary.org/wiki/Plantilla:pron-graf
+
+        test_cases = [
+            {
+                "input": "{{pron-graf|fone=ˈsim.ple}}",
+                "sounds": [{"ipa": ["ˈsim.ple"]}],
+                "spellings": [],
+            },
+            {
+                "input": "{{pron-graf|g=exemplo|gnota=desusado}}",
+                "sounds": [],
+                "spellings": [
+                    {
+                        "alternative": "exemplo",
+                        "note": "desusado",
+                        "same_pronunciation": True,
+                    }
+                ],
+            },
+            {
+                "input": "{{pron-graf|leng=grc|tl=parádeigma}}",
+                "sounds": [{"roman": ["parádeigma"]}],
+                "spellings": [],
+            },
+            {
+                "input": """{{pron-graf|leng=hit
+            |ts=wa-a-tar|ts2=u̯a-a-tar
+            |tl=wātar|tl2=u̯ātar
+            |pron=no
+            |v=𒉿𒋻|vnota=watar}}
+            """,
+                "sounds": [
+                    {
+                        "roman": ["wātar", "u̯ātar"],
+                        "syllabic": ["wa-a-tar", "u̯a-a-tar"],
+                    }
+                ],
+                "spellings": [
+                    {
+                        "alternative": "𒉿𒋻",
+                        "note": "watar",
+                        "same_pronunciation": False,
+                    }
+                ],
+            },
+            {
+                "input": "{{pron-graf|leng=de|fone=ˈzɪm.pəl|fone2=ˈzɪmpl̩}}",
+                "sounds": [{"ipa": ["ˈzɪm.pəl", "ˈzɪmpl̩"]}],
+                "spellings": [],
+            },
+            {
+                "input": "{{pron-graf|leng=en|pron=Reino Unido|fone=ˈɒ.pə.zɪt|fone2=ˈɒ.pə.sɪt|2pron=EE.UU.|2fone=ˈɑ.pə.sɪt|2fone2=ˈɑ.pə.sət}}",
+                "sounds": [
+                    {"ipa": ["ˈɒ.pə.zɪt", "ˈɒ.pə.sɪt"], "tag": ["Reino Unido"]},
+                    {"ipa": ["ˈɑ.pə.sɪt", "ˈɑ.pə.sət"], "tag": ["EE.UU."]},
+                ],
+                "spellings": [],
+            },
+            {
+                "input": "{{pron-graf|leng=en|pron=británico|audio2=En-uk-direction.ogg|2pron=americano|2audio=En-us-direction.ogg}}",
+                "sounds": [
+                    {
+                        "audio": ["En-uk-direction.ogg"],
+                        "tag": ["británico"],
+                    },
+                    {
+                        "audio": ["En-us-direction.ogg"],
+                        "tag": ["americano"],
+                    },
+                ],
+                "spellings": [],
+            }
+            #             {
+            #                 "input": """{{pron-graf|leng=??
+            # |ts=pa-ra-me-tir-uš
+            # |tl=parámetros
+            # |pron=estándar|fone=paˈɾa.me.tɾos|audio=Example.ogg|fone2=paˈɾa.me.tɾoː|fono3=paˈra.me.tros
+            # |2pron=segunda variación|2fono=paˈla.me.tlo|2fone2=paˈla.me.tɫo|2audio2=Example.ogg
+            # |3pron=tercera variación|3fone=paˈʐa.me.tʐo|3audio=Example.ogg|g=𒉺𒊏𒈨𒋻𒍑|gnota=pa-ra-me-tar-uš
+            # |v=𒉺𒊏𒈨𒋼𒊑𒍑|vnota=parámetreos
+            # |h=parámetroz
+            # |p=parametros|p2=barámetros|palt2=barámetrōs}}""",
+            #                 "sounds": [],
+            #                 "spellings": [],
+            #             },
+        ]
+        for case in test_cases:
+            with self.subTest(case=case):
+                # self.wxr.wtp.add_page("Modèle:pron-graf", 10, body="")
+                self.wxr.wtp.start_page("")
+                page_data = self.get_default_page_data()
+
+                root = self.wxr.wtp.parse(case["input"])
+
+                process_pron_graf_template(
+                    self.wxr, page_data[-1], root.children[0]
+                )
+
+                if case["sounds"] != []:
+                    sounds = page_data[0].model_dump(exclude_defaults=True)[
+                        "sounds"
+                    ]
+                    for sound in sounds:
+                        if "ogg_url" in sound:
+                            del sound["ogg_url"]
+                        if "mp3_url" in sound:
+                            del sound["mp3_url"]
+                    self.assertEqual(
+                        sounds,
+                        case["sounds"],
+                    )
+                else:
+                    self.assertFalse(page_data[0].sounds, case["sounds"])
+
+                if case["spellings"] != []:
+                    self.assertEqual(
+                        page_data[0].model_dump(exclude_defaults=True)[
+                            "spellings"
+                        ],
+                        case["spellings"],
+                    )
+                else:
+                    self.assertFalse(page_data[0].spellings, case["spellings"])

--- a/tests/test_es_pronunciation.py
+++ b/tests/test_es_pronunciation.py
@@ -1,8 +1,6 @@
 import unittest
-from typing import List
 
 from wikitextprocessor import Wtp
-
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.es.models import WordEntry
 from wiktextract.extractor.es.pronunciation import process_pron_graf_template
@@ -20,7 +18,7 @@ class TestESPronunciation(unittest.TestCase):
     def tearDown(self) -> None:
         self.wxr.wtp.close_db_conn()
 
-    def get_default_page_data(self) -> List[WordEntry]:
+    def get_default_page_data(self) -> list[WordEntry]:
         return [WordEntry(word="test", lang_code="es", lang_name="Language")]
 
     def test_es_extract_pronunciation(self):
@@ -122,7 +120,7 @@ class TestESPronunciation(unittest.TestCase):
                     self.wxr, page_data[-1], root.children[0]
                 )
 
-                if case["sounds"] != []:
+                if len(case["sounds"]) > 0:
                     sounds = page_data[0].model_dump(exclude_defaults=True)[
                         "sounds"
                     ]
@@ -131,14 +129,11 @@ class TestESPronunciation(unittest.TestCase):
                             del sound["ogg_url"]
                         if "mp3_url" in sound:
                             del sound["mp3_url"]
-                    self.assertEqual(
-                        sounds,
-                        case["sounds"],
-                    )
+                    self.assertEqual(sounds, case["sounds"])
                 else:
-                    self.assertFalse(page_data[0].sounds, case["sounds"])
+                    self.assertEqual(len(page_data[0].sounds), 0)
 
-                if case["spellings"] != []:
+                if len(case["spellings"]) > 0:
                     self.assertEqual(
                         page_data[0].model_dump(exclude_defaults=True)[
                             "spellings"
@@ -146,4 +141,4 @@ class TestESPronunciation(unittest.TestCase):
                         case["spellings"],
                     )
                 else:
-                    self.assertFalse(page_data[0].spellings, case["spellings"])
+                    self.assertEqual(len(page_data[0].spellings), 0)


### PR DESCRIPTION
This is basically to parse the [`{pron-graf}`](https://es.wiktionary.org/wiki/Plantilla:pron-graf) template and extract pronunciation data. The template itself is very vast and covers also different spellings.

I am not 100% whether extracting spelling data to a separate `spelling` field is the best way to proceed. But it's a start.



