### PR TITLE
Extract examples from Spanish Wiktionary

### DIFF
--- a/src/wiktextract/data/es/linkage_subtitles.json
+++ b/src/wiktextract/data/es/linkage_subtitles.json
@@ -1,0 +1,9 @@
+{
+  "antónimo": "antonyms",
+  "derivad": "derived",
+  "hipónimo": "hyponyms",
+  "hiperónimo": "hypernyms",
+  "merónimo": "meronyms",
+  "relacionado": "related",
+  "sinónimo": "synonyms"
+}

--- a/src/wiktextract/data/es/other_subtitles.json
+++ b/src/wiktextract/data/es/other_subtitles.json
@@ -1,5 +1,5 @@
 {
   "etymology": ["Etimología"],
-  "pronunciation": ["pronunciación"],
-  "ignored_sections": ["Véase también"]
+  "ignored_sections": ["Véase también"],
+  "translations": ["Traducciones"]
 }

--- a/src/wiktextract/extractor/es/example.py
+++ b/src/wiktextract/extractor/es/example.py
@@ -1,0 +1,183 @@
+import re
+from typing import Optional, Tuple, Union
+
+from wikitextprocessor import NodeKind, WikiNode
+from wikitextprocessor.parser import WikiNodeChildrenList
+
+from wiktextract.extractor.es.models import Example, Reference, Sense
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
+
+EXAMPLE_TEMPLATE_KEY_MAPPING = {
+    "título": "title",
+    "nombre": "first_name",
+    "apellidos": "last_name",
+    "páginas": "pages",
+    "URL": "url",
+    "año": "year",
+    "capítulo": "chapter",
+    "fecha": "date",
+    "editorial": "journal",
+    "editor": "editor",
+    "ubicación": "place",
+}
+
+
+def clean_text_and_url_from_text_nodes(
+    wxr: WiktextractContext, nodes: WikiNodeChildrenList
+) -> Tuple[str, Optional[str]]:
+    if not nodes:
+        return "", None
+
+    url_node = None
+    text_nodes_without_url = []
+    for n in nodes:
+        if isinstance(n, WikiNode) and n.kind == NodeKind.URL:
+            url_node = n
+        else:
+            text_nodes_without_url.append(n)
+
+    url = None
+    if url_node:
+        url = clean_node(wxr, {}, url_node)
+
+    text = clean_node(wxr, {}, text_nodes_without_url)
+
+    return text, url
+
+
+def add_template_params_to_reference(
+    wxr: WiktextractContext,
+    params: Optional[
+        dict[
+            Union[str, int],
+            Union[str, WikiNode, list[Union[str, WikiNode]]],
+        ]
+    ],
+    reference: Reference,
+):
+    for key in params.keys():
+        if isinstance(key, int):
+            continue
+
+        ref_key = (
+            EXAMPLE_TEMPLATE_KEY_MAPPING[key]
+            if key in EXAMPLE_TEMPLATE_KEY_MAPPING
+            else key
+        )
+        if ref_key in reference.model_fields:
+            setattr(reference, ref_key, clean_node(wxr, {}, params.get(key)))
+        else:
+            wxr.wtp.debug(
+                f"Unknown key {key} in example template {params}",
+                sortid="wiktextract/extractor/es/example/add_template_params_to_reference/73",
+            )
+
+
+def process_example_template(
+    wxr: WiktextractContext,
+    sense_data: Sense,
+    template_node: WikiNode,
+    reference: Reference,
+):
+    params = template_node.template_parameters
+    text_nodes = params.get(1)
+
+    # Remove url node before cleaning text nodes
+    text, url = clean_text_and_url_from_text_nodes(wxr, text_nodes)
+
+    if not text:
+        return
+
+    example = Example(text=text)
+
+    if url:
+        example.ref = Reference(url=url)
+
+    if template_node.template_name == "ejemplo_y_trad":
+        example.translation = clean_node(wxr, {}, params.get(2))
+
+    add_template_params_to_reference(wxr, params, reference)
+
+    sense_data.examples.append(example)
+
+
+def extract_example(
+    wxr: WiktextractContext,
+    sense_data: Sense,
+    nodes: WikiNodeChildrenList,
+):
+    rest: WikiNodeChildrenList = []
+
+    reference = Reference()
+    for node in nodes:
+        if isinstance(node, WikiNode) and node.kind == NodeKind.TEMPLATE:
+            if node.template_name in ["ejemplo", "ejemplo_y_trad"]:
+                process_example_template(wxr, sense_data, node, reference)
+            else:
+                rest.append(node)
+        elif isinstance(node, WikiNode) and node.kind == NodeKind.URL:
+            reference.url = clean_node(wxr, {}, node)
+        else:
+            rest.append(node)
+
+    if not sense_data.examples and rest:
+        example = Example(text=clean_node(wxr, {}, rest))
+        sense_data.examples.append(example)
+    elif rest:
+        wxr.wtp.debug(
+            f"Unprocessed nodes from example group: {rest}",
+            sortid="extractor/es/example/extract_example/87",
+        )
+
+    if sense_data.examples and reference.dict(exclude_defaults=True):
+        sense_data.examples[-1].ref = reference
+
+
+def process_example_list(
+    wxr: WiktextractContext,
+    sense_data: Sense,
+    list_item: WikiNode,
+):
+    for sub_list_item in list_item.find_child_recursively(NodeKind.LIST_ITEM):
+        text_nodes: WikiNodeChildrenList = []
+        template_nodes: list[WikiNode] = []
+        for child in sub_list_item.children:
+            if isinstance(child, WikiNode) and child.kind == NodeKind.TEMPLATE:
+                template_nodes.append(child)
+            else:
+                text_nodes.append(child)
+
+        text, url = clean_text_and_url_from_text_nodes(wxr, text_nodes)
+
+        if not text:
+            continue
+
+        example = Example(text=text)
+        if url:
+            example.ref = Reference(url=url)
+
+        for template_node in template_nodes:
+            reference = Reference()
+            if template_node.template_name == "cita libro":
+                add_template_params_to_reference(
+                    wxr, template_node.template_parameters, reference
+                )
+                if reference.model_dump(exclude_defaults=True):
+                    example.ref = reference
+
+        sense_data.examples.append(example)
+
+    # If no example was found in sublists, assume example is in list_item.children directly.
+    if not sense_data.examples:
+        text, url = clean_text_and_url_from_text_nodes(wxr, list_item.children)
+
+        text = re.sub(r"^(Ejemplos?:?)", "", text).strip()
+
+        if not text:
+            return
+        example = Example(text=text)
+        if url:
+            example.ref = Reference(url=url)
+
+        sense_data.examples.append(example)

--- a/src/wiktextract/extractor/es/example.py
+++ b/src/wiktextract/extractor/es/example.py
@@ -60,11 +60,7 @@ def add_template_params_to_reference(
         if isinstance(key, int):
             continue
 
-        ref_key = (
-            EXAMPLE_TEMPLATE_KEY_MAPPING[key]
-            if key in EXAMPLE_TEMPLATE_KEY_MAPPING
-            else key
-        )
+        ref_key = EXAMPLE_TEMPLATE_KEY_MAPPING.get(key, key)
         if ref_key in reference.model_fields:
             setattr(reference, ref_key, clean_node(wxr, {}, params.get(key)))
         else:
@@ -130,7 +126,7 @@ def extract_example(
             sortid="extractor/es/example/extract_example/87",
         )
 
-    if sense_data.examples and reference.dict(exclude_defaults=True):
+    if sense_data.examples and reference.model_dump(exclude_defaults=True):
         sense_data.examples[-1].ref = reference
 
 

--- a/src/wiktextract/extractor/es/gloss.py
+++ b/src/wiktextract/extractor/es/gloss.py
@@ -20,6 +20,9 @@ def extract_gloss(
         definition: WikiNodeChildrenList = []
         other: WikiNodeChildrenList = []
 
+        if not list_item.definition:
+            continue
+
         for node in list_item.definition:
             if isinstance(node, WikiNode) and node.kind == NodeKind.LIST:
                 other.append(node)

--- a/src/wiktextract/extractor/es/gloss.py
+++ b/src/wiktextract/extractor/es/gloss.py
@@ -1,17 +1,17 @@
 import re
-from typing import List
 
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.parser import WikiNodeChildrenList
 
 from wiktextract.extractor.es.models import Sense, WordEntry
+from wiktextract.extractor.es.sense_data import process_sense_data_list
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 
 
 def extract_gloss(
     wxr: WiktextractContext,
-    page_data: List[WordEntry],
+    page_data: list[WordEntry],
     list_node: WikiNode,
 ) -> None:
     for list_item in list_node.find_child(NodeKind.LIST_ITEM):
@@ -53,10 +53,18 @@ def extract_gloss(
             if tag:
                 gloss_data.tags.append(tag)
 
-        if other:
-            wxr.wtp.debug(
-                f"Found nodes that are not part of definition: {other}",
-                sortid="extractor/es/gloss/extract_gloss/46",
-            )
-
         page_data[-1].senses.append(gloss_data)
+
+        if other:
+            for node in other:
+                if isinstance(node, WikiNode) and node.kind == NodeKind.LIST:
+                    process_sense_data_list(
+                        wxr,
+                        page_data[-1].senses[-1],
+                        node,
+                    )
+                else:
+                    wxr.wtp.debug(
+                        f"Found nodes that are not part of definition: {node}",
+                        sortid="extractor/es/gloss/extract_gloss/46",
+                    )

--- a/src/wiktextract/extractor/es/linkage.py
+++ b/src/wiktextract/extractor/es/linkage.py
@@ -1,0 +1,20 @@
+from wikitextprocessor.parser import WikiNodeChildrenList
+
+from wiktextract.extractor.es.models import WordEntry
+from wiktextract.wxr_context import WiktextractContext
+
+
+def extract_linkage(
+    wxr: WiktextractContext,
+    page_data: list[WordEntry],
+    nodes: WikiNodeChildrenList,
+):
+    pass
+
+
+def process_linkage_list_children(
+    wxr: WiktextractContext,
+    page_data: list[WordEntry],
+    nodes: WikiNodeChildrenList,
+):
+    pass

--- a/src/wiktextract/extractor/es/models.py
+++ b/src/wiktextract/extractor/es/models.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.json_schema import GenerateJsonSchema
@@ -43,6 +43,36 @@ class LoggingExtraFieldsModel(BaseModelWrap):
         return values
 
 
+class Reference(LoggingExtraFieldsModel):
+    url: Optional[str] = Field(default=None, description="A web link")
+    first_name: Optional[str] = Field(
+        default=None, description="Author's first name"
+    )
+    last_name: Optional[str] = Field(
+        default=None, description="Author's last name"
+    )
+    title: Optional[str] = Field(
+        default=None, description="Title of the reference"
+    )
+    pages: Optional[str] = Field(default=None, description="Page numbers")
+    year: Optional[str] = Field(default=None, description="Year of publication")
+    date: Optional[str] = Field(default=None, description="Date of publication")
+    journal: Optional[str] = Field(default=None, description="Name of journal")
+    chapter: Optional[str] = Field(default=None, description="Chapter name")
+    place: Optional[str] = Field(
+        default=None, description="Place of publication"
+    )
+    editor: Optional[str] = Field(default=None, description="Editor")
+
+
+class Example(LoggingExtraFieldsModel):
+    text: str = Field(description="Example usage sentence")
+    translation: Optional[str] = Field(
+        default=None, description="Spanish translation of the example sentence"
+    )
+    ref: Optional["Reference"] = Field(default=None, description="")
+
+
 class Sense(LoggingExtraFieldsModel):
     glosses: list[str] = Field(
         description="list of gloss strings for the word sense (usually only one). This has been cleaned, and should be straightforward text with no tagging."
@@ -55,7 +85,9 @@ class Sense(LoggingExtraFieldsModel):
         default=[],
         description="list of sense-disambiguated category names extracted from (a subset) of the Category links on the page",
     )
-    # examples: list[SenseExample] = []
+    examples: list["Example"] = Field(
+        default=[], description="List of examples"
+    )
     subsenses: list["Sense"] = Field(
         default=[], description="List of subsenses"
     )
@@ -78,24 +110,24 @@ class Spelling(LoggingExtraFieldsModel):
 
 
 class Sound(LoggingExtraFieldsModel):
-    ipa: List[str] = Field(
+    ipa: list[str] = Field(
         default=[], description="International Phonetic Alphabet"
     )
-    phonetic_transcription: List[str] = Field(
+    phonetic_transcription: list[str] = Field(
         default=[], description="Phonetic transcription, less exact than IPA."
     )
-    audio: List[str] = Field(default=[], description="Audio file name")
-    wav_url: List[str] = Field(default=[])
-    ogg_url: List[str] = Field(default=[])
-    mp3_url: List[str] = Field(default=[])
-    flac_url: List[str] = Field(default=[])
-    roman: List[str] = Field(
+    audio: list[str] = Field(default=[], description="Audio file name")
+    wav_url: list[str] = Field(default=[])
+    ogg_url: list[str] = Field(default=[])
+    mp3_url: list[str] = Field(default=[])
+    flac_url: list[str] = Field(default=[])
+    roman: list[str] = Field(
         default=[], description="Translitaration to Roman characters"
     )
-    syllabic: List[str] = Field(
+    syllabic: list[str] = Field(
         default=[], description="Syllabic transcription"
     )
-    tag: List[str] = Field(
+    tag: list[str] = Field(
         default=[], description="Specifying the variant of the pronunciation"
     )
 

--- a/src/wiktextract/extractor/es/page.py
+++ b/src/wiktextract/extractor/es/page.py
@@ -8,7 +8,7 @@ from wikitextprocessor.parser import WikiNodeChildrenList
 from wiktextract.extractor.es.example import extract_example
 from wiktextract.extractor.es.gloss import extract_gloss
 from wiktextract.extractor.es.linkage import extract_linkage
-from wiktextract.extractor.es.models import PydanticLogger, WordEntry
+from wiktextract.extractor.es.models import WordEntry
 from wiktextract.extractor.es.pronunciation import process_pron_graf_template
 from wiktextract.extractor.es.sense_data import process_sense_data_list
 from wiktextract.page import clean_node
@@ -297,8 +297,6 @@ def parse_page(
 ) -> list[dict[str, any]]:
     if wxr.config.verbose:
         logging.info(f"Parsing page: {page_title}")
-        # Pass current wiktextractcontext to pydantic for more better logging
-        PydanticLogger.wxr = wxr
 
     wxr.config.word = page_title
     wxr.wtp.start_page(page_title)

--- a/src/wiktextract/extractor/es/sense_data.py
+++ b/src/wiktextract/extractor/es/sense_data.py
@@ -1,0 +1,57 @@
+from wikitextprocessor import NodeKind, WikiNode
+
+from wiktextract.extractor.es.example import process_example_list
+from wiktextract.extractor.es.linkage import process_linkage_list_children
+from wiktextract.extractor.es.models import Sense
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
+
+
+def process_sense_data_list(
+    wxr: WiktextractContext,
+    sense_data: Sense,
+    list_node: WikiNode,
+):
+    list_marker = list_node.sarg
+
+    if list_marker == ":;":
+        # XXX: Extract subsenses (rare!)
+        pass
+    elif list_marker in [":*"]:
+        for list_item in list_node.find_child(NodeKind.LIST_ITEM):
+            children = list(list_item.filter_empty_str_child())
+            # The first child will specify what data is listed
+            list_type = (
+                clean_node(wxr, {}, children[0])
+                .strip()
+                .removesuffix(":")
+                .removesuffix("s")
+                .lower()
+            )
+
+            if list_type == "ejemplo":
+                process_example_list(wxr, sense_data, list_item)
+            elif list_type in wxr.config.LINKAGE_SUBTITLES:
+                process_linkage_list_children(wxr, sense_data, children[1:])
+            elif list_type == "ámbito":
+                # XXX: Extract scope tag
+                pass
+            elif list_type == "uso":
+                # XXX: Extract usage note
+                pass
+            else:
+                wxr.wtp.debug(
+                    f"Found unknown list type '{list_type}' in {list_item}",
+                    sortid="extractor/es/sense_data/process_sense_data_list/46",
+                )
+
+    elif list_marker in ["::", ":::"]:
+        # E.g. https://es.wiktionary.org/wiki/silepsis
+        for list_item in list_node.find_child_recursively(NodeKind.LIST_ITEM):
+            process_example_list(wxr, sense_data, list_item)
+
+    else:
+        wxr.wtp.debug(
+            f"Found unknown list marker {list_marker} in: {list_node}",
+            sortid="extractor/es/sense_data/process_sense_data_list/52",
+        )

--- a/tests/test_es_example.py
+++ b/tests/test_es_example.py
@@ -1,0 +1,157 @@
+import unittest
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.es.example import (
+    extract_example,
+    process_example_list,
+)
+from wiktextract.extractor.es.models import Sense
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestESExample(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="es"),
+            WiktionaryConfig(dump_file_lang_code="es"),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def get_default_sense_data(self) -> Sense:
+        return Sense(glosses=["gloss1"])
+
+    def test_es_extract_example(self):
+        test_cases = [
+            # https://es.wiktionary.org/wiki/coñazo
+            {
+                "input": "{{ejemplo|La conferencia ha sido un ''coñazo''}}",
+                "expected": [{"text": "La conferencia ha sido un coñazo"}],
+            },
+            # https://es.wiktionary.org/wiki/necroporra
+            {
+                "input": "{{ejemplo|Nos gusta lo oscuro, y por eso triunfa la Necroporra, sea ético o no}}[https://www.menzig.es/a/necroporra-fantamorto-porra-famosos-muertos/ ]",
+                "expected": [
+                    {
+                        "text": "Nos gusta lo oscuro, y por eso triunfa la Necroporra, sea ético o no",
+                        "ref": {
+                            "url": "https://www.menzig.es/a/necroporra-fantamorto-porra-famosos-muertos/"
+                        },
+                    }
+                ],
+            },
+            # https://es.wiktionary.org/wiki/ser_más_viejo_que_Matusalén
+            {
+                "input": """{{ejemplo|Papel: más viejo que Matusalén, pero graduado "cum laude" en eficacia publicitaria [https://www.marketingdirecto.com/marketing-general/publicidad/papel-mas-viejo-matusalen-pero-graduado-cum-laude-eficacia-publicitaria]}}""",
+                "expected": [
+                    {
+                        "text": """Papel: más viejo que Matusalén, pero graduado "cum laude" en eficacia publicitaria""",
+                        "ref": {
+                            "url": "https://www.marketingdirecto.com/marketing-general/publicidad/papel-mas-viejo-matusalen-pero-graduado-cum-laude-eficacia-publicitaria"
+                        },
+                    }
+                ],
+            },
+            # https://es.wiktionary.org/wiki/zapotear
+            {
+                "input": "{{ejemplo|Era persona inteligente, culta, que me permitía ''zapotear'' los libros y me hacía comentarios sobre ellos y sus autores|título=Memorias intelectuales|apellidos=Jaramillo Uribe|nombre=Jaime|páginas=19|URL=https://books.google.com.co/books?id=X9MSAQAAIAAJ&q=zapotear|año=2007}}",
+                "expected": [
+                    {
+                        "text": "Era persona inteligente, culta, que me permitía zapotear los libros y me hacía comentarios sobre ellos y sus autores",
+                        "ref": {
+                            "title": "Memorias intelectuales",
+                            "first_name": "Jaime",
+                            "last_name": "Jaramillo Uribe",
+                            "pages": "19",
+                            "url": "https://books.google.com.co/books?id=X9MSAQAAIAAJ&q=zapotear",
+                            "year": "2007",
+                        },
+                    }
+                ],
+            },
+            # https://es.wiktionary.org/wiki/meek
+            {
+                "input": "{{ejemplo_y_trad|Blessed are the '''meek''', For they shall inherit the earth|Bienaventurados los '''mansos''', porque recibirán la tierra por heredad}}",
+                "expected": [
+                    {
+                        "text": "Blessed are the meek, For they shall inherit the earth",
+                        "translation": "Bienaventurados los mansos, porque recibirán la tierra por heredad",
+                    }
+                ],
+            },
+            # https://es.wiktionary.org/wiki/confesar
+            {
+                "input": "{{ejemplo}} El interrogatorio fue efectivo y el detenido ''confesó''.",
+                "expected": [
+                    {
+                        "text": "El interrogatorio fue efectivo y el detenido confesó.",
+                    }
+                ],
+            },
+        ]
+        for case in test_cases:
+            with self.subTest(case=case):
+                self.wxr.wtp.start_page("")
+                sense_data = self.get_default_sense_data()
+
+                root = self.wxr.wtp.parse(case["input"])
+
+                extract_example(self.wxr, sense_data, root.children)
+                self.assertEqual(
+                    sense_data.model_dump(exclude_defaults=True)["examples"],
+                    case["expected"],
+                )
+
+    def test_es_process_example_list(self):
+        test_cases = [
+            {"input": ":*'''Ejemplo:'''\n", "expected": []},
+            # https://es.wiktionary.org/wiki/cerebro
+            {
+                "input": ":*'''Ejemplo:''' Tú serás el cerebro del plan.",
+                "expected": [{"text": "Tú serás el cerebro del plan."}],
+            },
+            # https://es.wiktionary.org/wiki/quicio
+            {
+                "input": """:*'''Ejemplo:'''
+::* «Apoyado contra el ''quicio'' de la puerta, adivina, de pronto, a su marido.» {{cita libro|nombre=María Luisa|apellidos=Bombal}}""",
+                "expected": [
+                    {
+                        "text": "«Apoyado contra el quicio de la puerta, adivina, de pronto, a su marido.»",
+                        "ref": {
+                            "first_name": "María Luisa",
+                            "last_name": "Bombal",
+                        },
+                    }
+                ],
+            },
+            # https://es.wiktionary.org/wiki/silepsis
+            {
+                "input": "::Su [[obra]] comprendió [[esculpir]] un [[busto]], varios [[retrato|retratos]] y uno que otro [[dibujo]] al [[carbón]].",
+                "expected": [
+                    {
+                        "text": "Su obra comprendió esculpir un busto, varios retratos y uno que otro dibujo al carbón."
+                    }
+                ],
+            },
+        ]
+        for case in test_cases:
+            with self.subTest(case=case):
+                self.wxr.wtp.start_page("")
+                sense_data = self.get_default_sense_data()
+
+                root = self.wxr.wtp.parse(case["input"])
+
+                process_example_list(
+                    self.wxr, sense_data, root.children[0].children[0]
+                )
+                examples = [
+                    e.model_dump(exclude_defaults=True)
+                    for e in sense_data.examples
+                ]
+                self.assertEqual(
+                    examples,
+                    case["expected"],
+                )

--- a/tests/test_es_page.py
+++ b/tests/test_es_page.py
@@ -1,0 +1,51 @@
+import unittest
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.es.models import WordEntry
+from wiktextract.extractor.es.page import parse_entries
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestESPage(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="es"),
+            WiktionaryConfig(dump_file_lang_code="es"),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def get_default_page_data(self) -> list[WordEntry]:
+        return [WordEntry(word="test", lang_code="es", lang_name="Language")]
+
+    def test_es_parse_entries(self):
+        """
+        Writes data affecting multiple entries to all affected WordEntry objects.
+        """
+        self.wxr.wtp.start_page("love")
+
+        # https://es.wiktionary.org/wiki/love
+        root = self.wxr.wtp.parse(
+            """== {{lengua|en}} ==
+{{pron-graf|leng=en|fone=lʌv}}
+=== {{verbo|en}} ===
+=== {{sustantivo|en}} ===
+"""
+        )
+
+        base_data = self.get_default_page_data()[0]
+        page_data = []
+
+        parse_entries(self.wxr, page_data, base_data, root.children[0])
+
+        self.assertEqual(len(page_data), 2)
+
+        self.assertEqual(page_data[0].sounds, page_data[1].sounds)
+
+        self.assertNotEqual(
+            page_data[0].sounds,
+            base_data.sounds,
+        )


### PR DESCRIPTION
This is primarily to extract examples from the Spanish Wiktionary.

Unfortunately, the data in the Spanish Wiktionary isn't ordered very hierarchically anymore within the POS sections. This is why the `page.py` became quite evolved, doing the heavy lifting to collect and group what belongs together.

Also unfortunately, the Spanish Wiktionary is not overly consistent in where to place information. Examples, for example, can be either placed within a template `{ejemplo|...}` (though additional information to that example is often placed outside the template) or in lists which may or may not use a marker `'''Ejemplo'''`. I believe I also saw some pages where examples would be in their own section `===Ejemplos===` but I am ignoring this for the moment as a rare case.

I did my best to document everything and giving examples. 

Perhaps some function deserve more coverage with test cases? Let me know if you wish me to increase test coverage. 

Thanks for your review!