### PR TITLE
Fix bug introduced from 04ca7a8126e749f8fb500fdb96e43a8f8316d7ae

### DIFF
--- a/src/wiktextract/wiktwords.py
+++ b/src/wiktextract/wiktwords.py
@@ -149,7 +149,7 @@ def main():
     parser.add_argument(
         "--skip-extraction",
         action="store_true",
-        default="False",
+        default=False,
         help="Skip the (usually lengthy) json data extraction "
         "procedure to do other things, like creating a database "
         "file or other files."


### PR DESCRIPTION
This is why Python magic methods shouldn't be used, `not "False"` is `False`.