### PR TITLE
Remove category languages regex pattern

### DIFF
--- a/tests/test_en_category.py
+++ b/tests/test_en_category.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+
+from wikitextprocessor import Wtp
+from wiktextract.config import WiktionaryConfig
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestEnCategory(TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="en"), WiktionaryConfig(dump_file_lang_code="en")
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def test_filter_language_categories(self):
+        # GH issue #537
+        from wiktextract.page import process_categories
+
+        page_data = [
+            {
+                "categories": [
+                    "Rhymes:Afrikaans/als",
+                    "English phrasal verbs",
+                    "A'ou language",
+                ],
+                "lang_code": "en",
+                "lang": "English",
+            }
+        ]
+        process_categories(self.wxr, page_data)
+        self.assertEqual(page_data[0]["categories"], ["English phrasal verbs"])


### PR DESCRIPTION
This huge regex pattern can't handle languages that have the same prefix("E" and "English"), split the category link by space and slash should serve the original code's purpose.

Fix #537