### PR TITLE
Extract pronunciation from Russian Wiktionary

### DIFF
--- a/json_schema/ru.json
+++ b/json_schema/ru.json
@@ -1,7 +1,135 @@
 {
+  "$defs": {
+    "Sound": {
+      "additionalProperties": false,
+      "properties": {
+        "audio": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Audio file name",
+          "title": "Audio"
+        },
+        "flac_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Flac Url"
+        },
+        "homophones": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "description": "Words with same pronunciation",
+          "title": "Homophones"
+        },
+        "ipa": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "International Phonetic Alphabet",
+          "title": "Ipa"
+        },
+        "mp3_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mp3 Url"
+        },
+        "oga_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Oga Url"
+        },
+        "ogg_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ogg Url"
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": [],
+          "description": "Specifying the variant of the pronunciation",
+          "title": "Tags"
+        },
+        "wav_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Wav Url"
+        }
+      },
+      "title": "Sound",
+      "type": "object"
+    }
+  },
   "$id": "https://kaikki.org/ru.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "WordEntry is a dictionary containing lexical information of a single word extracted from Wiktionary with wiktextract.",
+  "additionalProperties": false,
+  "description": "WordEntry is a dictionary containing lexical information of a single\nword extracted from Wiktionary with wiktextract.",
   "properties": {
     "categories": {
       "default": [],
@@ -39,6 +167,21 @@
       "description": "Original POS title",
       "title": "Pos Title",
       "type": "string"
+    },
+    "sounds": {
+      "anyOf": [
+        {
+          "items": {
+            "$ref": "#/$defs/Sound"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": [],
+      "title": "Sounds"
     },
     "word": {
       "description": "word string",

--- a/src/wiktextract/extractor/ru/models.py
+++ b/src/wiktextract/extractor/ru/models.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -5,11 +6,30 @@ class BaseModelWrap(BaseModel):
     model_config = ConfigDict(validate_assignment=True, extra="forbid")
 
 
+class Sound(BaseModelWrap):
+    ipa: Optional[str] = Field(
+        default=None, description="International Phonetic Alphabet"
+    )
+    audio: Optional[str] = Field(default=None, description="Audio file name")
+    wav_url: Optional[str] = Field(default=None)
+    ogg_url: Optional[str] = Field(default=None)
+    oga_url: Optional[str] = Field(default=None)
+    mp3_url: Optional[str] = Field(default=None)
+    flac_url: Optional[str] = Field(default=None)
+    tags: Optional[list[str]] = Field(
+        default=[], description="Specifying the variant of the pronunciation"
+    )
+    homophones: Optional[list[str]] = Field(
+        default=[], description="Words with same pronunciation"
+    )
+
+
 class WordEntry(BaseModelWrap):
     """
     WordEntry is a dictionary containing lexical information of a single
     word extracted from Wiktionary with wiktextract.
     """
+
     model_config = ConfigDict(title="Russian Wiktionary")
 
     word: str = Field(description="word string")
@@ -25,3 +45,4 @@ class WordEntry(BaseModelWrap):
         default=[],
         description="list of non-disambiguated categories for the word",
     )
+    sounds: Optional[list[Sound]] = []

--- a/src/wiktextract/extractor/ru/pronunciation.py
+++ b/src/wiktextract/extractor/ru/pronunciation.py
@@ -1,12 +1,229 @@
-from wikitextprocessor.parser import LevelNode
+from typing import Union
+from wikitextprocessor import NodeKind
+from wikitextprocessor.parser import LevelNode, WikiNodeChildrenList, WikiNode
 
-from wiktextract.extractor.ru.models import WordEntry
+from wiktextract.extractor.ru.models import Sound, WordEntry
+from wiktextract.extractor.share import create_audio_url_dict
+from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
+import re
 
 
 def extract_pronunciation(
     wxr: WiktextractContext,
-    page_data: list[WordEntry],
+    word_entry: WordEntry,
     level_node: LevelNode,
 ):
-    pass
+    unprocessed_nodes: WikiNodeChildrenList = []
+    for child in level_node.filter_empty_str_child():
+        if isinstance(child, WikiNode) and child.kind == NodeKind.TEMPLATE:
+            template_name = child.template_name
+            if template_name == "transcription":
+                process_transcription_template(wxr, word_entry, child)
+            elif template_name == "transcriptions":
+                process_transcriptions_template(wxr, word_entry, child)
+            elif template_name == "transcription-ru":
+                process_transcription_ru_template(wxr, word_entry, child)
+            elif template_name == "transcriptions-ru":
+                process_transcriptions_ru_template(wxr, word_entry, child)
+            elif template_name in ["audio", "аудио", "медиа"]:
+                # XXX: Process simple audio file templates
+                pass
+            elif template_name in [
+                "transcription-grc",
+                "transcription-uk",
+                "transcription eo",
+            ]:
+                # XXX: Process other pronunciation templates
+                pass
+            else:
+                unprocessed_nodes.append(child)
+        else:
+            unprocessed_nodes.append(child)
+
+    if unprocessed_nodes and clean_node(wxr, {}, unprocessed_nodes).strip():
+        wxr.wtp.debug(
+            f"Unprocessed nodes in pronunciation section: {unprocessed_nodes}",
+            sortid="wiktextract/extractor/ru/pronunciation/extract_pronunciation/24",
+        )
+
+
+def process_transcription_template(
+    wxr: WiktextractContext,
+    word_entry: WordEntry,
+    template_node: WikiNode,
+):
+    # https://ru.wiktionary.org/wiki/Шаблон:transcription
+
+    sound = Sound()
+
+    template_params = template_node.template_parameters
+
+    extract_ipa(wxr, sound, template_params, 1)
+
+    extract_audio_file(wxr, sound, template_params, 2)
+
+    extract_tags(wxr, sound, template_params)
+
+    extract_homophones(wxr, sound, template_params)
+
+    if sound.model_dump(exclude_defaults=True) != {}:
+        word_entry.sounds.append(sound)
+
+
+def process_transcriptions_template(
+    wxr: WiktextractContext,
+    word_entry: WordEntry,
+    template_node: WikiNode,
+):
+    # https://ru.wiktionary.org/wiki/Шаблон:transcriptions
+
+    sound_sg = Sound()
+    sound_pl = Sound()
+
+    template_params = template_node.template_parameters
+
+    extract_ipa(wxr, sound_sg, template_params, 1)
+    extract_ipa(wxr, sound_pl, template_params, 2)
+
+    extract_audio_file(wxr, sound_sg, template_params, 3)
+    extract_audio_file(wxr, sound_pl, template_params, 4)
+
+    extract_tags(wxr, [sound_sg, sound_pl], template_params)
+
+    extract_homophones(wxr, sound_sg, template_params)
+
+    if sound_sg.model_dump(exclude_defaults=True) != {} and (
+        sound_sg.ipa or sound_sg.audio
+    ):
+        sound_sg.tags.append("singular")
+        word_entry.sounds.append(sound_sg)
+
+    if sound_pl.model_dump(exclude_defaults=True) != {} and (
+        sound_pl.ipa or sound_pl.audio
+    ):
+        sound_pl.tags.append("plural")
+        word_entry.sounds.append(sound_pl)
+
+
+def process_transcription_ru_template(
+    wxr: WiktextractContext,
+    word_entry: WordEntry,
+    template_node: WikiNode,
+):
+    # https://ru.wiktionary.org/wiki/Шаблон:transcription-ru
+    sound = Sound()
+
+    template_params = template_node.template_parameters
+
+    ipa = clean_node(wxr, {}, template_params.get("вручную", ""))
+    if not ipa:
+        cleaned_node = clean_node(wxr, {}, template_node)
+        ipa_match = re.search(r"\[(.*?)\]", cleaned_node)
+        if ipa_match:
+            ipa = ipa_match.group(1)
+
+    if ipa:
+        sound.ipa = ipa
+
+    extract_audio_file(wxr, sound, template_params, 2)
+
+    extract_homophones(wxr, sound, template_params)
+
+    extract_tags(wxr, sound, template_params)
+
+    if sound.model_dump(exclude_defaults=True) != {}:
+        word_entry.sounds.append(sound)
+
+
+def process_transcriptions_ru_template(
+    wxr: WiktextractContext,
+    word_entry: WordEntry,
+    template_node: WikiNode,
+):
+    sound_sg = Sound()
+    sound_pl = Sound()
+
+    template_params = template_node.template_parameters
+
+    cleaned_node = clean_node(wxr, {}, template_node)
+    ipa_matches = re.findall(r"\[(.*?)\]", cleaned_node)
+    if len(ipa_matches) > 0:
+        sound_sg.ipa = ipa_matches[0]
+    if len(ipa_matches) > 1:
+        sound_pl.ipa = ipa_matches[1]
+
+    extract_audio_file(wxr, sound_sg, template_params, 3)
+    extract_audio_file(wxr, sound_pl, template_params, 4)
+
+    extract_tags(wxr, [sound_sg, sound_pl], template_params)
+
+    extract_homophones(wxr, sound_sg, template_params)
+
+    if sound_sg.model_dump(exclude_defaults=True) != {}:
+        sound_sg.tags.append("singular")
+        word_entry.sounds.append(sound_sg)
+
+    if sound_pl.model_dump(exclude_defaults=True) != {}:
+        sound_pl.tags.append("plural")
+        word_entry.sounds.append(sound_pl)
+
+
+def extract_ipa(
+    wxr: WiktextractContext,
+    sound: Sound,
+    template_params: dict[str, WikiNode],
+    key: Union[str, int],
+):
+    ipa = clean_node(wxr, {}, template_params.get(key, ""))
+    if ipa:
+        sound.ipa = ipa
+
+
+def extract_audio_file(
+    wxr: WiktextractContext,
+    sound: Sound,
+    template_params: dict[str, WikiNode],
+    key: Union[str, int],
+):
+    audio_file = clean_node(wxr, {}, template_params.get(key, ""))
+    if audio_file:
+        audio_url_dict = create_audio_url_dict(audio_file)
+        for dict_key, dict_value in audio_url_dict.items():
+            if dict_value:
+                if dict_key in sound.model_fields:
+                    setattr(sound, dict_key, dict_value)
+                else:
+                    wxr.wtp.debug(
+                        f"Unknown key {dict_key} in audio_url_dict",
+                        sortid="wiktextract/extractor/ru/pronunciation/add_audio_file/123",
+                    )
+
+
+def extract_tags(
+    wxr: WiktextractContext,
+    sounds: Union[Sound, list[Sound]],
+    template_params: dict[str, WikiNode],
+):
+    tags = clean_node(wxr, {}, template_params.get("норма", ""))
+    if tags:
+        if isinstance(sounds, list):
+            for sound in sounds:
+                sound.tags = [tags]
+        else:
+            sounds.tags = [tags]
+
+
+def extract_homophones(
+    wxr: WiktextractContext,
+    sounds: Union[Sound, list[Sound]],
+    template_params: dict[str, WikiNode],
+):
+    homophones_raw = clean_node(wxr, {}, template_params.get("омофоны", ""))
+    homophones = [h.strip() for h in homophones_raw.split(",") if h.strip()]
+    if homophones:
+        if isinstance(sounds, list):
+            for sound in sounds:
+                sound.homophones = homophones
+        else:
+            sounds.homophones = homophones

--- a/tests/test_ru_pronunciation.py
+++ b/tests/test_ru_pronunciation.py
@@ -1,0 +1,202 @@
+import unittest
+
+from wikitextprocessor import Wtp
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.ru.models import WordEntry
+from wiktextract.extractor.ru.pronunciation import (
+    process_transcription_ru_template,
+    process_transcription_template,
+    process_transcriptions_ru_template,
+    process_transcriptions_template,
+)
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestRUPronunciation(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="ru"), WiktionaryConfig(dump_file_lang_code="ru")
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def get_default_word_entry(self) -> WordEntry:
+        return WordEntry(word="тест", lang_code="ru", lang_name="русский")
+
+    def process_template_and_assert(
+        self,
+        template: str,
+        process_function: callable,
+        expected_results: list[dict],
+    ):
+        self.wxr.wtp.start_page("")
+        word_entry = self.get_default_word_entry()
+        root = self.wxr.wtp.parse(template)
+        process_function(self.wxr, word_entry, root.children[0])
+
+        sounds = [
+            s.model_dump(exclude_defaults=True) for s in word_entry.sounds
+        ]
+
+        self.assertEqual(
+            len(expected_results),
+            len(sounds),
+            msg=f"Template: {template}, expected: {expected_results}, actual: {sounds}",
+        )
+
+        for expected, sound in zip(expected_results, sounds):
+            self.assertDictContainsSubset(expected, sound)
+
+    def test_process_transcription_template(self):
+        # https://ru.wiktionary.org/wiki/Шаблон:transcription
+        test_cases = [
+            {
+                "input": "{{transcription|məɫɐˈko|Ru-молоко.ogg|норма=московская норма}}",
+                "expected": {
+                    "ipa": "məɫɐˈko",
+                    "audio": "Ru-молоко.ogg",
+                    "tags": ["московская норма"],
+                },
+            },
+            {
+                "input": "{{transcription|vot|Ru-вот.ogg|омофоны=вод}}",
+                "expected": {
+                    "ipa": "vot",
+                    "audio": "Ru-вот.ogg",
+                    "homophones": ["вод"],
+                },
+            },
+        ]
+
+        for test_case in test_cases:
+            self.process_template_and_assert(
+                test_case["input"],
+                process_transcription_template,
+                [test_case["expected"]],
+            )
+
+    def test_process_transcriptions_template(self):
+        # https://ru.wiktionary.org/wiki/Шаблон:transcriptions
+        test_cases = [
+            {
+                "input": "{{transcriptions|ˈɫoʂɨtʲ|ˈɫoʂɨdʲɪ|Ru-лошадь.ogg|норма=московская норма}}",
+                "expected": [
+                    {
+                        "ipa": "ˈɫoʂɨtʲ",
+                        "audio": "Ru-лошадь.ogg",
+                        "tags": ["московская норма", "singular"],
+                    },
+                    {
+                        "ipa": "ˈɫoʂɨdʲɪ",
+                        "tags": ["московская норма", "plural"],
+                    },
+                ],
+            },
+            {
+                "input": "{{transcriptions|bɐˈlʲit|bɐˈlʲidɨ|омофоны=болит|источник=Зарва}}",
+                "expected": [
+                    {
+                        "ipa": "bɐˈlʲit",
+                        "homophones": ["болит"],
+                        "tags": ["singular"],
+                    },
+                    {
+                        "ipa": "bɐˈlʲidɨ",
+                        "tags": ["plural"],
+                    },
+                ],
+            },
+            {
+                "input": "{{transcriptions|ˈkʌl.ə(ɹ)|норма=брит.}}",
+                "expected": [
+                    {"ipa": "ˈkʌl.ə(ɹ)", "tags": ["брит.", "singular"]}
+                ],
+            },
+        ]
+
+        for test_case in test_cases:
+            self.process_template_and_assert(
+                test_case["input"],
+                process_transcriptions_template,
+                test_case["expected"],
+            )
+
+    def test_process_transcription_ru_template_1(self):
+        # https://ru.wiktionary.org/wiki/Шаблон:transcription-ru
+        self.wxr.wtp.add_page("Шаблон:transcription-ru", 10, "[məlɐˈko]")
+
+        self.process_template_and_assert(
+            "{{transcription-ru|молоко́|Ru-молоко.ogg|норма=московская норма}}",
+            process_transcription_ru_template,
+            [
+                {
+                    "ipa": "məlɐˈko",
+                    "audio": "Ru-молоко.ogg",
+                    "tags": ["московская норма"],
+                }
+            ],
+        )
+
+    def test_process_transcription_ru_template_2(self):
+        # https://ru.wiktionary.org/wiki/Шаблон:transcription-ru
+        self.wxr.wtp.add_page("Шаблон:transcription-ru", 10, "[vot]")
+
+        self.process_template_and_assert(
+            "{{transcription-ru|вот|Ru-вот.ogg|омофоны=вод}}",
+            process_transcription_ru_template,
+            [
+                {
+                    "ipa": "vot",
+                    "audio": "Ru-вот.ogg",
+                    "homophones": ["вод"],
+                }
+            ],
+        )
+
+    def test_process_transcriptions_ru_template_1(self):
+        # https://ru.wiktionary.org/wiki/Шаблон:transcriptions-ru
+        self.wxr.wtp.add_page(
+            "Шаблон:transcriptions-ru", 10, "ед. ч. [ˈɫoʂətʲ] мн. ч. [ˈɫoʂədʲɪ]"
+        )
+
+        self.process_template_and_assert(
+            "{{transcriptions-ru|ло́шадь|ло́шади|Ru-лошадь.ogg|норма=московская норма}}",
+            process_transcriptions_ru_template,
+            [
+                {
+                    "ipa": "ˈɫoʂətʲ",
+                    "audio": "Ru-лошадь.ogg",
+                    "tags": ["московская норма", "singular"],
+                },
+                {
+                    "ipa": "ˈɫoʂədʲɪ",
+                    "tags": ["московская норма", "plural"],
+                },
+            ],
+        )
+
+    def test_process_transcriptions_ru_template_2(self):
+        # https://ru.wiktionary.org/wiki/Шаблон:transcriptions-ru
+        self.wxr.wtp.add_page(
+            "Шаблон:transcriptions-ru",
+            10,
+            "ед. ч. [bɐˈlʲit], мн. ч. [bɐˈlʲidɨ]",
+        )
+        self.process_template_and_assert(
+            "{{transcriptions-ru|боли́д|боли́ды|омофоны=болит}}",
+            process_transcriptions_ru_template,
+            [
+                {
+                    "ipa": "bɐˈlʲit",
+                    "homophones": ["болит"],
+                    "tags": ["singular"],
+                },
+                {
+                    "ipa": "bɐˈlʲidɨ",
+                    "tags": ["plural"],
+                },
+            ],
+        )

--- a/tests/test_ru_pronunciation.py
+++ b/tests/test_ru_pronunciation.py
@@ -48,7 +48,7 @@ class TestRUPronunciation(unittest.TestCase):
         )
 
         for expected, sound in zip(expected_results, sounds):
-            self.assertDictContainsSubset(expected, sound)
+            self.assertEqual(sound, sound | expected)
 
     def test_process_transcription_template(self):
         # https://ru.wiktionary.org/wiki/Шаблон:transcription


### PR DESCRIPTION
More or less straightforward. I skipped some of the rarer pronunciation templates but indicated them in code with `# XXX:`

PS: I hope you don't mind the many simultaneous PRs. This is the last week where I can really focus on contributing to wiktextract, so I try to make the most of it.