### PR TITLE
Preliminary work on enabling not splitting links

### DIFF
--- a/src/wiktextract/datautils.py
+++ b/src/wiktextract/datautils.py
@@ -69,7 +69,11 @@ def split_at_comma_semi(
     parenthesis.  ``separators`` is default separators (setting it eliminates
     default separators).  ``extra`` is extra separators to be used in addition
     to ``separators``.  The separators in ``separators`` and ``extra`` must
-    be valid regexp pieces (already escaped if needed)."""
+    be valid regexp pieces (already escaped if needed). ``skipped`` can be a
+    list of strings, containing material that might be otherwise split, but
+    should not; for example phrases like 'Hunde, die bellen, beißen nicht',
+    which would otherwise be split on the commas. Often link text data, becase
+    those are prototypically one unit."""
     assert isinstance(text, str)
     assert isinstance(separators, (list, tuple))
     assert isinstance(extra, (list, tuple))
@@ -86,9 +90,7 @@ def split_at_comma_semi(
     splitters.append(r"[][()]")
     splitters.extend(sorted(separators, key=lambda x: -len(x)))
     split_re = "|".join(splitters)
-    print(f"{split_re=}")
     for m in re.finditer(split_re, text):
-        print(f"{m=}")
         if ofs < m.start():
             parts.append(text[ofs : m.start()])
         if m.start() == 0 and m.end() == len(text):

--- a/tests/test_linkages.py
+++ b/tests/test_linkages.py
@@ -36,6 +36,7 @@ class LinkageTests(unittest.TestCase):
         senses=[],
         is_reconstruction=False,
         check_errors=True,
+        links=None,
     ):
         """Runs a test where we expect the parsing to return None.  This
         function returns ``data``."""
@@ -60,6 +61,7 @@ class LinkageTests(unittest.TestCase):
             ruby,
             senses,
             is_reconstruction,
+            links=links or (),
         )
         self.assertIs(ret, None)
         if check_errors:
@@ -1700,6 +1702,50 @@ class LinkageTests(unittest.TestCase):
                     {"tags": ["Latin", "letter"], "word": "y"},
                     {"tags": ["Latin", "letter"], "word": "Z"},
                     {"tags": ["Latin", "letter"], "word": "z"},
+                ]
+            },
+        )
+
+    def test_links1(self):
+        data = self.run_data(
+            "Hunde, die bellen, beißen nicht",
+            links=["Hunde, die bellen, beißen nicht"],
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "Hunde, die bellen, beißen nicht"},
+                ]
+            },
+        )
+
+    def test_links2(self):
+        data = self.run_data(
+            "Hunde, die bellen, beißen nicht",
+            links=["Hunde, die bellen"],
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "Hunde, die bellen"},
+                    {"word": "beißen nicht"},
+                ]
+            },
+        )
+
+    def test_links3(self):
+        data = self.run_data(
+            "Hunde, die bellen, beißen nicht",
+            links=["die bellen, beißen nicht"],
+        )
+        self.assertEqual(
+            data,
+            {
+                "related": [
+                    {"word": "Hunde"},
+                    {"word": "die bellen, beißen nicht"},
                 ]
             },
         )


### PR DESCRIPTION
Previously we would just split on certain commas etc. even when a word or linkage contained them, creating extra partitions of words:

Hunde, die bellen, beißen nicht -> "Hunde", "die bellen", "beißen nicht".

This changes collects link data (visible link text strings where .alnum() == False) and passes it as a new parameter ultimately to split_on_comma_semi.

There, we use the links as part of the splitting regex, but ignore them when handling the iterations.

Also a couple of tests, but other tests fail.