### PR TITLE
Fix `AssertionError` in zh edition page "Thesaurus:diatribe"

### DIFF
--- a/src/wiktextract/extractor/zh/section_titles.py
+++ b/src/wiktextract/extractor/zh/section_titles.py
@@ -195,6 +195,7 @@ LINKAGE_TITLES: dict[str, str] = {
     "上位語": "hypernyms",
     "上位词": "hypernyms",
     "上義詞": "hypernyms",
+    "上义词": "hypernyms",
     "下义词": "hyponyms",
     "下位詞": "hyponyms",
     "下位語": "hyponyms",

--- a/src/wiktextract/page.py
+++ b/src/wiktextract/page.py
@@ -192,7 +192,8 @@ def inject_linkages(wxr: WiktextractContext, page_data: list[dict]) -> None:
                     dt["roman"] = term.roman
                 if term.language_variant is not None:
                     dt["language_variant"] = term.language_variant
-                data_append(data, term.linkage, dt)
+                if term.linkage is not None:
+                    data_append(data, term.linkage, dt)
 
 
 STARTS_LANG_RE = None


### PR DESCRIPTION
This error is caused by the wrong title wikitext, the linkage title should use the level 5 title, but a level 4 title(this is sense title) is used. Only one page has this error.