### PR TITLE
Fix index out of range exceptions in de edition

### DIFF
--- a/src/wiktextract/extractor/de/pronunciation.py
+++ b/src/wiktextract/extractor/de/pronunciation.py
@@ -140,8 +140,8 @@ def process_hoerbeispiele(
 def process_audio_template(
     wxr: WiktextractContext, sound_data: list[Sound], node: WikiNode
 ):
-    audio_file = node.template_parameters.get(1)
-    if audio_file:
+    audio_file = node.template_parameters.get(1, "").strip()
+    if len(audio_file) > 0:
         add_sound_data_without_appending_to_existing_properties(
             wxr, sound_data, create_audio_url_dict(audio_file)
         )

--- a/src/wiktextract/extractor/share.py
+++ b/src/wiktextract/extractor/share.py
@@ -57,6 +57,8 @@ def create_audio_url_dict(filename: str) -> dict[str, str]:
     filename = filename.strip(" \u200e")
     file_url_key = filename[filename.rfind(".") + 1 :].lower() + "_url"
     filename_without_prefix = filename.removeprefix("File:")
+    if len(filename_without_prefix) == 0:
+        return {}
     audio_dict = {
         "audio": filename_without_prefix,
         file_url_key: "https://commons.wikimedia.org/wiki/Special:FilePath/"


### PR DESCRIPTION
Pages like "Casinospiel" put empty string parameter to "Audio" template.