### PR TITLE
Fix `ValueError` in fr edition page "gigabit", "million", "亿"

### DIFF
--- a/src/wiktextract/extractor/fr/linkage.py
+++ b/src/wiktextract/extractor/fr/linkage.py
@@ -95,17 +95,19 @@ def process_linkage_list(
         for index, child_node in enumerate(  # remove nested lists
             template_or_list_node.invert_find_child(NodeKind.LIST)
         ):
-            if index == 0 or linkage_data.word == "":
-                if isinstance(child_node, TemplateNode):
-                    process_linkage_template(wxr, child_node, linkage_data)
-                else:
-                    linkage_data.word = clean_node(wxr, None, child_node)
+            if index == 0 and isinstance(child_node, TemplateNode):
+                process_linkage_template(wxr, child_node, linkage_data)
+            elif (
+                isinstance(child_node, WikiNode)
+                and child_node.kind == NodeKind.LINK
+            ):
+                linkage_data.word = clean_node(wxr, None, child_node)
             elif (
                 isinstance(child_node, WikiNode)
                 and child_node.kind == NodeKind.ITALIC
             ):
                 current_sense = clean_node(wxr, None, child_node).strip("()")
-                if current_sense.isdigit():
+                if current_sense.isdecimal():
                     linkage_data.sense_index = int(current_sense)
                 else:
                     linkage_data.sense = current_sense

--- a/tests/test_fr_linkage.py
+++ b/tests/test_fr_linkage.py
@@ -245,3 +245,18 @@ class TestLinkage(TestCase):
                 {"word": "korpo", "sense": "corps"},
             ],
         )
+
+    def test_italic_number_sense(self):
+        page_data = [WordEntry(word="gigabit", lang_code="en", lang="Anglais")]
+        self.wxr.wtp.start_page("gigabit")
+        root = self.wxr.wtp.parse("* (''10<sup>9</sup>'') [[Gb]]")
+        extract_linkage(self.wxr, page_data, root, "variantes orthographiques")
+        self.assertEqual(
+            [
+                d.model_dump(exclude_defaults=True)
+                for d in page_data[-1].related
+            ],
+            [
+                {"word": "Gb", "sense": "10⁹"},
+            ],
+        )


### PR DESCRIPTION
I should use `str.isdecimal()`, `str.isdigit()` returns `True` for letters that are not 0-9.