### PR TITLE
Extract translations from Spanish Wiktionary

### DIFF
--- a/json_schema/es.json
+++ b/json_schema/es.json
@@ -1,6 +1,197 @@
 {
   "$defs": {
+    "Example": {
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Reference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": ""
+        },
+        "text": {
+          "description": "Example usage sentence",
+          "title": "Text",
+          "type": "string"
+        },
+        "translation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Spanish translation of the example sentence",
+          "title": "Translation"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "title": "Example",
+      "type": "object"
+    },
+    "Reference": {
+      "additionalProperties": false,
+      "properties": {
+        "chapter": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Chapter name",
+          "title": "Chapter"
+        },
+        "date": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Date of publication",
+          "title": "Date"
+        },
+        "editor": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Editor",
+          "title": "Editor"
+        },
+        "first_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Author's first name",
+          "title": "First Name"
+        },
+        "journal": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of journal",
+          "title": "Journal"
+        },
+        "last_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Author's last name",
+          "title": "Last Name"
+        },
+        "pages": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Page numbers",
+          "title": "Pages"
+        },
+        "place": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Place of publication",
+          "title": "Place"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Title of the reference",
+          "title": "Title"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A web link",
+          "title": "Url"
+        },
+        "year": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Year of publication",
+          "title": "Year"
+        }
+      },
+      "title": "Reference",
+      "type": "object"
+    },
     "Sense": {
+      "additionalProperties": false,
       "properties": {
         "categories": {
           "default": [],
@@ -9,6 +200,15 @@
             "type": "string"
           },
           "title": "Categories",
+          "type": "array"
+        },
+        "examples": {
+          "default": [],
+          "description": "List of examples",
+          "items": {
+            "$ref": "#/$defs/Example"
+          },
+          "title": "Examples",
           "type": "array"
         },
         "glosses": {
@@ -58,6 +258,7 @@
       "type": "object"
     },
     "Sound": {
+      "additionalProperties": false,
       "properties": {
         "audio": {
           "default": [],
@@ -150,6 +351,7 @@
       "type": "object"
     },
     "Spelling": {
+      "additionalProperties": false,
       "properties": {
         "alternative": {
           "anyOf": [
@@ -193,10 +395,72 @@
       },
       "title": "Spelling",
       "type": "object"
+    },
+    "Translation": {
+      "additionalProperties": false,
+      "properties": {
+        "lang_code": {
+          "description": "Wiktionary language code of the translation term",
+          "title": "Lang Code",
+          "type": "string"
+        },
+        "notes": {
+          "default": [],
+          "description": "A list of notes",
+          "items": {
+            "type": "string"
+          },
+          "title": "Notes",
+          "type": "array"
+        },
+        "roman": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Transliteration in roman characters",
+          "title": "Roman"
+        },
+        "senseids": {
+          "default": [],
+          "description": "List of senseids where this translation applies",
+          "items": {
+            "type": "string"
+          },
+          "title": "Senseids",
+          "type": "array"
+        },
+        "tags": {
+          "default": [],
+          "description": "Tags specifying the translated term, usually gender information",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
+        },
+        "word": {
+          "description": "Translation term",
+          "title": "Word",
+          "type": "string"
+        }
+      },
+      "required": [
+        "word",
+        "lang_code"
+      ],
+      "title": "Translation",
+      "type": "object"
     }
   },
   "$id": "https://kaikki.org/es.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
   "description": "WordEntry is a dictionary containing lexical information of a single word extracted from Wiktionary with wiktextract.",
   "properties": {
     "categories": {
@@ -280,6 +544,21 @@
       ],
       "default": [],
       "title": "Spellings"
+    },
+    "translations": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Translation"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Translations"
     },
     "word": {
       "description": "word string",

--- a/json_schema/ru.json
+++ b/json_schema/ru.json
@@ -1,6 +1,7 @@
 {
   "$id": "https://kaikki.org/ru.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
   "description": "WordEntry is a dictionary containing lexical information of a single word extracted from Wiktionary with wiktextract.",
   "properties": {
     "categories": {

--- a/src/wiktextract/data/es/other_subtitles.json
+++ b/src/wiktextract/data/es/other_subtitles.json
@@ -1,5 +1,5 @@
 {
   "etymology": ["Etimología"],
   "ignored_sections": ["Véase también"],
-  "translations": ["Traducciones"]
+  "translations": ["Traducciones", "Traducción"]
 }

--- a/src/wiktextract/extractor/de/linkage.py
+++ b/src/wiktextract/extractor/de/linkage.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.parser import LevelNode
-from wiktextract.extractor.de.utils import split_senseids
+from wiktextract.extractor.share import split_senseids
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 

--- a/src/wiktextract/extractor/de/utils.py
+++ b/src/wiktextract/extractor/de/utils.py
@@ -23,31 +23,3 @@ def find_and_remove_child(node: WikiNode, kind: NodeKind, cb=None):
         del node.children[idx]
         children.append(child)
     return reversed(children)
-
-
-def split_senseids(senseids_str: str) -> list[str]:
-    senseids = []
-    raw_ids = (
-        senseids_str.strip().removeprefix("[").removesuffix("]").split(",")
-    )
-    for raw_id in raw_ids:
-        range_split = raw_id.split("-")
-        if len(range_split) == 1:
-            senseids.append(raw_id.strip())
-        elif len(range_split) == 2:
-            try:
-                start = re.sub(r"[a-z]", "", range_split[0].strip())
-                end = re.sub(r"[a-z]", "", range_split[1].strip())
-                senseids.extend(
-                    [
-                        str(id)
-                        for id in range(
-                            int(start),
-                            int(end) + 1,
-                        )
-                    ]
-                )
-            except:
-                pass
-
-    return senseids

--- a/src/wiktextract/extractor/de/utils.py
+++ b/src/wiktextract/extractor/de/utils.py
@@ -1,5 +1,4 @@
 import re
-from typing import List
 
 from wikitextprocessor import NodeKind, WikiNode
 
@@ -26,7 +25,7 @@ def find_and_remove_child(node: WikiNode, kind: NodeKind, cb=None):
     return reversed(children)
 
 
-def split_senseids(senseids_str: str) -> List[str]:
+def split_senseids(senseids_str: str) -> list[str]:
     senseids = []
     raw_ids = (
         senseids_str.strip().removeprefix("[").removesuffix("]").split(",")

--- a/src/wiktextract/extractor/es/models.py
+++ b/src/wiktextract/extractor/es/models.py
@@ -7,6 +7,25 @@ class BaseModelWrap(BaseModel):
     model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
 
+class Translation(BaseModelWrap):
+    word: str = Field(description="Translation term")
+    lang_code: str = Field(
+        description="Wiktionary language code of the translation term"
+    )
+    senseids: list[str] = Field(
+        default=[],
+        description="List of senseids where this translation applies",
+    )
+    tags: list[str] = Field(
+        default=[],
+        description="Tags specifying the translated term, usually gender information",
+    )
+    notes: list[str] = Field(default=[], description="A list of notes")
+    roman: Optional[str] = Field(
+        default=None, description="Transliteration in roman characters"
+    )
+
+
 class Reference(BaseModelWrap):
     url: Optional[str] = Field(default=None, description="A web link")
     first_name: Optional[str] = Field(
@@ -98,8 +117,7 @@ class Sound(BaseModelWrap):
 
 class WordEntry(BaseModelWrap):
     """
-    WordEntry is a dictionary containing lexical information of a single word
-    extracted from Wiktionary with wiktextract.
+    WordEntry is a dictionary containing lexical information of a single word extracted from Wiktionary with wiktextract.
     """
     model_config = ConfigDict(title="Spanish Wiktionary")
 
@@ -119,3 +137,4 @@ class WordEntry(BaseModelWrap):
     )
     sounds: Optional[list[Sound]] = []
     spellings: Optional[list[Spelling]] = []
+    translations: Optional[list[Translation]] = []

--- a/src/wiktextract/extractor/es/page.py
+++ b/src/wiktextract/extractor/es/page.py
@@ -11,6 +11,7 @@ from wiktextract.extractor.es.linkage import extract_linkage
 from wiktextract.extractor.es.models import WordEntry
 from wiktextract.extractor.es.pronunciation import process_pron_graf_template
 from wiktextract.extractor.es.sense_data import process_sense_data_list
+from wiktextract.extractor.es.translation import extract_translation
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 
@@ -128,8 +129,11 @@ def parse_section(
             pass
     elif section_title in wxr.config.OTHER_SUBTITLES["translations"]:
         if wxr.config.capture_translations:
-            # XXX: Extract translations
-            pass
+            for template_node in level_node.find_child_recursively(
+                NodeKind.TEMPLATE
+            ):
+                if template_node.template_name == "t+" and len(page_data)>0:
+                    extract_translation(wxr, page_data[-1], template_node)
     else:
         wxr.wtp.debug(
             f"Unprocessed section: {section_title}",

--- a/src/wiktextract/extractor/es/translation.py
+++ b/src/wiktextract/extractor/es/translation.py
@@ -1,0 +1,95 @@
+from typing import Optional
+
+from wikitextprocessor import WikiNode
+
+from wiktextract.extractor.de.utils import split_senseids
+from wiktextract.extractor.es.models import Translation, WordEntry
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
+
+
+def extract_translation(
+    wxr: WiktextractContext,
+    word_entry: WordEntry,
+    template_node: WikiNode,
+):
+    # Documentation: https://es.wiktionary.org/wiki/Plantilla:t+
+
+    lang_code = template_node.template_parameters.get(1)  # Language code
+
+    # Initialize variables
+    current_translation: Optional[Translation] = None
+    senseids: list[str] = []
+
+    for key in template_node.template_parameters.keys():
+        if key == 1:
+            continue  # Skip language code
+
+        value = clean_node(
+            wxr, {}, template_node.template_parameters[key]
+        ).strip()
+
+        if isinstance(key, int):
+            if value == ",":
+                if current_translation:
+                    word_entry.translations.append(current_translation)
+
+                    current_translation = None
+                    senseids = []
+            elif (
+                value.isdigit()
+                or (value != "," and "," in value)
+                or "-" in value
+            ):
+                # This gives the senseids
+                senseids.extend(split_senseids(value))
+            elif value in [
+                "m",
+                "f",
+                "mf",
+                "n",
+                "c",
+                "p",
+                "adj",
+                "sust",
+                "adj y sust",
+            ]:
+                if current_translation:
+                    current_translation.tags.append(value)
+            elif value in ["nota", "tr", "nl"]:
+                continue
+            elif (
+                key > 2
+                and isinstance(
+                    template_node.template_parameters.get(key - 1), str
+                )
+                and template_node.template_parameters.get(key - 1) == "nota"
+            ):
+                if current_translation:
+                    current_translation.notes.append(value)
+            elif (
+                key > 2
+                and isinstance(
+                    template_node.template_parameters.get(key - 1), str
+                )
+                and template_node.template_parameters.get(key - 1) == "tr"
+            ):
+                if current_translation:
+                    current_translation.roman = value
+            elif value != ",":
+                # This is a word
+                if current_translation:
+                    current_translation.word += " " + value
+
+                else:
+                    current_translation = Translation(
+                        word=value, lang_code=lang_code, senseids=list(senseids)
+                    )
+        elif isinstance(key, str):
+            if key == "tr":
+                if current_translation:
+                    current_translation.roman = value
+
+    # Add the last translation if it exists
+    if current_translation:
+        word_entry.translations.append(current_translation)

--- a/src/wiktextract/extractor/es/translation.py
+++ b/src/wiktextract/extractor/es/translation.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from wikitextprocessor import WikiNode
 
-from wiktextract.extractor.de.utils import split_senseids
+from wiktextract.extractor.share import split_senseids
 from wiktextract.extractor.es.models import Translation, WordEntry
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext

--- a/src/wiktextract/extractor/ru/models.py
+++ b/src/wiktextract/extractor/ru/models.py
@@ -7,8 +7,7 @@ class BaseModelWrap(BaseModel):
 
 class WordEntry(BaseModelWrap):
     """
-    WordEntry is a dictionary containing lexical information of a single
-    word extracted from Wiktionary with wiktextract.
+    WordEntry is a dictionary containing lexical information of a single word extracted from Wiktionary with wiktextract.
     """
     model_config = ConfigDict(title="Russian Wiktionary")
 

--- a/src/wiktextract/extractor/share.py
+++ b/src/wiktextract/extractor/share.py
@@ -90,3 +90,31 @@ def split_tag_text(text: str) -> List[str]:
         tag.strip("()").strip()
         for tag in re.split(r"(?<=\))\s+(?=\()", text.strip())
     ]
+
+
+def split_senseids(senseids_str: str) -> list[str]:
+    senseids = []
+    raw_ids = (
+        senseids_str.strip().removeprefix("[").removesuffix("]").split(",")
+    )
+    for raw_id in raw_ids:
+        range_split = raw_id.split("-")
+        if len(range_split) == 1:
+            senseids.append(raw_id.strip())
+        elif len(range_split) == 2:
+            try:
+                start = re.sub(r"[a-z]", "", range_split[0].strip())
+                end = re.sub(r"[a-z]", "", range_split[1].strip())
+                senseids.extend(
+                    [
+                        str(id)
+                        for id in range(
+                            int(start),
+                            int(end) + 1,
+                        )
+                    ]
+                )
+            except:
+                pass
+
+    return senseids

--- a/tests/test_es_translation.py
+++ b/tests/test_es_translation.py
@@ -1,0 +1,119 @@
+import unittest
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.es.models import WordEntry
+from wiktextract.extractor.es.translation import extract_translation
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestESTranslation(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="es"),
+            WiktionaryConfig(dump_file_lang_code="es"),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def get_default_page_data(self) -> list[WordEntry]:
+        return [
+            WordEntry(
+                word="test",
+                lang_code="es",
+                lang_name="Language",
+            )
+        ]
+
+    def test_es_extract_translation(self):
+        # Test cases from https://es.wiktionary.org/wiki/Plantilla:t+
+        test_cases = [
+            {
+                "input": "{{t+|af|1|kat}}",
+                "expected": [
+                    {"lang_code": "af", "word": "kat", "senseids": ["1"]}
+                ],
+            },
+            {
+                "input": "{{t+|de|1, 2|Katze|f|,|1|Kater|m|nota|gato macho|,|8|Tic Tac Toe}}",
+                "expected": [
+                    {
+                        "lang_code": "de",
+                        "word": "Katze",
+                        "senseids": ["1", "2"],
+                        "tags": ["f"],
+                    },
+                    {
+                        "lang_code": "de",
+                        "word": "Kater",
+                        "senseids": ["1"],
+                        "tags": ["m"],
+                        "notes": ["gato macho"],
+                    },
+                    {
+                        "lang_code": "de",
+                        "word": "Tic Tac Toe",
+                        "senseids": ["8"],
+                    },
+                ],
+            },
+            {
+                "input": "{{t+|fr|1|profession|nl|de|bateleur}}",
+                "expected": [
+                    {
+                        "lang_code": "fr",
+                        "word": "profession de bateleur",
+                        "senseids": ["1"],
+                    }
+                ],
+            },
+            {
+                "input": "{{t+|hy|1|կատու|tr|katu}}",
+                "expected": [
+                    {
+                        "lang_code": "hy",
+                        "word": "կատու",
+                        "roman": "katu",
+                        "senseids": ["1"],
+                    }
+                ],
+            },
+            {
+                "input": "{{t+|hy|1|կատու|tr=katu}}",
+                "expected": [
+                    {
+                        "lang_code": "hy",
+                        "word": "կատու",
+                        "roman": "katu",
+                        "senseids": ["1"],
+                    }
+                ],
+            },
+            {
+                "input": "{{t+|de|amphibisch|adj|,|Amphibie|sust|,|Amphibium|sust}}",
+                "expected": [
+                    {"lang_code": "de", "word": "amphibisch", "tags": ["adj"]},
+                    {"lang_code": "de", "word": "Amphibie", "tags": ["sust"]},
+                    {"lang_code": "de", "word": "Amphibium", "tags": ["sust"]},
+                ],
+            },
+        ]
+        for case in test_cases:
+            with self.subTest(case=case):
+                self.wxr.wtp.start_page("")
+                page_data = self.get_default_page_data()
+
+                root = self.wxr.wtp.parse(case["input"])
+
+                extract_translation(self.wxr, page_data, root.children[0])
+
+                translations = [
+                    t.model_dump(exclude_defaults=True)
+                    for t in page_data[-1].translations
+                ]
+                self.assertEqual(
+                    translations,
+                    case["expected"],
+                )

--- a/tests/test_es_translation.py
+++ b/tests/test_es_translation.py
@@ -107,7 +107,7 @@ class TestESTranslation(unittest.TestCase):
 
                 root = self.wxr.wtp.parse(case["input"])
 
-                extract_translation(self.wxr, page_data, root.children[0])
+                extract_translation(self.wxr, page_data[-1], root.children[0])
 
                 translations = [
                     t.model_dump(exclude_defaults=True)

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -1,9 +1,9 @@
 import unittest
 
-from wiktextract.extractor.de.utils import split_senseids
+from wiktextract.extractor.share import split_senseids
 
 
-class TestDEUtils(unittest.TestCase):
+class TestShare(unittest.TestCase):
     maxDiff = None
 
     def test_split_senseids(self):


### PR DESCRIPTION
Perhaps worth a discussion: I am reusing an utility that I wrote for the German Wiktionary: `split_senseids()`. This function currently is defined in `extractor/de/utils.py`. 

It would make sense to move it somewhere else since it's not  used exclusively by the German extractor anymore. Any suggestions?