### PR TITLE
Don't skip all templates in en edition's `process_children()`

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -3232,8 +3232,10 @@ def parse_language(
             if not isinstance(node, WikiNode):
                 # print("  X{}".format(repr(node)[:40]))
                 continue
-            if isinstance(node, TemplateNode):
-                process_soft_redirect_template(wxr, node, redirect_list)
+            if (
+                isinstance(node, TemplateNode)
+                and process_soft_redirect_template(wxr, node, redirect_list)
+            ):
                 continue
 
             if node.kind not in LEVEL_KINDS:
@@ -3984,7 +3986,8 @@ def process_soft_redirect_template(
     wxr: WiktextractContext,
     template_node: TemplateNode,
     redirect_pages: list[str],
-) -> None:
+) -> bool:
+    # return `True` if the template is soft redirect template
     if template_node.template_name == "zh-see":
         # https://en.wiktionary.org/wiki/Template:zh-see
         title = clean_node(
@@ -3992,6 +3995,7 @@ def process_soft_redirect_template(
         )
         if title != "":
             redirect_pages.append(title)
+        return True
     elif template_node.template_name == "ja-see":
         # https://en.wiktionary.org/wiki/Template:ja-see
         for key, value in template_node.template_parameters.items():
@@ -3999,3 +4003,5 @@ def process_soft_redirect_template(
                 title = clean_node(wxr, None, value)
                 if title != "":
                     redirect_pages.append(title)
+        return True
+    return False

--- a/tests/test_en_category.py
+++ b/tests/test_en_category.py
@@ -31,3 +31,19 @@ class TestEnCategory(TestCase):
         ]
         process_categories(self.wxr, page_data)
         self.assertEqual(page_data[0]["categories"], ["English phrasal verbs"])
+
+    def test_category_links_from_C_template(self):
+        # GH issue #577
+        from wiktextract.extractor.en.page import parse_page
+
+        self.wxr.wtp.add_page(
+            "Template:C",
+            10,
+            "[[Category:en:Beetles|BEETLE]][[Category:en:Games|BEETLE]]"
+        )
+        page_data = parse_page(self.wxr, "beetle", """==English==
+===Noun===
+# Any of numerous species of insect...
+
+{{C|en|Beetles|Games}}""")
+        self.assertEqual(page_data[0]["categories"], ["en:Beetles", "en:Games"])


### PR DESCRIPTION
The code should only skip soft redirect templates, some templates like "C" could be used to extract category links. Issue #577