### PR TITLE
Extract "Paronymes" section under the "Prononciation" section

### DIFF
--- a/src/wiktextract/extractor/fr/pronunciation.py
+++ b/src/wiktextract/extractor/fr/pronunciation.py
@@ -1,5 +1,5 @@
 from wikitextprocessor import NodeKind, WikiNode
-from wikitextprocessor.parser import TemplateNode
+from wikitextprocessor.parser import LEVEL_KIND_FLAGS, TemplateNode
 from wiktextract.extractor.share import create_audio_url_dict
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
@@ -15,11 +15,18 @@ def extract_pronunciation(
 ) -> None:
     sound_data = []
     lang_code = base_data.lang_code
-    for list_node in level_node.find_child(NodeKind.LIST):
-        for list_item_node in list_node.find_child(NodeKind.LIST_ITEM):
-            sound_data.extend(
-                process_pron_list_item(wxr, list_item_node, Sound(), lang_code)
-            )
+    for node in level_node.find_child(NodeKind.LIST | LEVEL_KIND_FLAGS):
+        if node.kind == NodeKind.LIST:
+            for list_item_node in node.find_child(NodeKind.LIST_ITEM):
+                sound_data.extend(
+                    process_pron_list_item(
+                        wxr, list_item_node, Sound(), lang_code
+                    )
+                )
+        else:
+            from .page import parse_section
+
+            parse_section(wxr, page_data, base_data, node)
 
     if len(sound_data) == 0:
         return

--- a/tests/test_fr_pronunciation.py
+++ b/tests/test_fr_pronunciation.py
@@ -120,3 +120,34 @@ class TestPronunciation(TestCase):
                 "mp3_url": "https://upload.wikimedia.org/wikipedia/commons/transcoded/3/3f/LL-Q9027_(swe)-Moonhouse-mars.wav/LL-Q9027_(swe)-Moonhouse-mars.wav.mp3",
             },
         )
+
+    def test_paronymes_subsection(self):
+        # https://fr.wiktionary.org/wiki/wagonnet
+        page_data = []
+        self.wxr.wtp.add_page("Modèle:pron", 10, body="\\{{{1|}}}\\")
+        self.wxr.wtp.start_page("wagonnet")
+        root = self.wxr.wtp.parse(
+            """=== {{S|prononciation}} ===
+* {{pron|va.ɡɔ.nɛ|fr}}
+
+==== {{S|paronymes}} ====
+* [[wagonnée]]
+* [[wagonnier]]
+"""
+        )
+        extract_pronunciation(
+            self.wxr,
+            page_data,
+            root.children[0],
+            WordEntry(word="wagonnet", lang_code="fr", lang_name="Français"),
+        )
+        self.assertEqual(
+            page_data[0].model_dump(exclude_defaults=True),
+            {
+                "word": "wagonnet",
+                "lang_code": "fr",
+                "lang_name": "Français",
+                "paronyms": [{"word": "wagonnée"}, {"word": "wagonnier"}],
+                "sounds": [{"ipa": "\\va.ɡɔ.nɛ\\"}],
+            },
+        )


### PR DESCRIPTION
Other sections under "Prononciation" will also be processed now. Requires https://github.com/tatuylonen/wikitextprocessor/pull/173