### PR TITLE
Inline images should print alt= text

### DIFF
--- a/src/wiktextract/form_descriptions.py
+++ b/src/wiktextract/form_descriptions.py
@@ -1029,32 +1029,6 @@ def decode_tags(
 
     return tagsets, topics
 
-    # Kludge to a wide-spread problem with Latin, where a lot of
-    # "indicative/imperative" style combinations aren't in
-    # xlat_tags_map. Instead of adding every possible combination
-    # manually, we look if there are any slashes in the string,
-    # then check for valid stuff in xlat_tags_map (like
-    # "first/third-person"), and if not, split on "/"
-    # and append on the string; will definitely give errors,
-    # but less of them.
-    # new_parts = []
-    # for part in parts:
-    #     new_seg = ""
-    #     if "/" in part:
-    #         for w in part.split():
-    #             if w in xlat_tags_map:
-    #                 new_seg += w + " "
-    #             elif "/" in w:
-    #                 for ww in w.split("/"):
-    #                     new_seg += ww + " "
-    #             else:
-    #                 new_seg += w + " "
-    #     else:
-    #         new_parts.append(part)
-    #         continue
-    #     new_parts.append(new_seg.strip())
-    # parts = new_parts
-
 
 def decode_tags1(
     src: str,
@@ -2437,9 +2411,6 @@ def parse_word_head(
                     related = alt_related
                     tagsets = alt_tagsets
 
-                    
-
-
             # print("FORM END: tagsets={} related={}".format(tagsets, related))
             if not tagsets:
                 continue
@@ -2539,7 +2510,6 @@ def parse_word_head(
                         data_extend(data, "tags", tags)
                     prev_tags = tagsets
                     following_tags = None
-
 
     # Finally, if we collected hirakana/katakana, add them now
     if hiragana:

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -103,8 +103,10 @@ class WiktExtractTests(unittest.TestCase):
         # This test was created when encountering issues with French
         # Wikipedia "Fichier" prefixes that replace Image:. The
         # parsing of links with multiple parameters was broken
-        v = ("[[Unknownprefix:Ikhwan.jpg|vignette|gauche|Troupes"
-        " des [[Ikhwan (Arabie saoudite)|Ikhwâns]].]]")
+        v = (
+            "[[Unknownprefix:Ikhwan.jpg|vignette|gauche|Troupes"
+            " des [[Ikhwan (Arabie saoudite)|Ikhwâns]].]]"
+        )
         v = clean_value(self.wxr, v)
         self.assertEqual(v, "Troupes des Ikhwâns.")
 
@@ -117,6 +119,15 @@ class WiktExtractTests(unittest.TestCase):
         v = "[[Foo:bar.JPG|conf bar|baz|baz2|baz3|baz4|Alt Text]]"
         v = clean_value(self.wxr, v)
         self.assertEqual(v, "Alt Text")
+
+    def test_cv_link12(self):
+        # if a File, Image or Wtp.file_alias link (an image)
+        # does not have anything from a set of parameters (left, right,
+        # thumb etc.) that would not make it inline, it is an inline
+        # image and its alt= text should be printer with [Alt: ...]
+        v = "[[File:bar.JPG|conf bar|baz|baz2|baz3|baz4|alt=Bar]]"
+        v = clean_value(self.wxr, v)
+        self.assertEqual(v, "[Alt: Bar]")
 
     def test_cv_url1(self):
         v = "This is a [http://ylonen.org test]."
@@ -299,9 +310,9 @@ class WiktExtractTests(unittest.TestCase):
         self.assertEqual(
             clean_value(
                 self.wxr,
-                'some text<ref name="OED"/> some other text<ref>ref text</ref>'
+                'some text<ref name="OED"/> some other text<ref>ref text</ref>',
             ),
-            "some text some other text"
+            "some text some other text",
         )
 
     def test_bold_node_in_link(self):
@@ -329,7 +340,7 @@ class WiktExtractTests(unittest.TestCase):
             end
 
             return export
-            """
+            """,
         )
         self.wxr.wtp.start_page("")
         tree = self.wxr.wtp.parse(wikitext)


### PR DESCRIPTION
If an image is inline (it doesn't have any of a set of arguments that, like 'right' or 'thumb' etc.), then its `alt=` text should be printed when returned from clean_value.

To make it clearer that this is an `alt` text, and to make post-processing easier, we add `[Alt: ` + `]` around the text.