### PR TITLE
Don't remove bold and italic wikitext before expanding nodes

### DIFF
--- a/src/wiktextract/page.py
+++ b/src/wiktextract/page.py
@@ -358,8 +358,6 @@ def clean_node(
         if kind in {
             NodeKind.TABLE_CELL,
             NodeKind.TABLE_HEADER_CELL,
-            NodeKind.BOLD,
-            NodeKind.ITALIC,
         }:
             return node.children
         return None


### PR DESCRIPTION
Remove the bold wikitext causes error in English Wiktionary template "ja-usex". Bold and italic nodes are converted to plain text later somewhere in `clean_value()`.

Resolves tatuylonen/wikitextprocessor#170