### PR TITLE
Add pydantic and json_schema to German extractor

### DIFF
--- a/json_schema/de.json
+++ b/json_schema/de.json
@@ -1,0 +1,932 @@
+{
+  "$defs": {
+    "Example": {
+      "additionalProperties": false,
+      "properties": {
+        "ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Reference"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": ""
+        },
+        "text": {
+          "default": null,
+          "description": "Example usage sentence",
+          "title": "Text",
+          "type": "string"
+        }
+      },
+      "title": "Example",
+      "type": "object"
+    },
+    "Reference": {
+      "additionalProperties": false,
+      "properties": {
+        "accessdate": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Date of access of online reference",
+          "title": "Accessdate"
+        },
+        "author": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Author's name",
+          "title": "Author"
+        },
+        "collection": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Name of collection that reference was published in",
+          "title": "Collection"
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Comment on the reference",
+          "title": "Comment"
+        },
+        "date": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Date of publication",
+          "title": "Date"
+        },
+        "day": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Day of publication",
+          "title": "Day"
+        },
+        "edition": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Edition number",
+          "title": "Edition"
+        },
+        "editor": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Editor",
+          "title": "Editor"
+        },
+        "isbn": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "ISBN number",
+          "title": "Isbn"
+        },
+        "month": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Month of publication",
+          "title": "Month"
+        },
+        "number": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Issue number",
+          "title": "Number"
+        },
+        "pages": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Page numbers",
+          "title": "Pages"
+        },
+        "place": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Place of publication",
+          "title": "Place"
+        },
+        "publisher": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Published by",
+          "title": "Publisher"
+        },
+        "raw_ref": {
+          "default": null,
+          "description": "Raw reference string",
+          "title": "Raw Ref",
+          "type": "string"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Title of the reference",
+          "title": "Title"
+        },
+        "title_complement": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Complement to the title",
+          "title": "Title Complement"
+        },
+        "translator": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Translator",
+          "title": "Translator"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A web link. Not necessarily well-formated.",
+          "title": "Url"
+        },
+        "volume": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Volume number",
+          "title": "Volume"
+        },
+        "year": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Year of publication",
+          "title": "Year"
+        }
+      },
+      "title": "Reference",
+      "type": "object"
+    },
+    "Sense": {
+      "additionalProperties": false,
+      "properties": {
+        "antonyms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "title": "Antonyms"
+        },
+        "categories": {
+          "default": [],
+          "description": "list of sense-disambiguated category names extracted from (a subset) of the Category links on the page",
+          "items": {
+            "type": "string"
+          },
+          "title": "Categories",
+          "type": "array"
+        },
+        "coordinate_terms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "title": "Coordinate Terms"
+        },
+        "derived": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "title": "Derived"
+        },
+        "examples": {
+          "default": [],
+          "description": "List of examples",
+          "items": {
+            "$ref": "#/$defs/Example"
+          },
+          "title": "Examples",
+          "type": "array"
+        },
+        "expressions": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "title": "Expressions"
+        },
+        "glosses": {
+          "default": [],
+          "description": "list of gloss strings for the word sense (usually only one). This has been cleaned, and should be straightforward text with no tagging.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Glosses",
+          "type": "array"
+        },
+        "holonyms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "title": "Holonyms"
+        },
+        "hypernyms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "title": "Hypernyms"
+        },
+        "hyponyms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "title": "Hyponyms"
+        },
+        "proverbs": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "title": "Proverbs"
+        },
+        "raw_glosses": {
+          "default": [],
+          "description": "list of uncleaned raw glosses for the word sense (usually only one).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Raw Glosses",
+          "type": "array"
+        },
+        "senseid": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Sense number used in Wiktionary",
+          "title": "Senseid"
+        },
+        "synonyms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "title": "Synonyms"
+        },
+        "tags": {
+          "default": [],
+          "description": "list of gloss strings for the word sense (usually only one). This has been cleaned, and should be straightforward text with no tagging.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
+        },
+        "translations": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Translation"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "title": "Translations"
+        }
+      },
+      "title": "Sense",
+      "type": "object"
+    },
+    "Sound": {
+      "additionalProperties": false,
+      "properties": {
+        "audio": {
+          "default": [],
+          "description": "Audio file name",
+          "items": {
+            "type": "string"
+          },
+          "title": "Audio",
+          "type": "array"
+        },
+        "flac_url": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Flac Url",
+          "type": "array"
+        },
+        "ipa": {
+          "default": [],
+          "description": "International Phonetic Alphabet",
+          "items": {
+            "type": "string"
+          },
+          "title": "Ipa",
+          "type": "array"
+        },
+        "lang_code": {
+          "default": [],
+          "description": "Wiktionary language code",
+          "items": {
+            "type": "string"
+          },
+          "title": "Lang Code",
+          "type": "array"
+        },
+        "lang_name": {
+          "default": [],
+          "description": "Localized language name",
+          "items": {
+            "type": "string"
+          },
+          "title": "Lang Name",
+          "type": "array"
+        },
+        "mp3_url": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Mp3 Url",
+          "type": "array"
+        },
+        "oga_url": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Oga Url",
+          "type": "array"
+        },
+        "ogg_url": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Ogg Url",
+          "type": "array"
+        },
+        "tags": {
+          "default": [],
+          "description": "Specifying the variant of the pronunciation",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
+        },
+        "wav_url": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Wav Url",
+          "type": "array"
+        }
+      },
+      "title": "Sound",
+      "type": "object"
+    },
+    "Translation": {
+      "additionalProperties": false,
+      "properties": {
+        "lang_code": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Wiktionary language code of the translation term",
+          "title": "Lang Code"
+        },
+        "lang_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Localized language name",
+          "title": "Lang Name"
+        },
+        "notes": {
+          "default": [],
+          "description": "A list of notes",
+          "items": {
+            "type": "string"
+          },
+          "title": "Notes",
+          "type": "array"
+        },
+        "roman": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Transliteration in roman characters",
+          "title": "Roman"
+        },
+        "sense": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A gloss of the sense being translated",
+          "title": "Sense"
+        },
+        "tags": {
+          "default": [],
+          "description": "Tags specifying the translated term, usually gender information",
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
+        },
+        "uncertain": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "description": "Translation marked as uncertain",
+          "title": "Uncertain"
+        },
+        "word": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Translation term",
+          "title": "Word"
+        }
+      },
+      "title": "Translation",
+      "type": "object"
+    }
+  },
+  "$id": "https://kaikki.org/de.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "WordEntry is a dictionary containing lexical information of a single word extracted from Wiktionary with wiktextract.",
+  "properties": {
+    "antonyms": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Antonyms"
+    },
+    "coordinate_terms": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Coordinate Terms"
+    },
+    "derived": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Derived"
+    },
+    "expressions": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Expressions"
+    },
+    "holonyms": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Holonyms"
+    },
+    "hypernyms": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Hypernyms"
+    },
+    "hyponyms": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Hyponyms"
+    },
+    "lang_code": {
+      "description": "Wiktionary language code",
+      "examples": [
+        "es"
+      ],
+      "title": "Lang Code",
+      "type": "string"
+    },
+    "lang_name": {
+      "description": "Localized language name of the word",
+      "examples": [
+        "español"
+      ],
+      "title": "Lang Name",
+      "type": "string"
+    },
+    "pos": {
+      "default": null,
+      "description": "Part of speech type",
+      "title": "Pos",
+      "type": "string"
+    },
+    "proverbs": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Proverbs"
+    },
+    "senses": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Sense"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Senses"
+    },
+    "sounds": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Sound"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Sounds"
+    },
+    "synonyms": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Synonyms"
+    },
+    "translations": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Translation"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Translations"
+    },
+    "word": {
+      "description": "word string",
+      "title": "Word",
+      "type": "string"
+    }
+  },
+  "required": [
+    "word",
+    "lang_code",
+    "lang_name"
+  ],
+  "title": "German Wiktionary",
+  "type": "object"
+}

--- a/src/wiktextract/extractor/de/models.py
+++ b/src/wiktextract/extractor/de/models.py
@@ -1,0 +1,196 @@
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class BaseModelWrap(BaseModel):
+    model_config = ConfigDict(validate_assignment=True, extra="forbid")
+
+
+class Translation(BaseModelWrap):
+    sense: Optional[str] = Field(
+        default=None, description="A gloss of the sense being translated"
+    )
+    word: Optional[str] = Field(default=None, description="Translation term")
+    lang_code: Optional[str] = Field(
+        default=None,
+        description="Wiktionary language code of the translation term",
+    )
+    lang_name: Optional[str] = Field(
+        default=None, description="Localized language name"
+    )
+    uncertain: Optional[bool] = Field(
+        default=False, description="Translation marked as uncertain"
+    )
+    roman: Optional[str] = Field(
+        default=None, description="Transliteration to Roman characters"
+    )
+    # senseids: list[str] = Field(
+    #     default=[],
+    #     description="List of senseids where this translation applies",
+    # )
+    tags: list[str] = Field(
+        default=[],
+        description="Tags specifying the translated term, usually gender information",
+    )
+    notes: list[str] = Field(default=[], description="A list of notes")
+    roman: Optional[str] = Field(
+        default=None, description="Transliteration in roman characters"
+    )
+
+
+class Reference(BaseModelWrap):
+    raw_ref: str = Field(default=None, description="Raw reference string")
+    url: Optional[str] = Field(
+        default=None, description="A web link. Not necessarily well-formated."
+    )
+    author: Optional[str] = Field(default=None, description="Author's name")
+
+    title: Optional[str] = Field(
+        default=None, description="Title of the reference"
+    )
+    title_complement: Optional[str] = Field(
+        default=None, description="Complement to the title"
+    )
+    pages: Optional[str] = Field(default=None, description="Page numbers")
+    year: Optional[str] = Field(default=None, description="Year of publication")
+    publisher: Optional[str] = Field(default=None, description="Published by")
+    editor: Optional[str] = Field(default=None, description="Editor")
+    translator: Optional[str] = Field(default=None, description="Translator")
+    collection: Optional[str] = Field(
+        default=None,
+        description="Name of collection that reference was published in",
+    )
+    volume: Optional[str] = Field(default=None, description="Volume number")
+    comment: Optional[str] = Field(
+        default=None, description="Comment on the reference"
+    )
+    day: Optional[str] = Field(default=None, description="Day of publication")
+    month: Optional[str] = Field(
+        default=None, description="Month of publication"
+    )
+    accessdate: Optional[str] = Field(
+        default=None, description="Date of access of online reference"
+    )
+
+    date: Optional[str] = Field(default=None, description="Date of publication")
+    number: Optional[str] = Field(default=None, description="Issue number")
+    # journal: Optional[str] = Field(default=None, description="Name of journal")
+    # chapter: Optional[str] = Field(default=None, description="Chapter name")
+    place: Optional[str] = Field(
+        default=None, description="Place of publication"
+    )
+    # editor: Optional[str] = Field(default=None, description="Editor")
+    edition: Optional[str] = Field(default=None, description="Edition number")
+    isbn: Optional[str] = Field(default=None, description="ISBN number")
+
+
+class Example(BaseModelWrap):
+    text: str = Field(default=None, description="Example usage sentence")
+    # translation: Optional[str] = Field(
+    #     default=None, description="Spanish translation of the example sentence"
+    # )
+    ref: Optional["Reference"] = Field(default=None, description="")
+
+
+class Sense(BaseModelWrap):
+    glosses: list[str] = Field(
+        default=[],
+        description="list of gloss strings for the word sense (usually only one). This has been cleaned, and should be straightforward text with no tagging.",
+    )
+    raw_glosses: list[str] = Field(
+        default=[],
+        description="list of uncleaned raw glosses for the word sense (usually only one).",
+    )
+    tags: list[str] = Field(
+        default=[],
+        description="list of gloss strings for the word sense (usually only one). This has been cleaned, and should be straightforward text with no tagging.",
+    )
+    categories: list[str] = Field(
+        default=[],
+        description="list of sense-disambiguated category names extracted from (a subset) of the Category links on the page",
+    )
+    examples: list["Example"] = Field(
+        default=[], description="List of examples"
+    )
+    # subsenses: list["Sense"] = Field(
+    #     default=[], description="List of subsenses"
+    # )
+    senseid: Optional[str] = Field(
+        default=None, description="Sense number used in Wiktionary"
+    )
+    translations: Optional[list[Translation]] = []
+    antonyms: Optional[list[str]] = []
+    derived: Optional[list[str]] = []
+    hyponyms: Optional[list[str]] = []
+    hypernyms: Optional[list[str]] = []
+    holonyms: Optional[list[str]] = []
+    expressions: Optional[list[str]] = []
+    coordinate_terms: Optional[list[str]] = []
+    proverbs: Optional[list[str]] = []
+    synonyms: Optional[list[str]] = []
+
+
+class Sound(BaseModelWrap):
+    ipa: list[str] = Field(
+        default=[], description="International Phonetic Alphabet"
+    )
+    # phonetic_transcription: list[str] = Field(
+    #     default=[], description="Phonetic transcription, less exact than IPA."
+    # )
+    audio: list[str] = Field(default=[], description="Audio file name")
+    wav_url: list[str] = Field(default=[])
+    ogg_url: list[str] = Field(default=[])
+    mp3_url: list[str] = Field(default=[])
+    oga_url: list[str] = Field(default=[])
+    flac_url: list[str] = Field(default=[])
+    lang_code: list[str] = Field(
+        default=[], description="Wiktionary language code"
+    )
+    lang_name: list[str] = Field(
+        default=[], description="Localized language name"
+    )
+    # roman: list[str] = Field(
+    #     default=[], description="Translitaration to Roman characters"
+    # )
+    # syllabic: list[str] = Field(
+    #     default=[], description="Syllabic transcription"
+    # )
+    tags: list[str] = Field(
+        default=[], description="Specifying the variant of the pronunciation"
+    )
+    pass
+
+
+class WordEntry(BaseModelWrap):
+    """
+    WordEntry is a dictionary containing lexical information of a single word extracted from Wiktionary with wiktextract.
+    """
+
+    model_config = ConfigDict(title="German Wiktionary")
+
+    word: str = Field(description="word string")
+    pos: str = Field(default=None, description="Part of speech type")
+    # pos_title: str = Field(default=None, description="Original POS title")
+    lang_code: str = Field(
+        description="Wiktionary language code", examples=["es"]
+    )
+    lang_name: str = Field(
+        description="Localized language name of the word", examples=["español"]
+    )
+    senses: Optional[list[Sense]] = []
+    # categories: list[str] = Field(
+    #     default=[],
+    #     description="list of non-disambiguated categories for the word",
+    # )
+    translations: Optional[list[Translation]] = []
+    sounds: Optional[list[Sound]] = []
+    antonyms: Optional[list[str]] = []
+    derived: Optional[list[str]] = []
+    hyponyms: Optional[list[str]] = []
+    hypernyms: Optional[list[str]] = []
+    holonyms: Optional[list[str]] = []
+    expressions: Optional[list[str]] = []
+    coordinate_terms: Optional[list[str]] = []
+    proverbs: Optional[list[str]] = []
+    synonyms: Optional[list[str]] = []

--- a/src/wiktextract/extractor/de/translation.py
+++ b/src/wiktextract/extractor/de/translation.py
@@ -1,16 +1,18 @@
+import copy
 import re
-from collections import defaultdict
-from typing import Dict, List, Union
+from typing import Union
 
 from mediawiki_langcodes import code_to_name
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.parser import TemplateNode
+
+from wiktextract.extractor.de.models import Translation, WordEntry
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 
 
 def extract_translation(
-    wxr: WiktextractContext, page_data: List[Dict], level_node: WikiNode
+    wxr: WiktextractContext, word_entry: WordEntry, level_node: WikiNode
 ) -> None:
     for level_node_child in level_node.filter_empty_str_child():
         if not (
@@ -24,7 +26,7 @@ def extract_translation(
             )
         else:
             sense_translations = []
-            base_translation_data = defaultdict(list)
+            base_translation_data = Translation()
             senseid = level_node_child.template_parameters.get(1)
             if senseid == None:
                 # XXX: Sense-disambiguate where senseids are in Ü-Liste (ca. 0.03% of pages), e.g.:
@@ -48,7 +50,7 @@ def extract_translation(
                     # """
                     continue
 
-                base_translation_data["sense"] = clean_node(wxr, {}, sense_text)
+                base_translation_data.sense = clean_node(wxr, {}, sense_text)
 
             translation_list = level_node_child.template_parameters.get(
                 "Ü-Liste"
@@ -69,9 +71,9 @@ def extract_translation(
 
             matched_senseid = False
             if senseid:
-                for sense in page_data[-1]["senses"]:
-                    if sense["senseid"] == senseid.strip():
-                        sense["translations"].extend(sense_translations)
+                for sense in word_entry.senses:
+                    if sense.senseid == senseid.strip():
+                        sense.translations.extend(sense_translations)
                         matched_senseid = True
 
             if not matched_senseid:
@@ -79,14 +81,14 @@ def extract_translation(
                     f"Unknown senseid: {senseid}.",
                     sortid="extractor/de/translation/extract_translation/65",
                 )
-                page_data[-1]["translations"].extend(sense_translations)
+                word_entry.translations.extend(sense_translations)
 
 
 def process_translation_list(
     wxr: WiktextractContext,
-    sense_translations: List[Dict],
-    base_translation_data: Dict[str, List],
-    translation_list: List[Union[WikiNode, str]],
+    sense_translations: list[dict],
+    base_translation_data: Translation,
+    translation_list: list[Union[WikiNode, str]],
 ):
     modifiers = []
     for node in translation_list:
@@ -94,23 +96,23 @@ def process_translation_list(
             modifiers.append(node)
 
         else:
-            translation_data = base_translation_data.copy()
+            translation_data = copy.deepcopy(base_translation_data)
             process_modifiers(
                 wxr, sense_translations, translation_data, modifiers
             )
 
             lang_code = node.template_parameters.get(1)
-            translation_data["code"] = lang_code
-            translation_data["lang"] = code_to_name(lang_code, "de")
-            if translation_data["lang"] == "":
+            translation_data.lang_code = lang_code
+            translation_data.lang_name = code_to_name(lang_code, "de")
+            if translation_data.lang_name == "":
                 wxr.wtp.debug(
-                    f"Unknown language code: {translation_data['lang']}",
+                    f"Unknown language code: {translation_data.lang_name}",
                     sortid="extractor/de/translation/process_translation_list/70",
                 )
             if node.template_name[-1] == "?":
-                translation_data["uncertain"] = True
+                translation_data.uncertain = True
 
-            translation_data["word"] = clean_node(
+            translation_data.word = clean_node(
                 wxr, {}, node.template_parameters.get(2)
             )
 
@@ -122,7 +124,7 @@ def process_translation_list(
 
             sense_translations.append(translation_data)
     # Process modifiers at the end of the list
-    process_modifiers(wxr, sense_translations, defaultdict, modifiers)
+    process_modifiers(wxr, sense_translations, Translation(), modifiers)
 
 
 def is_translation_template(node: any) -> bool:
@@ -135,7 +137,7 @@ def is_translation_template(node: any) -> bool:
 
 def process_Ü_template(
     wxr: WiktextractContext,
-    translation_data: Dict[str, Union[str, List, bool]],
+    translation_data: dict[str, Union[str, list, bool]],
     template_node: TemplateNode,
 ):
     overwrite_word(
@@ -145,19 +147,19 @@ def process_Ü_template(
 
 def process_Üt_template(
     wxr: WiktextractContext,
-    translation_data: Dict[str, Union[str, List, bool]],
+    translation_data: dict[str, Union[str, list, bool]],
     template_node: TemplateNode,
 ):
     transcription = template_node.template_parameters.get(3)
     if transcription:
-        translation_data["roman"] = clean_node(wxr, {}, transcription)
+        translation_data.roman = clean_node(wxr, {}, transcription)
     # Look for automatic transcription
     else:
         cleaned_node = clean_node(wxr, {}, template_node)
         match = re.search(r"\(([^)]+?)\^\☆\)", cleaned_node)
 
         if match:
-            translation_data["roman"] = match.group(1)
+            translation_data.roman = match.group(1)
 
     overwrite_word(
         wxr, translation_data, template_node.template_parameters.get(4)
@@ -166,45 +168,47 @@ def process_Üt_template(
 
 def overwrite_word(
     wxr: WiktextractContext,
-    translation_data: Dict[str, Union[str, List, bool]],
-    nodes: Union[List[Union[WikiNode, str]], WikiNode, str, None],
+    translation_data: Translation,
+    nodes: Union[list[Union[WikiNode, str]], WikiNode, str, None],
 ):
     if nodes == None:
         return
     overwrite_word = clean_node(wxr, {}, nodes).strip()
     if overwrite_word:
-        translation_data["word"] = overwrite_word
+        translation_data.word = overwrite_word
 
 
 def process_modifiers(
     wxr: WiktextractContext,
-    sense_translations: List[Dict],
-    translation_data: Dict[str, Union[str, List, bool]],
+    sense_translations: list[Translation],
+    base_translation_data: Translation,
     modifiers,
 ):
+    if not modifiers:
+        return
     # Get rid of the "*" and language template nodes that start each translation
     for i, elem in enumerate(modifiers):
         if isinstance(elem, str) and "*" in elem:
             del modifiers[i:]
             break
-
     clean_text = clean_node(wxr, {}, modifiers).strip()
     if clean_text:
         tags = re.split(r";|,|\(|\)|:", clean_text)
         tags = [tag.strip() for tag in tags if tag.strip()]
         if tags:
             if clean_text.endswith(":"):
-                translation_data["tags"].extend(tags)
+                base_translation_data.tags.extend(tags)
             elif sense_translations:
-                sense_translations[-1]["tags"].extend(tags)
+                sense_translations[-1].tags.extend(tags)
+
     # Reset modifiers
     modifiers.clear()
 
 
 def process_dialect_table(
     wxr: WiktextractContext,
-    base_translation_data: Dict[str, Union[str, List, bool]],
-    dialect_table: List[Union[WikiNode, str]],
+    base_translation_data: Translation,
+    dialect_table: list[Union[WikiNode, str]],
 ):
     wxr.wtp.debug("Dialect table not implemented yet.", sortid="TODO")
     # XXX: Extract dialect information (ca. 0.12% of pages), e.g.:

--- a/tests/test_de_example.py
+++ b/tests/test_de_example.py
@@ -1,10 +1,10 @@
 import unittest
-from collections import defaultdict
 
 from wikitextprocessor import Wtp
 
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.de.example import extract_examples, extract_reference
+from wiktextract.extractor.de.models import Example, Sense, WordEntry
 from wiktextract.wxr_context import WiktextractContext
 
 
@@ -19,38 +19,37 @@ class TestDEExample(unittest.TestCase):
     def tearDown(self) -> None:
         self.wxr.wtp.close_db_conn()
 
+    def get_default_page_data(self) -> list[WordEntry]:
+        return [WordEntry(word="Beispiel", lang_code="de", lang_name="Deutsch")]
+
     def test_de_extract_examples(self):
         self.wxr.wtp.start_page("")
         root = self.wxr.wtp.parse(
             ":[1] example1A \n:[1] example1B\n:[2] example2\n:[3] example3"
         )
 
-        page_data = [defaultdict(list)]
-        page_data[-1]["senses"] = [
-            defaultdict(list, {"senseid": "1"}),
-            defaultdict(list, {"senseid": "2"}),
+        page_data = self.get_default_page_data()
+        page_data[-1].senses = [Sense(senseid="1"), Sense(senseid="2")]
+
+        extract_examples(self.wxr, page_data[-1], root)
+
+        senses = [
+            s.model_dump(exclude_defaults=True) for s in page_data[-1].senses
         ]
-
-        extract_examples(self.wxr, page_data, root)
-
         self.assertEqual(
-            page_data,
+            senses,
             [
                 {
-                    "senses": [
-                        {
-                            "examples": [
-                                {"text": "example1A"},
-                                {"text": "example1B"},
-                            ],
-                            "senseid": "1",
-                        },
-                        {
-                            "examples": [{"text": "example2"}],
-                            "senseid": "2",
-                        },
-                    ]
-                }
+                    "examples": [
+                        {"text": "example1A"},
+                        {"text": "example1B"},
+                    ],
+                    "senseid": "1",
+                },
+                {
+                    "examples": [{"text": "example2"}],
+                    "senseid": "2",
+                },
             ],
         )
 
@@ -58,29 +57,26 @@ class TestDEExample(unittest.TestCase):
         self.wxr.wtp.start_page("")
         root = self.wxr.wtp.parse(":[1] example1 <ref>ref1A</ref>")
 
-        page_data = [defaultdict(list)]
-        page_data[-1]["senses"] = [
-            defaultdict(list, {"senseid": "1"}),
+        page_data = self.get_default_page_data()
+        page_data[-1].senses = [Sense(senseid="1")]
+
+        extract_examples(self.wxr, page_data[-1], root)
+
+        senses = [
+            s.model_dump(exclude_defaults=True) for s in page_data[-1].senses
         ]
-
-        extract_examples(self.wxr, page_data, root)
-
         self.assertEqual(
-            page_data,
+            senses,
             [
                 {
-                    "senses": [
+                    "examples": [
                         {
-                            "examples": [
-                                {
-                                    "text": "example1",
-                                    "ref": {"raw_ref": "ref1A"},
-                                },
-                            ],
-                            "senseid": "1",
+                            "text": "example1",
+                            "ref": {"raw_ref": "ref1A"},
                         },
-                    ]
-                }
+                    ],
+                    "senseid": "1",
+                },
             ],
         )
 
@@ -92,21 +88,21 @@ class TestDEExample(unittest.TestCase):
             "<ref>{{Literatur|Autor=Steffen Möller|Titel=Viva Warszawa|TitelErg=Polen für Fortgeschrittene|Verlag=Piper|Ort=München/Berlin|Jahr=2015}}, Seite 273. ISBN 978-3-89029-459-9.</ref>"
         )
 
-        example_data = defaultdict(str)
+        example_data = Example()
 
         extract_reference(self.wxr, example_data, root.children[0])
 
         self.assertEqual(
-            example_data,
+            example_data.model_dump(exclude_defaults=True),
             {
                 "ref": {
                     "raw_ref": "Expanded template, Seite 273. ISBN 978-3-89029-459-9.",
-                    "titel": "Viva Warszawa",
-                    "autor": "Steffen Möller",
-                    "titelerg": "Polen für Fortgeschrittene",
-                    "verlag": "Piper",
-                    "ort": "München/Berlin",
-                    "jahr": "2015",
+                    "title": "Viva Warszawa",
+                    "author": "Steffen Möller",
+                    "title_complement": "Polen für Fortgeschrittene",
+                    "publisher": "Piper",
+                    "place": "München/Berlin",
+                    "year": "2015",
                 }
             },
         )
@@ -121,12 +117,12 @@ class TestDEExample(unittest.TestCase):
             "<ref>{{Ref-OWID|Sprichwörter|401781|Schlechte Beispiele verderben gute Sitten.}}</ref>"
         )
 
-        example_data = defaultdict(str)
+        example_data = Example()
 
         extract_reference(self.wxr, example_data, root.children[0])
 
         self.assertEqual(
-            example_data,
+            example_data.model_dump(exclude_defaults=True),
             {
                 "ref": {
                     "raw_ref": "Expanded template",

--- a/tests/test_de_linkages.py
+++ b/tests/test_de_linkages.py
@@ -1,10 +1,10 @@
 import unittest
-from collections import defaultdict
 
 from wikitextprocessor import Wtp
 
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.de.linkage import extract_linkages
+from wiktextract.extractor.de.models import Sense, WordEntry
 from wiktextract.wxr_context import WiktextractContext
 
 
@@ -19,86 +19,66 @@ class TestDELinkages(unittest.TestCase):
     def tearDown(self) -> None:
         self.wxr.wtp.close_db_conn()
 
+    def get_default_word_entry(self) -> WordEntry:
+        return WordEntry(word="Beispiel", lang_code="de", lang_name="Deutsch")
+
     def test_de_extract_linkages(self):
         test_cases = [
             # https://de.wiktionary.org/wiki/Beispiel
             # Extracts linkages and places them in the correct sense.
             {
                 "input": "==== Sinnverwandte Wörter ====\n:[1] [[Beleg]], [[Exempel]]\n:[2] [[Muster]], [[Vorbild]]",
-                "page_data": [
-                    defaultdict(
-                        list,
+                "senses": [Sense(senseid="1"), Sense(senseid="2")],
+                "expected": {
+                    "senses": [
                         {
-                            "senses": [
-                                defaultdict(list, {"senseid": "1"}),
-                                defaultdict(list, {"senseid": "2"}),
-                            ]
+                            "senseid": "1",
+                            "coordinate_terms": ["Beleg", "Exempel"],
                         },
-                    )
-                ],
-                "expected": [
-                    {
-                        "senses": [
-                            {
-                                "senseid": "1",
-                                "coordinate_terms": ["Beleg", "Exempel"],
-                            },
-                            {
-                                "senseid": "2",
-                                "coordinate_terms": ["Muster", "Vorbild"],
-                            },
-                        ]
-                    }
-                ],
+                        {
+                            "senseid": "2",
+                            "coordinate_terms": ["Muster", "Vorbild"],
+                        },
+                    ]
+                },
             },
             # https://de.wiktionary.org/wiki/Beispiel
             # Cleans explanatory text from expressions.
             {
                 "input": "====Redewendungen====\n:[[ein gutes Beispiel geben|ein gutes ''Beispiel'' geben]] – als [[Vorbild]] zur [[Nachahmung]] [[dienen]]/[[herausfordern]]",
-                "page_data": [defaultdict(list)],
-                "expected": [
-                    {
-                        "expressions": ["ein gutes Beispiel geben"],
-                        "senses": [],
-                    },
-                ],
+                "senses": [Sense()],
+                "expected": {
+                    "senses": [
+                        {
+                            "expressions": ["ein gutes Beispiel geben"],
+                        }
+                    ]
+                },
             },
             # Always places relations in first sense if just one sense.
             {
                 "input": "====Synonyme====\n:[[Synonym1]]",
-                "page_data": [
-                    defaultdict(
-                        list, {"senses": [defaultdict(list, {"senseid": "1"})]}
-                    )
-                ],
-                "expected": [
-                    {
-                        "senses": [{"senseid": "1", "synonyms": ["Synonym1"]}],
-                    },
-                ],
+                "senses": [Sense(senseid="1")],
+                "expected": {
+                    "senses": [{"senseid": "1", "synonyms": ["Synonym1"]}],
+                },
             },
             # https://de.wiktionary.org/wiki/Kokospalme
             # Ignores modifiers of relations and all other text.
             {
                 "input": "====Synonyme====\n:[1] [[Kokosnusspalme]], ''wissenschaftlich:'' [[Cocos nucifera]]",
-                "page_data": [
-                    defaultdict(
-                        list, {"senses": [defaultdict(list, {"senseid": "1"})]}
-                    )
-                ],
-                "expected": [
-                    {
-                        "senses": [
-                            {
-                                "senseid": "1",
-                                "synonyms": [
-                                    "Kokosnusspalme",
-                                    "Cocos nucifera",
-                                ],
-                            }
-                        ],
-                    },
-                ],
+                "senses": [Sense(senseid="1")],
+                "expected": {
+                    "senses": [
+                        {
+                            "senseid": "1",
+                            "synonyms": [
+                                "Kokosnusspalme",
+                                "Cocos nucifera",
+                            ],
+                        }
+                    ],
+                },
             },
         ]
 
@@ -107,6 +87,15 @@ class TestDELinkages(unittest.TestCase):
                 self.wxr.wtp.start_page("")
                 root = self.wxr.wtp.parse(case["input"])
 
-                extract_linkages(self.wxr, case["page_data"], root.children[0])
+                word_entry = self.get_default_word_entry()
+                word_entry.senses = case["senses"]
 
-                self.assertEqual(case["page_data"], case["expected"])
+                extract_linkages(self.wxr, word_entry, root.children[0])
+
+                self.assertEqual(
+                    word_entry.model_dump(
+                        exclude_defaults=True,
+                        exclude={"word", "lang_code", "lang_name"},
+                    ),
+                    case["expected"],
+                )

--- a/tests/test_desc.py
+++ b/tests/test_desc.py
@@ -1,6 +1,7 @@
 import unittest
 
 from wikitextprocessor import Wtp
+
 from wiktextract.config import WiktionaryConfig
 from wiktextract.datautils import split_at_comma_semi
 from wiktextract.thesaurus import close_thesaurus_db


### PR DESCRIPTION
This is to add pydantic classes to the German extractor.

In some cases, pydantic fields are defined as lists of strings where probably they could be just a string. I decided to accept for now this looser schema to avoid refactoring even more. This was already quite a bit more painful than I anticipated.

