### PR TITLE
Fix 'str' object has no attribute 'extend' in de edition page "BU"

### DIFF
--- a/src/wiktextract/extractor/de/page.py
+++ b/src/wiktextract/extractor/de/page.py
@@ -224,7 +224,7 @@ def process_pos_section(
         elif (
             isinstance(non_l4_node, WikiNode)
             and non_l4_node.kind == NodeKind.TABLE
-            and "inflection-table" in non_l4_node.attrs.get("class")
+            and "inflection-table" in non_l4_node.attrs.get("class", "")
         ):
             # XXX: de: Extract html form table
             pass

--- a/src/wiktextract/extractor/de/pronunciation.py
+++ b/src/wiktextract/extractor/de/pronunciation.py
@@ -97,7 +97,7 @@ def process_lautschrift_template(
 ) -> None:
     template_parameters = node.template_parameters
 
-    ipa = template_parameters.get(1)
+    ipa = template_parameters.get(1, "")
 
     lang_code = template_parameters.get("spr")
     if lang_code:

--- a/tests/test_de_pronunciation.py
+++ b/tests/test_de_pronunciation.py
@@ -6,6 +6,7 @@ from wiktextract.extractor.de.models import Sound
 from wiktextract.extractor.de.pronunciation import (
     process_hoerbeispiele,
     process_ipa,
+    process_lautschrift_template,
 )
 from wiktextract.wxr_context import WiktextractContext
 
@@ -178,3 +179,10 @@ class TestDEPronunciation(unittest.TestCase):
                 self.assertIn(key, exp)
                 if exp[key] is not None:
                     self.assertEqual(data[key], exp[key])
+
+    def test_empty_ipa_in_lautschrift(self):
+        self.wxr.wtp.start_page("BU")
+        root = self.wxr.wtp.parse("{{Lautschrift}}")
+        sound_data = [Sound()]
+        process_lautschrift_template(self.wxr, sound_data, root.children[0])
+        self.assertEqual(sound_data[0].model_dump(exclude_defaults=True), {})


### PR DESCRIPTION
Some pages doesn't pass the IPA data to template "Lautschrift" and the `None` was added to the `ipa` field.