### PR TITLE
Extract glosses and examples from Russian Wiktionary

### DIFF
--- a/src/wiktextract/data/ru/linkage_subtitles.json
+++ b/src/wiktextract/data/ru/linkage_subtitles.json
@@ -1,0 +1,12 @@
+{
+  "антонимы": "antonyms",
+  "анаграммы": "anagrams",
+  "варианты": "variants",
+  "гиперонимы": "hypernyms",
+  "гипонимы": "hyponyms",
+  "дериваты": "derived",
+  "меронимы": "meronyms",
+  "синонимы": "synonyms",
+  "согипонимы": "coordinate_terms",
+  "холонимы": "holonyms"
+}

--- a/src/wiktextract/extractor/ru/example.py
+++ b/src/wiktextract/extractor/ru/example.py
@@ -1,0 +1,13 @@
+from wikitextprocessor import WikiNode
+
+from wiktextract.extractor.ru.models import WordEntry
+from wiktextract.wxr_context import WiktextractContext
+
+
+def process_example_template(
+    wxr: WiktextractContext,
+    word_entry: WordEntry,
+    template_node: WikiNode,
+):
+    pass
+    # wxr.wtp.debug(str(template_node), sortid="example")

--- a/src/wiktextract/extractor/ru/example.py
+++ b/src/wiktextract/extractor/ru/example.py
@@ -1,13 +1,63 @@
 from wikitextprocessor import WikiNode
 
-from wiktextract.extractor.ru.models import WordEntry
+from wiktextract.extractor.ru.models import Example, Reference, Sense
+from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
+
+EXAMPLE_TEMPLATE_KEY_MAPPING = {
+    "автор": "author",
+    "титул": "title",
+    "дата": "date",
+    "издание": "collection",
+    "дата издания": "date_published",
+    "ответственный": "editor",
+    "перев": "translator",
+    "источник": "source",
+}
 
 
 def process_example_template(
     wxr: WiktextractContext,
-    word_entry: WordEntry,
+    sense: Sense,
     template_node: WikiNode,
 ):
-    pass
-    # wxr.wtp.debug(str(template_node), sortid="example")
+    example = Example()
+    reference = Reference()
+    for key, value_raw in template_node.template_parameters.items():
+        value = clean_node(wxr, {}, value_raw).strip()
+        if not value:
+            continue
+        if isinstance(key, int):
+            if int(key) == 1:
+                example.text = value
+            elif int(key) == 2:
+                reference.author = value
+            elif int(key) == 3:
+                reference.title = value
+            elif int(key) == 4:
+                reference.date = value
+            elif int(key) == 5:
+                reference.collection = value
+            elif int(key) == 6:
+                reference.date_published = value
+        else:
+            key = clean_node(wxr, {}, key)
+            if key == "текст":
+                example.text = value
+            elif key == "перевод":
+                example.translation = value
+            elif key in EXAMPLE_TEMPLATE_KEY_MAPPING:
+                field_name = EXAMPLE_TEMPLATE_KEY_MAPPING.get(key, key)
+                if field_name in reference.model_fields:
+                    setattr(reference, field_name, value)
+                else:
+                    wxr.wtp.debug(
+                        f"Unknown key {key} in example template {template_node}",
+                        sortid="wiktextract/extractor/ru/example/process_example_template/54",
+                    )
+
+    if example.model_dump(exclude_defaults=True) != {}:
+        if reference.model_dump(exclude_defaults=True) != {}:
+            example.ref = reference
+
+        sense.examples.append(example)

--- a/src/wiktextract/extractor/ru/gloss.py
+++ b/src/wiktextract/extractor/ru/gloss.py
@@ -64,7 +64,7 @@ def extract_gloss(
     for child in item_node.children:
         if isinstance(child, WikiNode) and child.kind == NodeKind.TEMPLATE:
             if child.template_name == "пример":
-                process_example_template(wxr, word_entry, child)
+                process_example_template(wxr, sense, child)
 
             elif child.template_name in TAGS_TEMPLATE_NAMES:
                 tag_templates.append(child)

--- a/src/wiktextract/extractor/ru/gloss.py
+++ b/src/wiktextract/extractor/ru/gloss.py
@@ -1,0 +1,122 @@
+from wikitextprocessor import NodeKind, WikiNode
+from wikitextprocessor.parser import WikiNodeChildrenList
+
+from wiktextract.extractor.ru.example import process_example_template
+from wiktextract.extractor.ru.models import Sense, WordEntry
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
+
+TAGS_TEMPLATE_NAMES = {
+    # XXX: This list is incomplete. There are many more tag templates. Perhaps it would be better to assume all templates that are not recognized as something else are tags?
+    "жарг.",
+    "зоол.",
+    "искусств.",
+    "истор.",
+    "ихтиол.",
+    "книжн.",
+    "кулин.",
+    "ласк.",
+    "лингв.",
+    "матем.",
+    "мед.",
+    "минер.",
+    "минерал.",
+    "миф.",
+    "мифол.",
+    "неодобр.",
+    "п.",
+    "перен.",
+    "полит.",
+    "поэт.",
+    "пренебр.",
+    "прост.",
+    "разг.",
+    "религ.",
+    "техн.",
+    "устар.",
+    "фарм.",
+    "физ.",
+    "физиол.",
+    "филол.",
+    "филос.",
+    "фолькл.",
+    "хим.",
+    "церк.",
+    "шутл.",
+    "эвф.",
+    "экон.",
+    "юр.",
+}
+
+
+def extract_gloss(
+    wxr: WiktextractContext,
+    word_entry: WordEntry,
+    item_node: WikiNode,
+):
+    sense = Sense()
+
+    raw_gloss_children: WikiNodeChildrenList = []
+    clean_gloss_children: WikiNodeChildrenList = []
+    tag_templates: list[WikiNode] = []
+    note_templates: list[WikiNode] = []
+
+    for child in item_node.children:
+        if isinstance(child, WikiNode) and child.kind == NodeKind.TEMPLATE:
+            if child.template_name == "пример":
+                process_example_template(wxr, word_entry, child)
+
+            elif child.template_name in TAGS_TEMPLATE_NAMES:
+                tag_templates.append(child)
+                raw_gloss_children.append(child)
+
+            elif child.template_name == "помета":
+                note_templates.append(child)
+                raw_gloss_children.append(child)
+
+            else:
+                clean_gloss_children.append(child)
+                raw_gloss_children.append(child)
+
+                wxr.wtp.debug(
+                    f"Found template '{child.template_name}' in gloss that could be a tag",
+                    sortid="extractor/ru/gloss/extract_gloss/75",
+                )
+        else:
+            clean_gloss_children.append(child)
+            raw_gloss_children.append(child)
+
+    remove_obsolete_leading_nodes(raw_gloss_children)
+    remove_obsolete_leading_nodes(clean_gloss_children)
+
+    if raw_gloss_children:
+        raw_gloss = clean_node(wxr, {}, raw_gloss_children).strip()
+        if raw_gloss:
+            sense.raw_gloss = raw_gloss
+
+    if clean_gloss_children:
+        gloss = clean_node(wxr, {}, clean_gloss_children).strip()
+        if gloss:
+            sense.gloss = gloss
+
+    for tag_template in tag_templates:
+        tag = clean_node(wxr, {}, tag_template).strip()
+        if tag:
+            sense.tags.append(tag)
+
+    for note_template in note_templates:
+        note = clean_node(wxr, {}, note_template).strip()
+        if note:
+            sense.notes.append(note)
+
+    if sense.model_dump(exclude_defaults=True) != {}:
+        word_entry.senses.append(sense)
+
+
+def remove_obsolete_leading_nodes(nodes: WikiNodeChildrenList):
+    while (
+        nodes
+        and isinstance(nodes[0], str)
+        and nodes[0].strip() in ["", "и", "или", ",", ".", ";", ":", "\n"]
+    ):
+        nodes.pop(0)

--- a/src/wiktextract/extractor/ru/linkage.py
+++ b/src/wiktextract/extractor/ru/linkage.py
@@ -1,0 +1,13 @@
+from wikitextprocessor import WikiNode
+
+from wiktextract.extractor.ru.models import WordEntry
+from wiktextract.wxr_context import WiktextractContext
+
+
+def extract_linkages(
+    wxr: WiktextractContext,
+    word_entry: WordEntry,
+    linkage_type: str,
+    level_node: WikiNode,
+):
+    pass

--- a/src/wiktextract/extractor/ru/models.py
+++ b/src/wiktextract/extractor/ru/models.py
@@ -46,15 +46,47 @@ class Sense(BaseModelWrap):
         default=[],
         description="list of sense-disambiguated category names extracted from (a subset) of the Category links on the page",
     )
-    # examples: list["Example"] = Field(
-    #     default=[], description="List of examples"
-    # )
+    examples: list["Example"] = Field(
+        default=[], description="List of examples"
+    )
     # subsenses: list["Sense"] = Field(
     #     default=[], description="List of subsenses"
     # )
     # senseid: Optional[int] = Field(
     #     default=None, description="Sense number used in Wiktionary"
     # )
+
+
+class Reference(BaseModelWrap):
+    author: Optional[str] = Field(default=None, description="Author's name")
+    title: Optional[str] = Field(
+        default=None, description="Title of the reference"
+    )
+    date: Optional[str] = Field(default=None, description="Original date")
+    date_published: Optional[str] = Field(
+        default=None, description="Date of publication"
+    )
+
+    collection: Optional[str] = Field(
+        default=None,
+        description="Name of the collection the example was taken from",
+    )
+    editor: Optional[str] = Field(default=None, description="Editor")
+    translator: Optional[str] = Field(default=None, description="Translator")
+    source: Optional[str] = Field(
+        default=None,
+        description="Source of reference, corresponds to template parameter 'источник'",
+    )
+
+
+class Example(BaseModelWrap):
+    text: Optional[str] = Field(
+        default=None, description="Example usage sentence"
+    )
+    translation: Optional[str] = Field(
+        default=None, description="Spanish translation of the example sentence"
+    )
+    ref: Optional["Reference"] = Field(default=None, description="")
 
 
 class WordEntry(BaseModelWrap):

--- a/src/wiktextract/extractor/ru/models.py
+++ b/src/wiktextract/extractor/ru/models.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -24,6 +25,38 @@ class Sound(BaseModelWrap):
     )
 
 
+class Sense(BaseModelWrap):
+    raw_gloss: Optional[str] = Field(
+        default=None,
+        description="Raw gloss string for the word sense. This might contain tags and other markup.",
+    )
+    gloss: Optional[str] = Field(
+        default=None,
+        description="Gloss string for the word sense. This has been cleaned, and should be straightforward text with no tags.",
+    )
+    tags: list[str] = Field(
+        default=[],
+        description="List of tags affecting the word sense.",
+    )
+    notes: list[str] = Field(
+        default=[],
+        description="List of notes for the word sense. Usually describing usage.",
+    )
+    categories: list[str] = Field(
+        default=[],
+        description="list of sense-disambiguated category names extracted from (a subset) of the Category links on the page",
+    )
+    # examples: list["Example"] = Field(
+    #     default=[], description="List of examples"
+    # )
+    # subsenses: list["Sense"] = Field(
+    #     default=[], description="List of subsenses"
+    # )
+    # senseid: Optional[int] = Field(
+    #     default=None, description="Sense number used in Wiktionary"
+    # )
+
+
 class WordEntry(BaseModelWrap):
     """
     WordEntry is a dictionary containing lexical information of a single word extracted from Wiktionary with wiktextract.
@@ -45,3 +78,4 @@ class WordEntry(BaseModelWrap):
         description="list of non-disambiguated categories for the word",
     )
     sounds: Optional[list[Sound]] = []
+    senses: Optional[list[Sense]] = []

--- a/tests/test_ru_example.py
+++ b/tests/test_ru_example.py
@@ -1,0 +1,69 @@
+import unittest
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.ru.example import process_example_template
+from wiktextract.extractor.ru.models import Sense
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestRUGloss(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="ru"),
+            WiktionaryConfig(dump_file_lang_code="ru"),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def get_default_sense_data(self) -> Sense:
+        return Sense()
+
+    def test_ru_extract_gloss(self):
+        test_cases = [
+            # Ignores empty template
+            {"input": "{{пример|}}", "expected": []},
+            # https://ru.wiktionary.org/wiki/Красная_Шапочка
+            {
+                "input": "{{пример|Недолго думая, отправляю овощ в рот.|М. И. Саитов|Островки||Бельские Просторы|2010|источник=НКРЯ}}",
+                "expected": [
+                    {
+                        "ref": {
+                            "author": "М. И. Саитов",
+                            "collection": "Бельские Просторы",
+                            "date_published": "2010",
+                            "source": "НКРЯ",
+                            "title": "Островки",
+                        },
+                        "text": "Недолго думая, отправляю овощ в рот.",
+                    }
+                ],
+            },
+            # https://ru.wiktionary.org/wiki/house
+            {
+                "input": "{{пример|This is my {{выдел|house}} and my family’s ancestral home.||перевод=Это мой {{выдел|дом}} и поселение моих семейных предков.}}",
+                "expected": [
+                    {
+                        "text": "This is my and my family’s ancestral home.",
+                        "translation": "Это мой и поселение моих семейных предков.",
+                    }
+                ],
+            },
+        ]
+
+        for case in test_cases:
+            with self.subTest(case=case):
+                self.wxr.wtp.start_page("")
+                sense_data = self.get_default_sense_data()
+
+                root = self.wxr.wtp.parse(case["input"])
+
+                process_example_template(self.wxr, sense_data, root.children[0])
+
+                examples = [
+                    e.model_dump(exclude_defaults=True)
+                    for e in sense_data.examples
+                ]
+                self.assertEqual(examples, case["expected"])

--- a/tests/test_ru_gloss.py
+++ b/tests/test_ru_gloss.py
@@ -1,0 +1,74 @@
+import unittest
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.ru.gloss import extract_gloss
+from wiktextract.extractor.ru.models import WordEntry
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestRUGloss(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="ru"),
+            WiktionaryConfig(dump_file_lang_code="ru"),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def get_default_page_data(self) -> list[WordEntry]:
+        return [WordEntry(word="пример", lang_code="ru", lang_name="Русский")]
+
+    def test_ru_extract_gloss(self):
+        # https://ru.wiktionary.org/wiki/овощ
+        test_cases = [
+            # Cleans examples from gloss and raw_gloss
+            {
+                "input": "# [[съедобный|съедобная]] [[часть]] овоща [1] {{пример|Недолго думая, отправляю овощ в рот.|М. И. Саитов|Островки||Бельские Просторы|2010|источник=НКРЯ}}",
+                "expected": {
+                    "raw_gloss": "съедобная часть овоща [1]",
+                    "gloss": "съедобная часть овоща [1]",
+                },
+            },
+            # Extracts tags
+            {
+                "input": "# {{разг.|ru}}, {{неодобр.|ru}} или {{пренебр.|ru}} [[бесхарактерный]], [[безвольный]] человек, лишённый активной жизненной позиции {{пример|}}",
+                "expected": {
+                    "tags": ["разг.", "неодобр.", "пренебр."],
+                    "gloss": "бесхарактерный, безвольный человек, лишённый активной жизненной позиции",
+                    "raw_gloss": "разг., неодобр. или пренебр. бесхарактерный, безвольный человек, лишённый активной жизненной позиции",
+                },
+            },
+            # Extracts notes
+            {
+                "input": "# {{помета|часто мн}} обобщающее [[название]] растительной пищи, не включающей [[фрукт]]ы ''и'' [[крупа|крупы]]",
+                "expected": {
+                    "notes": ["часто мн. ч."],
+                    "gloss": "обобщающее название растительной пищи, не включающей фрукты и крупы",
+                    "raw_gloss": "часто мн. ч. обобщающее название растительной пищи, не включающей фрукты и крупы",
+                },
+            },
+        ]
+
+        self.wxr.wtp.add_page("Шаблон:разг.", 10, "разг.")
+        self.wxr.wtp.add_page("Шаблон:неодобр.", 10, "неодобр.")
+        self.wxr.wtp.add_page("Шаблон:пренебр.", 10, "пренебр.")
+        self.wxr.wtp.add_page("Шаблон:помета", 10, "часто мн. ч.")
+
+        for case in test_cases:
+            with self.subTest(case=case):
+                self.wxr.wtp.start_page("")
+                page_data = self.get_default_page_data()
+
+                root = self.wxr.wtp.parse(case["input"])
+
+                extract_gloss(
+                    self.wxr, page_data[-1], root.children[0].children[0]
+                )
+
+                new_sense = (
+                    page_data[-1].senses[-1].model_dump(exclude_defaults=True)
+                )
+                self.assertEqual(new_sense, case["expected"])

--- a/tests/test_ru_page.py
+++ b/tests/test_ru_page.py
@@ -1,0 +1,55 @@
+import unittest
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.ru.page import parse_page
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestRUPage(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="ru"),
+            WiktionaryConfig(
+                dump_file_lang_code="ru", capture_language_codes={"ru"}
+            ),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    # def get_default_page_data(self) -> list[WordEntry]:
+    #     return [WordEntry(word="test", lang_code="es", lang_name="Language")]
+
+    def test_ru_parse_page_1(self):
+        # Navigates homonyms/homographs
+        # E.g. https://ru.wiktionary.org/wiki/овощ
+
+        self.wxr.wtp.add_page("Шаблон:-ru-", 10, "")
+        self.wxr.wtp.add_page("Шаблон:з", 10, "")
+
+        page_text = """= {{-ru-}} =
+== {{з|I}} ==
+=== Морфологические и синтаксические свойства ===
+== {{з|II}} ==
+=== Морфологические и синтаксические свойства ===
+"""
+
+        page_data_dicts = parse_page(self.wxr, "овощ", page_text)
+
+        self.assertEqual(len(page_data_dicts), 2)
+
+    def test_ru_parse_page_2(self):
+        # Navigates in case of absence of H2 headings (homonyms/homographs)
+        # E.g. https://ru.wiktionary.org/wiki/сарлык
+
+        self.wxr.wtp.add_page("Шаблон:-ru-", 10, "")
+
+        page_text = """= {{-ru-}} =
+=== Морфологические и синтаксические свойства ===
+"""
+
+        page_data_dicts = parse_page(self.wxr, "овощ", page_text)
+
+        self.assertEqual(len(page_data_dicts), 1)


### PR DESCRIPTION
This extracts raw_glosses and attempts to extract clean glosses (without notes and tags). Currently only some tags are recognized and moved to the tags field. The rest of the tags are left in the gloss. I marked this with a `# XXX: ` note.

This also extracts examples from the template `{пример|}`.