### PR TITLE
Remove `Sense.translations` field from de edition's model

### DIFF
--- a/src/wiktextract/extractor/de/models.py
+++ b/src/wiktextract/extractor/de/models.py
@@ -12,6 +12,7 @@ class BaseModelWrap(BaseModel):
 
 class Linkage(BaseModelWrap):
     word: str
+    sense_id: str = ""
 
 
 class Translation(BaseModelWrap):
@@ -104,15 +105,6 @@ class Sense(BaseModelWrap):
     senseid: str = Field(
         default="", description="Sense number used in Wiktionary"
     )
-    antonyms: list[Linkage] = []
-    derived: list[Linkage] = []
-    hyponyms: list[Linkage] = []
-    hypernyms: list[Linkage] = []
-    holonyms: list[Linkage] = []
-    expressions: list[Linkage] = []
-    coordinate_terms: list[Linkage] = []
-    proverbs: list[Linkage] = []
-    synonyms: list[Linkage] = []
 
 
 class Sound(BaseModelWrap):

--- a/src/wiktextract/extractor/de/models.py
+++ b/src/wiktextract/extractor/de/models.py
@@ -30,10 +30,7 @@ class Translation(BaseModelWrap):
     roman: str = Field(
         default="", description="Transliteration to Roman characters"
     )
-    # senseids: list[str] = Field(
-    #     default=[],
-    #     description="List of senseids where this translation applies",
-    # )
+    sense_id: str = ""
     tags: list[str] = Field(
         default=[],
         description="Tags specifying the translated term, usually gender information",
@@ -107,7 +104,6 @@ class Sense(BaseModelWrap):
     senseid: str = Field(
         default="", description="Sense number used in Wiktionary"
     )
-    translations: list[Translation] = []
     antonyms: list[Linkage] = []
     derived: list[Linkage] = []
     hyponyms: list[Linkage] = []

--- a/src/wiktextract/extractor/de/translation.py
+++ b/src/wiktextract/extractor/de/translation.py
@@ -25,9 +25,9 @@ def extract_translation(
             )
         else:
             sense_translations = []
-            base_translation_data = Translation()
-            senseid = level_node_child.template_parameters.get(1)
-            if senseid == None:
+            sense_id = level_node_child.template_parameters.get(1, "")
+            base_translation_data = Translation(sense_id=sense_id)
+            if sense_id == "":
                 # XXX: Sense-disambiguate where senseids are in Ü-Liste (ca. 0.03% of pages), e.g.:
                 # https://de.wiktionary.org/wiki/Beitrag
                 # """
@@ -68,19 +68,7 @@ def extract_translation(
             if dialect_table:
                 process_dialect_table(wxr, base_translation_data, dialect_table)
 
-            matched_senseid = False
-            if senseid:
-                for sense in word_entry.senses:
-                    if sense.senseid == senseid.strip():
-                        sense.translations.extend(sense_translations)
-                        matched_senseid = True
-
-            if not matched_senseid:
-                wxr.wtp.debug(
-                    f"Unknown senseid: {senseid}.",
-                    sortid="extractor/de/translation/extract_translation/65",
-                )
-                word_entry.translations.extend(sense_translations)
+            word_entry.translations.extend(sense_translations)
 
 
 def process_translation_list(
@@ -171,7 +159,7 @@ def overwrite_word(
     translation_data: Translation,
     nodes: Union[list[Union[WikiNode, str]], WikiNode, str, None],
 ):
-    if nodes == None:
+    if nodes is None:
         return
     overwrite_word = clean_node(wxr, {}, nodes).strip()
     if overwrite_word:

--- a/src/wiktextract/extractor/es/linkage.py
+++ b/src/wiktextract/extractor/es/linkage.py
@@ -1,19 +1,17 @@
-from typing import Union
-
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.parser import WikiNodeChildrenList
-from wiktextract.extractor.es.models import Linkage, Sense, WordEntry
+from wiktextract.extractor.es.models import Linkage, WordEntry
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 
 
 def extract_linkage(
     wxr: WiktextractContext,
-    data_container: Union[WordEntry, Sense],
+    word_entry: WordEntry,
     node: WikiNode,
     linkage_type: str,
 ):
-    if linkage_type not in data_container.model_fields:
+    if linkage_type not in word_entry.model_fields:
         wxr.wtp.debug(
             f"Linkage type {linkage_type} not found in pydantic model",
             sortid="extractor/es/linkage/extract_linkage/20",
@@ -21,60 +19,55 @@ def extract_linkage(
         return
 
     for link_node in node.find_child_recursively(NodeKind.LINK):
-        word = clean_node(wxr, {}, link_node)
-        if word:
-            getattr(data_container, linkage_type).append(Linkage(word=word))
+        word = clean_node(wxr, None, link_node)
+        if len(word) > 0:
+            getattr(word_entry, linkage_type).append(Linkage(word=word))
 
     for template_node in node.find_child_recursively(NodeKind.TEMPLATE):
         if template_node.template_name == "l":
-            word = clean_node(wxr, {}, template_node)
-            if word:
-                getattr(data_container, linkage_type).append(Linkage(word=word))
+            word = clean_node(wxr, None, template_node)
+            if len(word) > 0:
+                getattr(word_entry, linkage_type).append(Linkage(word=word))
 
 
 def process_linkage_template(
     wxr: WiktextractContext,
-    data_container: Union[WordEntry, Sense],
+    word_entry: WordEntry,
     template_node: WikiNode,
 ):
     linkage_type = wxr.config.LINKAGE_SUBTITLES.get(
         template_node.template_name.removesuffix("s")
     )
-    if linkage_type not in data_container.model_fields:
+    if linkage_type not in word_entry.model_fields:
         wxr.wtp.debug(
             f"Linkage type {linkage_type} not found in pydantic model",
             sortid="extractor/es/linkage/process_linkage_template/51",
         )
         return
 
+    linkage_list = getattr(word_entry, linkage_type)
     for key, value_raw in template_node.template_parameters.items():
-        value = clean_node(wxr, {}, value_raw)
+        value = clean_node(wxr, None, value_raw)
         if isinstance(key, int):
-            getattr(data_container, linkage_type).append(Linkage(word=value))
-
+            getattr(word_entry, linkage_type).append(Linkage(word=value))
         elif isinstance(key, str):
             if key.startswith("nota"):
                 idx = int(key[4:]) - 1 if len(key) > 4 else 0
-
-                if len(getattr(data_container, linkage_type)) > idx:
-                    getattr(data_container, linkage_type)[idx].note = value
-
+                if len(linkage_list) > idx:
+                    linkage_list[idx].note = value
             elif key.startswith("alt"):
                 idx = int(key[3:]) - 1 if len(key) > 3 else 0
-
-                if len(getattr(data_container, linkage_type)) > idx:
-                    getattr(data_container, linkage_type)[
-                        idx
-                    ].alternative_spelling = value
+                if len(linkage_list) > idx:
+                    linkage_list[idx].alternative_spelling = value
 
 
 def process_linkage_list_children(
     wxr: WiktextractContext,
-    data_container: Union[WordEntry, Sense],
+    word_entry: WordEntry,
     nodes: WikiNodeChildrenList,
     linkage_type: str,
 ):
-    if linkage_type not in data_container.model_fields:
+    if linkage_type not in word_entry.model_fields:
         wxr.wtp.debug(
             f"Linkage type {linkage_type} not found in pydantic model",
             sortid="extractor/es/linkage/process_linkage_list_children/89",
@@ -82,6 +75,6 @@ def process_linkage_list_children(
         return
     for node in nodes:
         if isinstance(node, WikiNode) and node.kind == NodeKind.LINK:
-            word = clean_node(wxr, {}, node)
-            if word:
-                getattr(data_container, linkage_type).append(Linkage(word=word))
+            word = clean_node(wxr, None, node)
+            if len(word) > 0:
+                getattr(word_entry, linkage_type).append(Linkage(word=word))

--- a/src/wiktextract/extractor/es/models.py
+++ b/src/wiktextract/extractor/es/models.py
@@ -89,15 +89,6 @@ class Sense(BaseModelWrap):
     senseid: str = Field(
         default="", description="Sense number used in Wiktionary"
     )
-    antonyms: list[Linkage] = []
-    compounds: list[Linkage] = []
-    derived: list[Linkage] = []
-    hyponyms: list[Linkage] = []
-    hypernyms: list[Linkage] = []
-    idioms: list[Linkage] = []
-    meronyms: list[Linkage] = []
-    related: list[Linkage] = []
-    synonyms: list[Linkage] = []
 
 
 class Spelling(BaseModelWrap):

--- a/tests/test_de_linkages.py
+++ b/tests/test_de_linkages.py
@@ -26,66 +26,39 @@ class TestDELinkages(unittest.TestCase):
             # https://de.wiktionary.org/wiki/Beispiel
             # Extracts linkages and places them in the correct sense.
             {
-                "input": "==== Sinnverwandte Wörter ====\n:[1] [[Beleg]], [[Exempel]]\n:[2] [[Muster]], [[Vorbild]]",
-                "senses": [Sense(senseid="1"), Sense(senseid="2")],
+                "input": """==== Sinnverwandte Wörter ====
+:[1] [[Beleg]], [[Exempel]]
+:[2] [[Muster]], [[Vorbild]]""",
                 "expected": {
-                    "senses": [
-                        {
-                            "senseid": "1",
-                            "coordinate_terms": [
-                                {"word": "Beleg"},
-                                {"word": "Exempel"},
-                            ],
-                        },
-                        {
-                            "senseid": "2",
-                            "coordinate_terms": [
-                                {"word": "Muster"},
-                                {"word": "Vorbild"},
-                            ],
-                        },
-                    ]
+                    "coordinate_terms": [
+                        {"word": "Beleg", "sense_id": "1"},
+                        {"word": "Exempel", "sense_id": "1"},
+                        {"word": "Muster", "sense_id": "2"},
+                        {"word": "Vorbild", "sense_id": "2"},
+                    ],
                 },
             },
             # https://de.wiktionary.org/wiki/Beispiel
             # Cleans explanatory text from expressions.
             {
                 "input": "====Redewendungen====\n:[[ein gutes Beispiel geben|ein gutes ''Beispiel'' geben]] – als [[Vorbild]] zur [[Nachahmung]] [[dienen]]/[[herausfordern]]",
-                "senses": [Sense()],
                 "expected": {
-                    "senses": [
-                        {
-                            "expressions": [
-                                {"word": "ein gutes Beispiel geben"}
-                            ],
-                        }
-                    ]
+                    "expressions": [{"word": "ein gutes Beispiel geben"}],
                 },
             },
             # Always places relations in first sense if just one sense.
             {
                 "input": "====Synonyme====\n:[[Synonym1]]",
-                "senses": [Sense(senseid="1")],
-                "expected": {
-                    "senses": [
-                        {"senseid": "1", "synonyms": [{"word": "Synonym1"}]}
-                    ],
-                },
+                "expected": {"synonyms": [{"word": "Synonym1"}]},
             },
             # https://de.wiktionary.org/wiki/Kokospalme
             # Ignores modifiers of relations and all other text.
             {
                 "input": "====Synonyme====\n:[1] [[Kokosnusspalme]], ''wissenschaftlich:'' [[Cocos nucifera]]",
-                "senses": [Sense(senseid="1")],
                 "expected": {
-                    "senses": [
-                        {
-                            "senseid": "1",
-                            "synonyms": [
-                                {"word": "Kokosnusspalme"},
-                                {"word": "Cocos nucifera"},
-                            ],
-                        }
+                    "synonyms": [
+                        {"word": "Kokosnusspalme", "sense_id": "1"},
+                        {"word": "Cocos nucifera", "sense_id": "1"},
                     ],
                 },
             },
@@ -95,12 +68,8 @@ class TestDELinkages(unittest.TestCase):
             with self.subTest(case=case):
                 self.wxr.wtp.start_page("")
                 root = self.wxr.wtp.parse(case["input"])
-
                 word_entry = self.get_default_word_entry()
-                word_entry.senses = case["senses"]
-
                 extract_linkages(self.wxr, word_entry, root.children[0])
-
                 self.assertEqual(
                     word_entry.model_dump(
                         exclude_defaults=True,

--- a/tests/test_de_translation.py
+++ b/tests/test_de_translation.py
@@ -2,7 +2,7 @@ import unittest
 
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
-from wiktextract.extractor.de.models import Sense, Translation, WordEntry
+from wiktextract.extractor.de.models import Translation, WordEntry
 from wiktextract.extractor.de.translation import (
     extract_translation,
     process_translation_list,
@@ -29,33 +29,22 @@ class TestDETranslation(unittest.TestCase):
             # Adds sense data to correct sense
             {
                 "input": "{{Ü-Tabelle|1|G=Beispiel|Ü-Liste=*{{en}}: {{Ü|en|example}}}}",
-                "senses": [Sense(senseid="1")],
                 "expected": {
-                    "senses": [
+                    "translations": [
                         {
-                            "senseid": "1",
-                            "translations": [
-                                {
-                                    "sense": "Beispiel",
-                                    "lang_code": "en",
-                                    "lang": "Englisch",
-                                    "word": "example",
-                                }
-                            ],
+                            "sense": "Beispiel",
+                            "sense_id": "1",
+                            "lang_code": "en",
+                            "lang": "Englisch",
+                            "word": "example",
                         }
-                    ]
+                    ],
                 },
             },
             # Adds sense data to page_data root if no senseid is given
             {
                 "input": "{{Ü-Tabelle||G=Beispiel|Ü-Liste=*{{en}}: {{Ü|en|example}}}}",
-                "senses": [Sense(senseid="1")],
                 "expected": {
-                    "senses": [
-                        {
-                            "senseid": "1",
-                        }
-                    ],
                     "translations": [
                         {
                             "sense": "Beispiel",
@@ -69,16 +58,11 @@ class TestDETranslation(unittest.TestCase):
             # Adds sense data to page_data root if senseid could not be matched
             {
                 "input": "{{Ü-Tabelle|2|G=Beispiel|Ü-Liste=*{{en}}: {{Ü|en|example}}}}",
-                "senses": [Sense(senseid="1")],
                 "expected": {
-                    "senses": [
-                        {
-                            "senseid": "1",
-                        }
-                    ],
                     "translations": [
                         {
                             "sense": "Beispiel",
+                            "sense_id": "2",
                             "lang_code": "en",
                             "lang": "Englisch",
                             "word": "example",
@@ -92,12 +76,8 @@ class TestDETranslation(unittest.TestCase):
             with self.subTest(case=case):
                 self.wxr.wtp.start_page("")
                 root = self.wxr.wtp.parse(case["input"])
-
                 word_entry = self.get_default_word_entry()
-                word_entry.senses = case.get("senses", [])
-
                 extract_translation(self.wxr, word_entry, root)
-
                 self.assertEqual(
                     word_entry.model_dump(
                         exclude_defaults=True,


### PR DESCRIPTION
Sense ids in Wiktionary pages could be outdated or wrong, we shouldn't move the data extracted from other sections under the `Sense` field.

Fixes #478