### PR TITLE
Extract "Onglets conjugaison" template

### DIFF
--- a/src/wiktextract/extractor/fr/conjugation.py
+++ b/src/wiktextract/extractor/fr/conjugation.py
@@ -75,7 +75,7 @@ def process_fr_conj_modes_table(
                     entry.forms.append(form)
                     form_text = ""
                 else:
-                    if len(form_text) > 0:
+                    if len(form_text) > 0 and not form_text.endswith("’"):
                         form_text += " "
                     form_text += clean_node(wxr, None, cell)
 
@@ -120,16 +120,19 @@ def process_fr_conj_html_table(
             for td_index, td_node in enumerate(
                 tr_node.find_html_recursively("td")
             ):
+                td_text = clean_node(wxr, None, td_node)
                 if td_index < 2:
-                    if len(form.form) > 0:
+                    form.form += td_text
+                    if td_index == 0 and not td_text.endswith("’"):
                         form.form += " "
-                    form.form += clean_node(wxr, None, td_node)
                 else:
                     if len(form.ipas) > 0:
-                        form.ipas[0] += " "
-                        form.ipas[0] += clean_node(wxr, None, td_node)
+                        form.ipas[0] += td_text
                     else:
-                        form.ipas.append(clean_node(wxr, None, td_node))
+                        if not td_text.endswith("‿"):
+                            td_text += " "
+                        form.ipas.append(td_text)
+
             entry.forms.append(form)
 
 
@@ -148,10 +151,12 @@ def process_fr_conj_wiki_table(
             for cell_index, cell in enumerate(
                 row.find_child(NodeKind.TABLE_CELL)
             ):
+                cell_text = clean_node(wxr, None, cell)
                 if cell_index < 2:
-                    if len(form.form) > 0:
+                    form.form += cell_text
+                    if cell_index == 0:
                         form.form += " "
-                    form.form += clean_node(wxr, None, cell.children)
                 else:
-                    form.ipas.append(clean_node(wxr, None, cell.children))
+                    form.ipas.append(cell_text)
+
             entry.forms.append(form)

--- a/tests/test_fr_conj.py
+++ b/tests/test_fr_conj.py
@@ -98,3 +98,62 @@ class TestNotes(TestCase):
                 },
             ],
         )
+
+    def test_onglets_conjugaison(self):
+        # https://fr.wiktionary.org/wiki/Conjugaison:français/s’abattre
+        self.wxr.wtp.start_page("s’abattre")
+        self.wxr.wtp.add_page(
+            "Conjugaison:français/abattre",
+            116,
+            """{{Onglets conjugaison
+| onglet1  =Conjugaison active
+| contenu1 ={{fr-conj-3-attre|ab|a.b|'=oui}}
+| onglet2  =Conjugaison pronominale
+| contenu2 ={{fr-conj-3-attre|ab|a.b|'=oui|réfl=1}}
+| sél ={{{sél|1}}}
+}}""",
+        )
+        self.wxr.wtp.add_page(
+            "Conjugaison:français/s’abattre",
+            116,
+            "{{:Conjugaison:français/abattre|sél=2}}",
+        )
+        self.wxr.wtp.add_page(
+            "Modèle:fr-conj-3-attre",
+            10,
+            """<h3> Modes impersonnels </h3>
+<div>
+{|
+|-[[mode|Mode]]
+!colspan=\"3\"|[[présent|Présent]]
+!colspan=\"3\"|[[passé|Passé]]
+|-
+|'''[[infinitif|Infinitif]]'''
+|s’
+|[[abattre]]
+|<span>\\s‿a.batʁ\\</span>
+|s’être
+|[[abattu]]
+|<span>\\s‿ɛtʁ‿a.ba.ty\\</span>
+|}
+</div>""",
+        )
+        entry = WordEntry(lang_code="fr", lang="Français", word="s’abattre")
+        extract_conjugation(self.wxr, entry)
+        self.assertEqual(
+            [f.model_dump(exclude_defaults=True) for f in entry.forms],
+            [
+                {
+                    "form": "s’abattre",
+                    "ipas": ["\\s‿a.batʁ\\"],
+                    "source": "Conjugaison page",
+                    "tags": ["Modes impersonnels", "Infinitif", "Présent"],
+                },
+                {
+                    "form": "s’être abattu",
+                    "ipas": ["\\s‿ɛtʁ‿a.ba.ty\\"],
+                    "source": "Conjugaison page",
+                    "tags": ["Modes impersonnels", "Infinitif", "Passé"],
+                },
+            ],
+        )

--- a/tests/test_fr_form_line.py
+++ b/tests/test_fr_form_line.py
@@ -24,9 +24,7 @@ class TestFormLine(TestCase):
         self.wxr.wtp.start_page("bonjour")
         self.wxr.wtp.add_page("Modèle:pron", 10, "\\bɔ̃.ʒuʁ\\")
         root = self.wxr.wtp.parse("'''bonjour''' {{pron|bɔ̃.ʒuʁ|fr}}")
-        page_data = [
-            WordEntry(word="bonjour", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="bonjour", lang_code="fr", lang="Français")]
         extract_form_line(self.wxr, page_data, root.children)
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].sounds],
@@ -37,9 +35,7 @@ class TestFormLine(TestCase):
         self.wxr.wtp.start_page("bonjour")
         self.wxr.wtp.add_page("Modèle:m", 10, "masculin")
         root = self.wxr.wtp.parse("'''bonjour''' {{m}}")
-        page_data = [
-            WordEntry(word="bonjour", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="bonjour", lang_code="fr", lang="Français")]
         extract_form_line(self.wxr, page_data, root.children)
         self.assertEqual(page_data[-1].tags, ["masculin"])
 
@@ -49,9 +45,7 @@ class TestFormLine(TestCase):
         self.wxr.wtp.add_page("Modèle:lang", 10, body="mǎ")
         self.wxr.wtp.add_page("Modèle:pron", 10, body="\\ma̠˨˩˦\\")
         root = self.wxr.wtp.parse("{{zh-mot|马|mǎ}}")
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         process_zh_mot_template(self.wxr, root.children[0], page_data)
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].sounds],
@@ -98,9 +92,7 @@ class TestFormLine(TestCase):
         root = self.wxr.wtp.parse(
             "'''minéral argileux''' {{pron|mi.ne.ʁa.l{{liaison|fr}}aʁ.ʒi.lø|fr}}"
         )
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_form_line(self.wxr, page_data, root.children)
         self.assertEqual(
             page_data[-1].sounds[0].model_dump(exclude_defaults=True),
@@ -117,9 +109,7 @@ class TestFormLine(TestCase):
         root = self.wxr.wtp.parse(
             "{{équiv-pour|un homme|auteur|2egenre=une personne non-binaire|2egenre1=autaire|2egenre2=auteurice|2egenre3=auteur·ice|lang=fr}}"
         )
-        page_data = [
-            WordEntry(word="autrice", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="autrice", lang_code="fr", lang="Français")]
         extract_form_line(self.wxr, page_data, root.children)
         self.assertEqual(
             page_data[-1].model_dump(exclude_defaults=True),

--- a/tests/test_fr_gloss.py
+++ b/tests/test_fr_gloss.py
@@ -29,9 +29,7 @@ class TestFrGloss(TestCase):
     def test_theme_templates(self, mock_get_page):
         self.wxr.wtp.start_page("")
         root = self.wxr.wtp.parse("# {{sportifs|fr}} gloss.\n#* example")
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_gloss(self.wxr, page_data, root.children[0])
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].senses],
@@ -50,9 +48,7 @@ class TestFrGloss(TestCase):
         root = self.wxr.wtp.parse(
             "# gloss.\n#* {{exemple|text|translation|roman|source=source}}"
         )
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_gloss(self.wxr, page_data, root.children[0])
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].senses],
@@ -80,9 +76,7 @@ class TestFrGloss(TestCase):
         root = self.wxr.wtp.parse(
             "# gloss.\n#* example {{source|source_title}}"
         )
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_gloss(self.wxr, page_data, root.children[0])
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].senses],
@@ -151,9 +145,7 @@ class TestFrGloss(TestCase):
         root = self.wxr.wtp.parse(
             "# {{désuet|en}} {{sports|en}} {{indénombrable|en}} {{variante de|basketball|en}}."
         )
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_gloss(self.wxr, page_data, root.children[0])
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].senses],
@@ -171,9 +163,7 @@ class TestFrGloss(TestCase):
         root = self.wxr.wtp.parse(
             "# (''localement'') [[bassin#Nom_commun|Bassin]], [[lavoir#Nom_commun|lavoir]]."
         )
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_gloss(self.wxr, page_data, root.children[0])
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].senses],
@@ -186,9 +176,7 @@ class TestFrGloss(TestCase):
         root = self.wxr.wtp.parse(
             "# [[oiseau|Oiseau]] aquatique de taille moyenne du genre ''[[Rhynchops]]''."
         )
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_gloss(self.wxr, page_data, root.children[0])
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].senses],
@@ -206,9 +194,7 @@ class TestFrGloss(TestCase):
         # the space between italic node and the link node should be preserved
         self.wxr.wtp.start_page("becs-en-ciseaux")
         root = self.wxr.wtp.parse("# ''Pluriel de'' [[bec-en-ciseaux]].")
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_gloss(self.wxr, page_data, root.children[0])
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].senses],
@@ -225,9 +211,7 @@ class TestFrGloss(TestCase):
         root = self.wxr.wtp.parse(
             "# {{lien|autrice|fr|dif=Autrice}}, [[celle]] qui est à l’[[origine]] de [[quelque chose]]."
         )
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_gloss(self.wxr, page_data, root.children[0])
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].senses],
@@ -250,9 +234,7 @@ class TestFrGloss(TestCase):
 ##* nest example
             """
         )
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_gloss(self.wxr, page_data, root.children[0])
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[-1].senses],

--- a/tests/test_fr_inflection.py
+++ b/tests/test_fr_inflection.py
@@ -43,9 +43,7 @@ class TestInflection(TestCase):
 
     def test_fr_accord_al(self):
         # https://fr.wiktionary.org/wiki/animal#Adjectif
-        page_data = [
-            WordEntry(word="animal", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="animal", lang_code="fr", lang="Français")]
         self.wxr.wtp.add_page(
             "Modèle:fr-accord-al",
             10,
@@ -90,9 +88,7 @@ class TestInflection(TestCase):
     def test_multiple_lines_ipa(self):
         # https://fr.wiktionary.org/wiki/ration#Nom_commun_2
         # template "en-nom-rég"
-        page_data = [
-            WordEntry(word="ration", lang_code="en", lang="Anglais")
-        ]
+        page_data = [WordEntry(word="ration", lang_code="en", lang="Anglais")]
         self.wxr.wtp.add_page(
             "Modèle:en-nom-rég",
             10,
@@ -120,9 +116,7 @@ class TestInflection(TestCase):
     def test_single_line_multiple_ipa(self):
         # https://fr.wiktionary.org/wiki/ration#Verbe
         # template "en-conj-rég"
-        page_data = [
-            WordEntry(word="ration", lang_code="en", lang="Anglais")
-        ]
+        page_data = [WordEntry(word="ration", lang_code="en", lang="Anglais")]
         self.wxr.wtp.add_page(
             "Modèle:en-conj-rég",
             10,
@@ -152,9 +146,7 @@ class TestInflection(TestCase):
 
     def test_invalid_ipa(self):
         # https://fr.wiktionary.org/wiki/animal#Nom_commun_3
-        page_data = [
-            WordEntry(word="animal", lang_code="en", lang="Français")
-        ]
+        page_data = [WordEntry(word="animal", lang_code="en", lang="Français")]
         self.wxr.wtp.add_page(
             "Modèle:ast-accord-mf",
             10,
@@ -179,9 +171,7 @@ class TestInflection(TestCase):
     def test_no_column_headers(self):
         # https://fr.wiktionary.org/wiki/一万#Nom_commun
         # template "zh-formes"
-        page_data = [
-            WordEntry(word="一万", lang_code="zh", lang="Chinois")
-        ]
+        page_data = [WordEntry(word="一万", lang_code="zh", lang="Chinois")]
         self.wxr.wtp.add_page(
             "Modèle:zh-formes",
             10,
@@ -204,9 +194,7 @@ class TestInflection(TestCase):
 
     def test_lt_décl_as(self):
         # empty table cells should be ignored
-        page_data = [
-            WordEntry(word="abadai", lang_code="lt", lang="Lituanien")
-        ]
+        page_data = [WordEntry(word="abadai", lang_code="lt", lang="Lituanien")]
         self.wxr.wtp.add_page(
             "Modèle:lt-décl-as",
             10,
@@ -229,9 +217,7 @@ class TestInflection(TestCase):
         )
 
     def test_fr_accord_s(self):
-        page_data = [
-            WordEntry(word="aastais", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="aastais", lang_code="fr", lang="Français")]
         self.wxr.wtp.add_page(
             "Modèle:fr-accord-s",
             10,
@@ -276,9 +262,7 @@ class TestInflection(TestCase):
     def test_fr_accord_personne(self):
         # https://fr.wiktionary.org/wiki/enculé_de_ta_race
         page_data = [
-            WordEntry(
-                word="enculé de ta race", lang_code="fr", lang="Français"
-            )
+            WordEntry(word="enculé de ta race", lang_code="fr", lang="Français")
         ]
         self.wxr.wtp.add_page(
             "Modèle:fr-accord-personne",
@@ -330,9 +314,7 @@ class TestInflection(TestCase):
 
     def test_ro_nom_tab(self):
         # https://fr.wiktionary.org/wiki/fenil#Nom_commun_4
-        page_data = [
-            WordEntry(word="fenil", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="fenil", lang_code="fr", lang="Français")]
         self.wxr.wtp.add_page(
             "Modèle:ro-nom-tab",
             10,
@@ -386,9 +368,7 @@ class TestInflection(TestCase):
 
     def test_sv_nom_c_ar(self):
         # https://fr.wiktionary.org/wiki/robot#Nom_commun_7
-        page_data = [
-            WordEntry(word="robot", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="robot", lang_code="fr", lang="Français")]
         self.wxr.wtp.add_page(
             "Modèle:sv-nom-c-ar",
             10,
@@ -422,9 +402,7 @@ class TestInflection(TestCase):
 
     def test_cs_decl_nom_ma_dur(self):
         # https://fr.wiktionary.org/wiki/robot#Nom_commun_1_2
-        page_data = [
-            WordEntry(word="robot", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="robot", lang_code="fr", lang="Français")]
         self.wxr.wtp.add_page(
             "Modèle:cs-décl-nom-ma-dur",
             10,

--- a/tests/test_fr_linkage.py
+++ b/tests/test_fr_linkage.py
@@ -17,9 +17,7 @@ class TestLinkage(TestCase):
         self.wxr.wtp.close_db_conn()
 
     def test_tags(self):
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         self.wxr.wtp.start_page("bonjour")
         self.wxr.wtp.add_page("Modèle:Canada", 10, body="(Canada)")
         self.wxr.wtp.add_page("Modèle:Louisiane", 10, body="(Louisiane)")
@@ -33,9 +31,7 @@ class TestLinkage(TestCase):
         )
 
     def test_zh_synonyms(self):
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         self.wxr.wtp.start_page("你好")
         root = self.wxr.wtp.parse(
             "* {{zh-lien|你们好|nǐmen hǎo|你們好}} — Bonjour (au pluriel)."
@@ -52,9 +48,7 @@ class TestLinkage(TestCase):
         )
 
     def test_template_as_partial_tag(self):
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         self.wxr.wtp.start_page("bonjour")
         self.wxr.wtp.add_page("Modèle:lien", 10, body="kwei")
         self.wxr.wtp.add_page("Modèle:Canada", 10, body="(Canada)")
@@ -69,9 +63,7 @@ class TestLinkage(TestCase):
         )
 
     def test_list_item_has_two_words(self):
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         self.wxr.wtp.start_page("masse")
         root = self.wxr.wtp.parse(
             "* [[être à la masse]], [[mettre à la masse]]"
@@ -89,9 +81,7 @@ class TestLinkage(TestCase):
         )
 
     def test_sub_list(self):
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         self.wxr.wtp.start_page("lézard ocellé")
         root = self.wxr.wtp.parse(
             """* [[saurien]]s (Sauria)
@@ -119,9 +109,7 @@ class TestLinkage(TestCase):
     def test_sense(self):
         # https://fr.wiktionary.org/wiki/autrice
         # https://fr.wiktionary.org/wiki/embouteillage
-        page_data = [
-            WordEntry(word="autrice", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="autrice", lang_code="fr", lang="Français")]
         self.wxr.wtp.start_page("autrice")
         root = self.wxr.wtp.parse(
             """{{(|Celle qui est à l’origine de quelque chose|1}}
@@ -163,9 +151,7 @@ class TestLinkage(TestCase):
 | en = Anglais
 }}""",
         )
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         self.wxr.wtp.start_page("eau")
         root = self.wxr.wtp.parse(
             """* {{L|kmv}} : {{lien|dlo|kmv}}, {{lien|djilo|kmv}}
@@ -197,9 +183,7 @@ class TestLinkage(TestCase):
         )
 
     def test_words_divided_by_slash(self):
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         self.wxr.wtp.start_page("eau")
         root = self.wxr.wtp.parse("* [[benoîte d’eau]] / [[benoite d’eau]]")
         extract_linkage(self.wxr, page_data, root, "dérivés")

--- a/tests/test_fr_note.py
+++ b/tests/test_fr_note.py
@@ -28,9 +28,7 @@ class TestNotes(TestCase):
 paragrapy 1
 {{note-féminisation}}"""
         )
-        page_data = [
-            WordEntry(word="test", lang_code="fr", lang="Français")
-        ]
+        page_data = [WordEntry(word="test", lang_code="fr", lang="Français")]
         extract_note(self.wxr, page_data, nodes.children[0])
         self.assertEqual(
             page_data[-1].notes,

--- a/tests/test_fr_translation.py
+++ b/tests/test_fr_translation.py
@@ -23,9 +23,7 @@ class TestTranslation(TestCase):
         root = self.wxr.wtp.parse(
             "=== Traductions ===\n* {{trad-début|Formule pour saluer}}\n* {{T|sq}} : {{trad+|sq|mirëdita}}, {{trad-|sq|mirë mëngjes}} ''(le matin)''"
         )
-        base_data = WordEntry(
-            word="bonjour", lang_code="fr", lang="Français"
-        )
+        base_data = WordEntry(word="bonjour", lang_code="fr", lang="Français")
         page_data = [base_data.model_copy(deep=True)]
         extract_translation(self.wxr, page_data, base_data, root.children[0])
         self.assertEqual(
@@ -60,9 +58,7 @@ class TestTranslation(TestCase):
         root = self.wxr.wtp.parse(
             "=== Traductions ===\n* {{T|ar}} : {{trad+|ar|مرحبا|dif=مرحبًا|tr={{transliterator|ar|مرحبا}}}} {{informel|nocat=1}}"
         )
-        base_data = WordEntry(
-            word="bonjour", lang_code="fr", lang="Français"
-        )
+        base_data = WordEntry(word="bonjour", lang_code="fr", lang="Français")
         page_data = [base_data.model_copy(deep=True)]
         extract_translation(self.wxr, page_data, base_data, root.children[0])
         self.assertEqual(
@@ -89,9 +85,7 @@ class TestTranslation(TestCase):
         root = self.wxr.wtp.parse(
             "=== Traductions ===\n* {{T|mn}} : {{trad+|mn|сайн байна уу|tr=sain baina uu|tradi=ᠰᠠᠶᠢᠨ ᠪᠠᠶᠢᠨ᠎ᠠ ᠤᠤ}}"
         )
-        base_data = WordEntry(
-            word="bonjour", lang_code="fr", lang="Français"
-        )
+        base_data = WordEntry(word="bonjour", lang_code="fr", lang="Français")
         page_data = [base_data.model_copy(deep=True)]
         extract_translation(self.wxr, page_data, base_data, root.children[0])
         self.assertEqual(
@@ -120,9 +114,7 @@ class TestTranslation(TestCase):
         root = self.wxr.wtp.parse(
             "=== Traductions ===\n* {{T|de}} : {{trad|de|Kambium|n}}"
         )
-        base_data = WordEntry(
-            word="cambium", lang_code="fr", lang="Français"
-        )
+        base_data = WordEntry(word="cambium", lang_code="fr", lang="Français")
         page_data = [base_data.model_copy(deep=True)]
         extract_translation(self.wxr, page_data, base_data, root.children[0])
         self.assertEqual(
@@ -164,9 +156,7 @@ class TestTranslation(TestCase):
 ===== {{S|traductions à trier}} =====
 * {{T|af|trier}} : {{trad+|af|massa}}"""
         )
-        base_data = WordEntry(
-            word="masse", lang_code="fr", lang="Français"
-        )
+        base_data = WordEntry(word="masse", lang_code="fr", lang="Français")
         page_data = [base_data.model_copy(deep=True)]
         extract_translation(self.wxr, page_data, base_data, root.children[0])
         self.assertEqual(


### PR DESCRIPTION
I only take a look the link parser code: https://github.com/tatuylonen/wikitextprocessor/blob/0cb88feb77be2e03ba0eac4aca1ea1cb4cba20f8/src/wikitextprocessor/core.py#L598

This seems not easy to fix.