### PR TITLE
Forbid setting extra attributes during model initialization

### DIFF
--- a/src/wiktextract/extractor/fr/models.py
+++ b/src/wiktextract/extractor/fr/models.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class FrenchBaseModel(BaseModel):
     model_config = ConfigDict(
-        extra="ignore",
+        extra="forbid",
         strict=True,
         validate_assignment=True,
         validate_default=True,

--- a/src/wiktextract/extractor/zh/models.py
+++ b/src/wiktextract/extractor/zh/models.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class ChineseBaseModel(BaseModel):
     model_config = ConfigDict(
-        extra="ignore",
+        extra="forbid",
         strict=True,
         validate_assignment=True,
         validate_default=True,


### PR DESCRIPTION
I forgot to use `forbid` in previous commits.