### PR TITLE
Add `raw_tags` fields to zh edition pydantic models

### DIFF
--- a/src/wiktextract/extractor/zh/descendant.py
+++ b/src/wiktextract/extractor/zh/descendant.py
@@ -67,7 +67,7 @@ def extract_descendant_list_item(
                                 descendant_data.ruby = ruby_data
                         descendant_data.word = clean_node(wxr, None, child_node)
                     if "qualifier-content" in class_names:
-                        descendant_data.tags.append(
+                        descendant_data.raw_tags.append(
                             clean_node(wxr, None, child_node)
                         )
                 elif child_node.tag == "i":

--- a/src/wiktextract/extractor/zh/gloss.py
+++ b/src/wiktextract/extractor/zh/gloss.py
@@ -85,6 +85,6 @@ def extract_gloss_and_tags(raw_gloss: str) -> Sense:
                 tags += re.split(split_tag_regex, rear_label)
 
         gloss = raw_gloss[front_tag_end + 1 : rear_tag_start].strip()
-        return Sense(glosses=[gloss], raw_glosses=[raw_gloss], tags=tags)
+        return Sense(glosses=[gloss], raw_glosses=[raw_gloss], raw_tags=tags)
     else:
         return Sense(glosses=[raw_gloss])

--- a/src/wiktextract/extractor/zh/inflection.py
+++ b/src/wiktextract/extractor/zh/inflection.py
@@ -46,14 +46,14 @@ def extract_ja_i_template(
                     table_header = clean_node(wxr, None, child.children)
                 else:
                     inflection_data = Form(
-                        tags=[table_header], source="inflection"
+                        raw_tags=[table_header], source="inflection"
                     )
                     cell_node_index = 0
                     keys = ["form", "hiragana", "roman"]
                     for row_child in child.children:
                         if isinstance(row_child, WikiNode):
                             if row_child.kind == NodeKind.TABLE_HEADER_CELL:
-                                inflection_data.tags.append(
+                                inflection_data.raw_tags.append(
                                     clean_node(wxr, None, row_child)
                                 )
                             elif row_child.kind == NodeKind.TABLE_CELL:

--- a/src/wiktextract/extractor/zh/linkage.py
+++ b/src/wiktextract/extractor/zh/linkage.py
@@ -51,7 +51,7 @@ def extract_linkages(
                                 return sense
                         elif template_name in {"qualifier", "qual"}:
                             not_term_indexes.add(index)
-                            linkage_data.tags.append(
+                            linkage_data.raw_tags.append(
                                 clean_node(wxr, None, item_child).strip("()")
                             )
                         elif template_name.lower() in DESCENDANT_TEMPLATES:
@@ -165,7 +165,7 @@ def extract_saurus_template(
         if thesaurus.roman is not None:
             linkage_data.roman = thesaurus.roman
         if thesaurus.tags is not None:
-            linkage_data.tags = thesaurus.tags.split("|")
+            linkage_data.raw_tags = thesaurus.tags.split("|")
         if thesaurus.language_variant is not None:
             linkage_data.language_variant = thesaurus.language_variant
         if len(sense) > 0:
@@ -192,7 +192,7 @@ def extract_zh_dial_template(
         if len(sense) > 0:
             linkage_data.sense = sense
         if len(tags) > 0:
-            linkage_data.tags = tags
+            linkage_data.raw_tags = tags
         pre_data = getattr(page_data[-1], linkage_type)
         pre_data.append(linkage_data)
 

--- a/src/wiktextract/extractor/zh/models.py
+++ b/src/wiktextract/extractor/zh/models.py
@@ -33,6 +33,7 @@ class Sense(ChineseBaseModel):
     glosses: list[str] = []
     raw_glosses: list[str] = Field([], description="Gloss text without tags")
     tags: list[str] = []
+    raw_tags: list[str] = []
     categories: list[str] = []
     examples: list[Example] = []
     ruby: list[list[str]] = Field([], description="Japanese Kanji and furigana")
@@ -41,6 +42,7 @@ class Sense(ChineseBaseModel):
 class Form(ChineseBaseModel):
     form: str = ""
     tags: list[str] = []
+    raw_tags: list[str] = []
     source: str = ""
     ruby: list[list[str]] = Field([], description="Japanese Kanji and furigana")
     hiragana: str = ""
@@ -57,6 +59,7 @@ class Sound(ChineseBaseModel):
     mp3_url: str = ""
     opus_url: str = ""
     tags: list[str] = []
+    raw_tags: list[str] = []
     homophone: str = ""
 
 
@@ -68,6 +71,7 @@ class Translation(ChineseBaseModel):
     word: str = Field(description="Translation term")
     sense: str = Field("", description="Translation gloss")
     tags: list[str] = []
+    raw_tags: list[str] = []
     roman: str = Field("", description="Roman script")
     alt: str = Field("", description="Alternative form")
     lit: str = Field("", description="Literal translation for the term")
@@ -76,6 +80,7 @@ class Translation(ChineseBaseModel):
 class Linkage(ChineseBaseModel):
     word: str = ""
     tags: list[str] = []
+    raw_tags: list[str] = []
     roman: str = ""
     sense: str = ""
     language_variant: Literal["", "zh-Hant", "zh-Hans"] = Field(
@@ -90,6 +95,7 @@ class Descendant(ChineseBaseModel):
     word: str = ""
     roman: str = ""
     tags: list[str] = []
+    raw_tags: list[str] = []
     descendants: list["Descendant"] = []
     ruby: list[list[str]] = Field([], description="Japanese Kanji and furigana")
 
@@ -126,6 +132,7 @@ class WordEntry(ChineseBaseModel):
     categories: list[str] = []
     notes: list[str] = []
     tags: list[str] = []
+    raw_tags: list[str] = []
     descendants: list[Descendant] = []
     redirects: list[str] = Field(
         [],

--- a/src/wiktextract/extractor/zh/pronunciation.py
+++ b/src/wiktextract/extractor/zh/pronunciation.py
@@ -44,7 +44,7 @@ def extract_pronunciation_recursively(
             last_sounds_list = page_data[-1].sounds
             for index in range(len(last_sounds_list)):
                 if last_sounds_list[index].audio == "" and (
-                    tags == last_sounds_list[index].tags[:-1]
+                    tags == last_sounds_list[index].raw_tags[:-1]
                     or lang_code != "zh"
                 ):
                     for key, value in create_audio_url_dict(data).items():
@@ -69,7 +69,7 @@ def extract_pronunciation_recursively(
                 base_data,
                 lang_code,
                 rest_children,
-                data.tags[:-1],
+                data.raw_tags[:-1],
             )
         elif isinstance(data, list):
             # list item is a tag
@@ -146,7 +146,7 @@ def extract_pronunciation_item(
             tags, split_pronunciation_tags(sound_tags_text)
         )
         if len(ipa) > 0:
-            data = Sound(tags=new_tags)
+            data = Sound(raw_tags=new_tags)
             ipa_key = "zh_pron" if lang_code == "zh" else "ipa"
             setattr(data, ipa_key, ipa[0].strip())
             return data
@@ -176,7 +176,7 @@ def process_homophone_data(
                 "span", attr_name="lang"
             ):
                 sound_data = Sound(
-                    homophone=clean_node(wxr, None, span_node), tags=tags
+                    homophone=clean_node(wxr, None, span_node), raw_tags=tags
                 )
                 page_data[-1].sounds.append(sound_data)
         elif (
@@ -190,6 +190,6 @@ def process_homophone_data(
                 "span", attr_name="lang"
             ):
                 sound_data = Sound(
-                    homophone=clean_node(wxr, None, span_node), tags=tags
+                    homophone=clean_node(wxr, None, span_node), raw_tags=tags
                 )
                 page_data[-1].sounds.append(sound_data)

--- a/src/wiktextract/extractor/zh/section_titles.py
+++ b/src/wiktextract/extractor/zh/section_titles.py
@@ -195,7 +195,6 @@ LINKAGE_TITLES: dict[str, str] = {
     "上位語": "hypernyms",
     "上位词": "hypernyms",
     "上義詞": "hypernyms",
-    "上义词": "hypernyms",
     "下义词": "hyponyms",
     "下位詞": "hyponyms",
     "下位語": "hyponyms",

--- a/src/wiktextract/extractor/zh/thesaurus.py
+++ b/src/wiktextract/extractor/zh/thesaurus.py
@@ -29,11 +29,11 @@ def parse_ja_thesaurus_term(
     linkage: Optional[str],
     term_str: str,
 ) -> list[ThesaurusTerm]:
-    tags = None
+    # tags = None
     roman = None
     if term_str.startswith("("):  # has qualifier
         qual_bracket_idx = term_str.find(")")
-        tags = "|".join(term_str[1:qual_bracket_idx].split(", "))
+        # tags = "|".join(term_str[1:qual_bracket_idx].split(", "))
         term_str = term_str[qual_bracket_idx + 2 :]
 
     thesaurus = []
@@ -54,7 +54,7 @@ def parse_ja_thesaurus_term(
                 pos=pos,
                 linkage=linkage,
                 term=term,
-                tags=tags,
+                # tags=tags,
                 roman=roman,
                 sense=sense,
             )
@@ -93,7 +93,7 @@ def parse_zh_thesaurus_term(
             pos=pos,
             linkage=linkage,
             term=variant_term,
-            tags="|".join(tags) if len(tags) > 0 else None,
+            # tags="|".join(tags) if len(tags) > 0 else None,
             roman=roman,
             sense=sense,
             language_variant=variant_type,

--- a/src/wiktextract/extractor/zh/translation.py
+++ b/src/wiktextract/extractor/zh/translation.py
@@ -110,7 +110,7 @@ def process_translation_list_item(
                     if "gender" in class_str:
                         for abbr_tag in span_node.find_html("abbr"):
                             if len(abbr_tag.attrs.get("title")) > 0:
-                                tr_data.tags.append(
+                                tr_data.raw_tags.append(
                                     clean_node(
                                         wxr, None, abbr_tag.attrs.get("title")
                                     )
@@ -129,12 +129,12 @@ def process_translation_list_item(
                 for span_node in expanded_template.find_html("span"):
                     tag = span_node.attrs.get("title", "")
                     if len(tag) > 0:
-                        tr_data.tags.append(tag.strip())
+                        tr_data.raw_tags.append(tag.strip())
                         find_title = True
                 if not find_title:
                     tag = clean_node(wxr, None, child)
                     if len(tag) > 0:
-                        tr_data.tags.append(tag.strip("()"))
+                        tr_data.raw_tags.append(tag.strip("()"))
         elif isinstance(child, WikiNode) and child.kind == NodeKind.LINK:
             if len(tr_data.word) > 0:
                 page_data[-1].translations.append(tr_data.model_copy(deep=True))

--- a/tests/test_zh_descendant.py
+++ b/tests/test_zh_descendant.py
@@ -62,7 +62,7 @@ class TestDescendant(TestCase):
             {
                 "lang_code": "za",
                 "lang": "壯語",
-                "tags": ["仿譯"],
+                "raw_tags": ["仿譯"],
                 "word": "mwngz ndei",
             },
         )

--- a/tests/test_zh_gloss.py
+++ b/tests/test_zh_gloss.py
@@ -57,22 +57,22 @@ class TestGloss(TestCase):
                 {
                     "glosses": ["有趣的：", "有趣的"],
                     "raw_glosses": ["(棄用) 有趣的："],
-                    "tags": ["棄用"],
+                    "raw_tags": ["棄用"],
                 },
                 {
                     "glosses": ["有趣的：", "美味的"],
                     "raw_glosses": ["(棄用) 有趣的："],
-                    "tags": ["棄用"],
+                    "raw_tags": ["棄用"],
                 },
                 {
                     "glosses": ["有趣的：", "漂亮的"],
                     "raw_glosses": ["(棄用) 有趣的："],
-                    "tags": ["棄用"],
+                    "raw_tags": ["棄用"],
                 },
                 {
                     "glosses": ["有趣的：", "很好的，卓越的"],
                     "raw_glosses": ["(棄用) 有趣的："],
-                    "tags": ["棄用"],
+                    "raw_tags": ["棄用"],
                 },
             ],
         )

--- a/tests/test_zh_headword.py
+++ b/tests/test_zh_headword.py
@@ -40,10 +40,10 @@ class TestHeadword(TestCase):
                     "lang_code": "en",
                     "lang": "英語",
                     "forms": [
-                        {"form": "manga", "tags": ["複數"]},
-                        {"form": "mangas", "tags": ["複數"]},
+                        {"form": "manga", "raw_tags": ["複數"]},
+                        {"form": "mangas", "raw_tags": ["複數"]},
                     ],
-                    "tags": ["可數", "不可數"],
+                    "raw_tags": ["可數", "不可數"],
                 }
             ],
         )
@@ -70,8 +70,14 @@ class TestHeadword(TestCase):
                     "lang_code": "en",
                     "lang": "英語",
                     "forms": [
-                        {"form": "manga's", "tags": ["複數"]},
-                        {"form": "mangaatje", "tags": ["指小詞", "neuter"]},
+                        {"form": "manga's", "raw_tags": ["複數"]},
+                        {
+                            "form": "mangaatje",
+                            "raw_tags": [
+                                "指小詞",
+                            ],
+                            "tags": ["neuter"],
+                        },
                     ],
                     "tags": ["masculine"],
                 }

--- a/tests/test_zh_inflection.py
+++ b/tests/test_zh_inflection.py
@@ -52,7 +52,7 @@ class TestInflection(TestCase):
                     "hiragana": "おかしかろ",
                     "roman": "okashikaro",
                     "source": "inflection",
-                    "tags": ["基本形", "未然形"],
+                    "raw_tags": ["基本形", "未然形"],
                 },
             ],
         )

--- a/tests/test_zh_pronunciation.py
+++ b/tests/test_zh_pronunciation.py
@@ -33,8 +33,8 @@ class TestPronunciation(TestCase):
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[0].sounds],
             [
-                {"homophone": "大姑", "tags": ["同音詞"]},
-                {"homophone": "小姑", "tags": ["同音詞"]},
+                {"homophone": "大姑", "raw_tags": ["同音詞"]},
+                {"homophone": "小姑", "raw_tags": ["同音詞"]},
             ],
         )
 
@@ -54,8 +54,8 @@ class TestPronunciation(TestCase):
         self.assertEqual(
             [d.model_dump(exclude_defaults=True) for d in page_data[0].sounds],
             [
-                {"homophone": "大矢", "tags": ["同音詞"]},
-                {"homophone": "大宅", "tags": ["同音詞"]},
-                {"homophone": "大谷", "tags": ["同音詞"]},
+                {"homophone": "大矢", "raw_tags": ["同音詞"]},
+                {"homophone": "大宅", "raw_tags": ["同音詞"]},
+                {"homophone": "大谷", "raw_tags": ["同音詞"]},
             ],
         )

--- a/tests/test_zh_translation.py
+++ b/tests/test_zh_translation.py
@@ -57,14 +57,14 @@ class TestZhTranslation(TestCase):
                     "sense": "太陽上層大氣射出的超高速電漿流",
                     "word": "רוח סולרית",
                     "roman": "ruakh solarit",
-                    "tags": ["陰性名詞"],
+                    "raw_tags": ["陰性名詞"],
                 },
                 {
                     "lang_code": "sh",
                     "lang": "西里尔字母",
                     "sense": "太陽上層大氣射出的超高速電漿流",
                     "word": "сунчев ветар",
-                    "tags": ["Ekavian", "陽性名詞"],
+                    "raw_tags": ["Ekavian", "陽性名詞"],
                 },
             ],
         )
@@ -211,7 +211,7 @@ class TestZhTranslation(TestCase):
                     "lang_code": "cs",
                     "lang": "捷克语",
                     "word": "patližán",
-                    "tags": ["陽性名詞", "口语词汇"],
+                    "raw_tags": ["陽性名詞", "口语词汇"],
                 },
             ],
         )


### PR DESCRIPTION
Only tags used in en edition are added to the `tags` field.