### PR TITLE
Fix the wrong tag in fr edition page "5-0"

### DIFF
--- a/src/wiktextract/extractor/fr/form_line.py
+++ b/src/wiktextract/extractor/fr/form_line.py
@@ -47,13 +47,23 @@ def extract_form_line(
                 process_conj_template(wxr, node, page_data)
             else:
                 raw_tag = clean_node(wxr, page_data[-1], node)
+                expanded_template = wxr.wtp.parse(
+                    wxr.wtp.node_to_wikitext(node), expand_all=True
+                )
                 if (
-                    raw_tag.startswith("(")
-                    and raw_tag.endswith(")")
+                    len(
+                        list(
+                            expanded_template.find_html(
+                                "span", attr_name="id", attr_value="région"
+                            )
+                        )
+                    )
+                    == 1
                     and pre_template_name in PRON_TEMPLATES
                     and len(page_data[-1].sounds) > 0
                 ):
                     # it's the location of the previous IPA template
+                    # https://fr.wiktionary.org/wiki/Modèle:région
                     page_data[-1].sounds[-1].raw_tags.append(
                         raw_tag.strip("()")
                     )

--- a/src/wiktextract/extractor/fr/topics.py
+++ b/src/wiktextract/extractor/fr/topics.py
@@ -35,4 +35,5 @@ TOPIC_TAGS: dict[str, str] = {
     "grammaire": "linguistics",
     "journalisme": "journalism",
     "commerce": "commerce",
+    "habillement": "textiles fashion",
 }

--- a/tests/test_fr_form_line.py
+++ b/tests/test_fr_form_line.py
@@ -59,8 +59,12 @@ class TestFormLine(TestCase):
         # https://fr.wiktionary.org/wiki/basket-ball
         self.wxr.wtp.start_page("basket-ball")
         self.wxr.wtp.add_page("Modèle:pron", 10, body="{{{1}}}")
-        self.wxr.wtp.add_page("Modèle:FR", 10, body="(France)")
-        self.wxr.wtp.add_page("Modèle:CA", 10, body="(Canada)")
+        self.wxr.wtp.add_page(
+            "Modèle:FR", 10, body="""<span id="région">''(France)''</span>"""
+        )
+        self.wxr.wtp.add_page(
+            "Modèle:CA", 10, body="""<span id="région">''(Canada)''</span>"""
+        )
         self.wxr.wtp.add_page("Modèle:m", 10, body="masculin")
         root = self.wxr.wtp.parse(
             "{{pron|bas.kɛt.bol|fr}} {{FR|nocat=1}} ''ou'' {{pron|bas.kɛt.bɔl|fr}} {{FR|nocat=1}} ''ou'' {{pron|bas.kɛt.bɑl|fr}} {{CA|nocat=1}} {{m}}"
@@ -148,3 +152,16 @@ class TestFormLine(TestCase):
         root = self.wxr.wtp.parse("'''飢える''' ''ichidan''")
         extract_form_line(self.wxr, page_data, root.children)
         self.assertEqual(page_data[-1].raw_tags, ["ichidan"])
+
+    def test_not_region_tag_after_ipa(self):
+        self.wxr.wtp.start_page("5-0")
+        self.wxr.wtp.add_page("Modèle:pron", 10, body="{{{1}}}")
+        self.wxr.wtp.add_page(
+            "Modèle:indénombrable", 10, body="(Indénombrable)"
+        )
+        page_data = [WordEntry(word="5-0", lang_code="en", lang="Anglais")]
+        root = self.wxr.wtp.parse(
+            "'''5-0''' {{pron|ˈfaɪvˌoʊ|en}} {{indénombrable|en}}"
+        )
+        extract_form_line(self.wxr, page_data, root.children)
+        self.assertEqual(page_data[-1].tags, ["uncountable"])


### PR DESCRIPTION
The tag from "indénombrable" template shouldn't be added to the sound data, only region data templates should be added.