### PR TITLE
Urlstarts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ github_pages:
 clean:
 	python -m coverage erase
 	rm -rf __pycache__ _site
+rcheck:
+	python -m ruff check --diff src/wiktextract
+	python -m ruff check --diff tests

--- a/src/wiktextract/clean.py
+++ b/src/wiktextract/clean.py
@@ -1337,6 +1337,7 @@ url_starts_re = re.compile(
     r"({})".format(r"|".join(URL_STARTS)), flags=re.IGNORECASE
 )
 
+
 def clean_value(
     wxr: WiktextractContext, title: str, no_strip=False, no_html_strip=False
 ) -> str:

--- a/src/wiktextract/clean.py
+++ b/src/wiktextract/clean.py
@@ -9,7 +9,7 @@
 import re
 import html
 import unicodedata
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 from wikitextprocessor.common import MAGIC_FIRST, MAGIC_LAST
 from wikitextprocessor.core import (
     NamespaceDataEntry,
@@ -1330,10 +1330,10 @@ def remove_italic_and_bold(text: str) -> str:
 
 # regex to find File/Image link attributes that would mean an image
 # is *not* inline
-inline_re = re.compile(r"\|\s*(right|left|center|thumb|frame)\s*\|")
+INLINE_RE = re.compile(r"\|\s*(right|left|center|thumb|frame)\s*\|")
 
 
-url_starts_re = re.compile(
+URL_STARTS_RE = re.compile(
     r"({})".format(r"|".join(URL_STARTS)), flags=re.IGNORECASE
 )
 
@@ -1355,7 +1355,7 @@ def clean_value(
         args = re.split(r"\s+", m.group(1))
         i = 0
         while i < len(args) - 1:
-            if not url_starts_re.match(args[i]):
+            if not URL_STARTS_RE.match(args[i]):
                 break
             i += 1
         return " ".join(args[i:])
@@ -1370,7 +1370,7 @@ def clean_value(
         lnk = m.group(1)
         if wxr.wtp.file_aliases_re.match(lnk):
             # Handle File / Image / Fichier 'links' here.
-            if not inline_re.match(m.group(0)) and "alt" in m.group(0):
+            if not INLINE_RE.match(m.group(0)) and "alt" in m.group(0):
                 # This image should be inline, so let's print its alt text
                 alt_m = re.search(r"\|\s*alt\s*=([^]|]+)(\||\]\])", m.group(0))
                 if alt_m is not None:

--- a/src/wiktextract/clean.py
+++ b/src/wiktextract/clean.py
@@ -15,6 +15,7 @@ from wikitextprocessor.core import (
     NamespaceDataEntry,
     TemplateArgs,
 )
+from wikitextprocessor.common import URL_STARTS
 from .wxr_context import WiktextractContext
 
 ######################################################################
@@ -1332,6 +1333,10 @@ def remove_italic_and_bold(text: str) -> str:
 inline_re = re.compile(r"\|\s*(right|left|center|thumb|frame)\s*\|")
 
 
+url_starts_re = re.compile(
+    r"({})".format(r"|".join(URL_STARTS)), flags=re.IGNORECASE
+)
+
 def clean_value(
     wxr: WiktextractContext, title: str, no_strip=False, no_html_strip=False
 ) -> str:
@@ -1349,7 +1354,7 @@ def clean_value(
         args = re.split(r"\s+", m.group(1))
         i = 0
         while i < len(args) - 1:
-            if not re.match(r"(https?|mailto)://", args[i]):
+            if not url_starts_re.match(args[i]):
                 break
             i += 1
         return " ".join(args[i:])

--- a/src/wiktextract/extractor/fr/inflection.py
+++ b/src/wiktextract/extractor/fr/inflection.py
@@ -248,10 +248,10 @@ def split_ipa(text: str) -> list[str]:
         return text.split(" ou ")
     if text.startswith("ou "):
         return [text.removeprefix("ou ")]
-    if text.endswith(" Prononciation ?\\"):
+    if text.endswith("Prononciation ?\\"):
         # inflection table templates use a edit link when the ipa data is
-        # missing, and the link usually ends with " Prononciation ?"
-        return ""
+        # missing, and the link usually ends with "Prononciation ?"
+        return []
     return [text]
 
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -348,3 +348,10 @@ class WiktExtractTests(unittest.TestCase):
         self.assertEqual(
             clean_node(self.wxr, None, tree.children), "2ちゃんねる, italic"
         )
+
+    def test_protocol_relative_url(self):
+        # https://en.wikipedia.org/wiki/Wikipedia:Protocol-relative_URL
+        self.assertEqual(
+            clean_value(self.wxr, "[//obsolete_url shouldn't be used]"),
+            "shouldn't be used",
+        )


### PR DESCRIPTION
Some urls with `//` were passing through from modules etc. In Wikitext, the `//` is handled by replacing it with the current applicable URL prefix (typically `https://`) based on the page's url, but it's not really sensible for us so let's accept `//` as a prefix.

Some changes to either French inflection tests or to French inflection code was needed, if you could take a look @xxyzz