### PR TITLE
Linkage

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -3913,6 +3913,7 @@ def parse_page(
         wxr.wtp.start_section(lang)
 
         # Collect all words from the page.
+        # print(f"{langnode=}")
         datas = parse_language(wxr, langnode, lang, lang_code)
 
         # Propagate fields resulting from top-level templates to this

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1314,6 +1314,25 @@ def parse_language(
         header_tags: list[str],
     ) -> None:
         ruby = []
+        links: list[str] = []
+        if not word.isalnum():
+            # if the word contains non-letter or -number characters, it might
+            # have something that messes with split-at-semi-comma; we collect
+            # links so that we can skip splitting them.
+            exp = wxr.wtp.parse(
+                wxr.wtp.node_to_wikitext(header_nodes), expand_all=True
+            )
+            link_nodes, _ = recursively_extract(
+                exp.children,
+                lambda x: isinstance(x, WikiNode)
+                and x.kind == NodeKind.LINK
+            )
+            for ln in link_nodes:
+                ltext = "".join(ln.largs[-1])  # type: ignore
+                if not ltext.isalnum():
+                    links.append(ltext)
+            if word not in links:
+                links.append(word)
         if lang_code == "ja":
             exp = wxr.wtp.parse(
                 wxr.wtp.node_to_wikitext(header_nodes), expand_all=True
@@ -1346,6 +1365,7 @@ def parse_language(
             is_reconstruction,
             header_group,
             ruby=ruby,
+            links=links,
         )
         if "tags" in pos_data:
             # pos_data can get "tags" data from some source; type-checkers

--- a/src/wiktextract/form_descriptions.py
+++ b/src/wiktextract/form_descriptions.py
@@ -1716,7 +1716,7 @@ def add_related(
 
 
 def parse_word_head(
-    wxr, pos, text, data, is_reconstruction, head_group, ruby=[]
+    wxr, pos, text, data, is_reconstruction, head_group, ruby=[], links=[],
 ):
     """Parses the head line for a word for in a particular language and
     part-of-speech, extracting tags and related forms."""
@@ -1803,7 +1803,7 @@ def parse_word_head(
     if m:
         tag, readings = m.groups()
         tag = re.sub(r"\s+", "-", tag)
-        for reading in split_at_comma_semi(readings):
+        for reading in split_at_comma_semi(readings, skipped=links):
             add_related(
                 wxr,
                 data,
@@ -2035,7 +2035,7 @@ def parse_word_head(
         for desc in descriptors:
             new_desc.extend(
                 map_with(
-                    xlat_tags_map, split_at_comma_semi(desc, extra=[", or "])
+                    xlat_tags_map, split_at_comma_semi(desc, extra=[", or "], skipped=links)
                 )
             )
         prev_tags = None
@@ -2388,7 +2388,7 @@ def parse_word_head(
                                 and desc in data["categories"]
                             )
                         ):
-                            for r in split_at_comma_semi(paren, extra=[" or "]):
+                            for r in split_at_comma_semi(paren, extra=[" or "], skipped=links):
                                 add_romanization(
                                     wxr,
                                     data,
@@ -2420,7 +2420,7 @@ def parse_word_head(
             if "or" in titleparts:
                 alts = [related]
             else:
-                alts = split_at_comma_semi(related, separators=[" or "])
+                alts = split_at_comma_semi(related, separators=[" or "], skipped=links)
                 if not alts:
                     alts = [""]
             for related in alts:

--- a/tests/test_head.py
+++ b/tests/test_head.py
@@ -7,6 +7,7 @@ import unittest
 from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.form_descriptions import parse_word_head
+from wiktextract.extractor.en.page import parse_language
 from wiktextract.thesaurus import close_thesaurus_db
 from wiktextract.wxr_context import WiktextractContext
 
@@ -41,14 +42,16 @@ class HeadTests(unittest.TestCase):
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"forms": [{"form": "testfoo",
-                                           "tags": ["canonical"]}]})
+        self.assertEqual(
+            data, {"forms": [{"form": "testfoo", "tags": ["canonical"]}]}
+        )
 
     def test_reconstruction3(self):
         data = {}
         parse_word_head(self.wxr, "noun", "*testpage", data, False, None)
-        self.assertEqual(data, {"forms": [{"form": "*testpage",
-                                           "tags": ["canonical"]}]})
+        self.assertEqual(
+            data, {"forms": [{"form": "*testpage", "tags": ["canonical"]}]}
+        )
 
     def test_head1(self):
         data = {}
@@ -72,8 +75,9 @@ class HeadTests(unittest.TestCase):
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"forms": [{"form": "testpAge",
-                                           "tags": ["canonical"]}]})
+        self.assertEqual(
+            data, {"forms": [{"form": "testpAge", "tags": ["canonical"]}]}
+        )
 
     def test_head4(self):
         data = {}
@@ -89,9 +93,14 @@ class HeadTests(unittest.TestCase):
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"forms": [
-            {"form": "testpAge", "tags": ["canonical", "masculine"]},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"form": "testpAge", "tags": ["canonical", "masculine"]},
+                ]
+            },
+        )
 
     def test_head6(self):
         data = {}
@@ -122,90 +131,119 @@ class HeadTests(unittest.TestCase):
         self.assertEqual(self.wxr.wtp.errors, [])
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertNotEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"forms": [{"form": "testpage 1",
-                                           "tags": ["canonical"]}]})
+        self.assertEqual(
+            data, {"forms": [{"form": "testpage 1", "tags": ["canonical"]}]}
+        )
 
     def test_head9(self):
         data = {}
-        parse_word_head(self.wxr, "noun",
-                        "testpage f (plurale tantum, inanimate)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "testpage f (plurale tantum, inanimate)",
+            data,
+            False,
+            None,
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"tags": ["feminine", "inanimate",
-                                         "plural", "plural-only"]})
+        self.assertEqual(
+            data, {"tags": ["feminine", "inanimate", "plural", "plural-only"]}
+        )
 
     def test_head10(self):
         data = {}
-        parse_word_head(self.wxr, "noun",
-                        "testpage f (plurale tantum, stem testpag, inanimate)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "testpage f (plurale tantum, stem testpag, inanimate)",
+            data,
+            False,
+            None,
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"tags": ["feminine", "inanimate",
-                                         "plural", "plural-only"],
-                                "forms": [{"tags": ["stem"],
-                                           "form": "testpag"}]})
+        self.assertEqual(
+            data,
+            {
+                "tags": ["feminine", "inanimate", "plural", "plural-only"],
+                "forms": [{"tags": ["stem"], "form": "testpag"}],
+            },
+        )
 
     def test_head11(self):
         data = {}
-        parse_word_head(self.wxr, "noun",
-                        "testpage f (plurale tantum, stem testpag, inanimate) "
-                        "(+ dative)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "testpage f (plurale tantum, stem testpag, inanimate) "
+            "(+ dative)",
+            data,
+            False,
+            None,
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
         print(data)
-        self.assertEqual(data, {"tags": ["feminine", "inanimate",
-                                         "plural", "plural-only",
-                                         "with-dative"],
-                                "forms": [{"tags": ["stem"],
-                                           "form": "testpag"}]})
+        self.assertEqual(
+            data,
+            {
+                "tags": [
+                    "feminine",
+                    "inanimate",
+                    "plural",
+                    "plural-only",
+                    "with-dative",
+                ],
+                "forms": [{"tags": ["stem"], "form": "testpag"}],
+            },
+        )
 
     def test_head12(self):
         # McCune-Reischauer is used in Korean characters; we're really testing
         # the hyphen in keyword names
         data = {}
-        parse_word_head(self.wxr, "noun",
-                        "foo (McCune-Reischauer bar)", data, False, None)
+        parse_word_head(
+            self.wxr, "noun", "foo (McCune-Reischauer bar)", data, False, None
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"forms": [
-            {"form": "foo", "tags": ["canonical"]},
-            {"form": "bar", "tags": ["McCune-Reischauer"]}]})
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"form": "foo", "tags": ["canonical"]},
+                    {"form": "bar", "tags": ["McCune-Reischauer"]},
+                ]
+            },
+        )
 
     def test_head13(self):
         data = {}
-        parse_word_head(self.wxr, "noun",
-                        "testpage f or m",
-                        data, False, None)
+        parse_word_head(self.wxr, "noun", "testpage f or m", data, False, None)
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
         self.assertEqual(data, {"tags": ["feminine", "masculine"]})
 
     def test_head14(self):
         data = {}
-        parse_word_head(self.wxr, "noun",
-                        "testpage f, m",
-                        data, False, None)
+        parse_word_head(self.wxr, "noun", "testpage f, m", data, False, None)
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
         self.assertEqual(data, {"tags": ["feminine", "masculine"]})
 
     def test_head15(self):
         data = {}
-        parse_word_head(self.wxr, "noun",
-                        "testpage f, m, n",
-                        data, False, None)
+        parse_word_head(self.wxr, "noun", "testpage f, m, n", data, False, None)
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
         self.assertEqual(data, {"tags": ["feminine", "masculine", "neuter"]})
 
     def test_head16(self):
         data = {}
-        parse_word_head(self.wxr, "noun",
-                        "testpage f or m or n",
-                        data, False, None)
+        parse_word_head(
+            self.wxr, "noun", "testpage f or m or n", data, False, None
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
         self.assertEqual(data, {"tags": ["feminine", "masculine", "neuter"]})
@@ -215,9 +253,7 @@ class HeadTests(unittest.TestCase):
         self.wxr.wtp.start_page("index")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "index n",
-                        data, False, None)
+        parse_word_head(self.wxr, "noun", "index n", data, False, None)
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
         self.assertEqual(data, {"tags": ["neuter"]})
@@ -227,17 +263,25 @@ class HeadTests(unittest.TestCase):
         self.wxr.wtp.start_page("index")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "index m or f (genitive indicis); third declension",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "index m or f (genitive indicis); third declension",
+            data,
+            False,
+            None,
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"tags": ["declension-3", "feminine",
-                                         "masculine"],
-                                "forms": [
-                                    {"tags": ["genitive"],
-                                     "form": "indicis"},
-                                ]})
+        self.assertEqual(
+            data,
+            {
+                "tags": ["declension-3", "feminine", "masculine"],
+                "forms": [
+                    {"tags": ["genitive"], "form": "indicis"},
+                ],
+            },
+        )
 
     def test_head19(self):
         data = {}
@@ -247,10 +291,15 @@ class HeadTests(unittest.TestCase):
         parse_word_head(self.wxr, "noun", "foo f or bar m", data, False, None)
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"forms": [
-            {"form": "foo", "tags": ["canonical", "feminine"]},
-            {"form": "bar", "tags": ["canonical", "masculine"]},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"form": "foo", "tags": ["canonical", "feminine"]},
+                    {"form": "bar", "tags": ["canonical", "masculine"]},
+                ]
+            },
+        )
 
     def test_head20(self):
         data = {}
@@ -260,48 +309,73 @@ class HeadTests(unittest.TestCase):
         parse_word_head(self.wxr, "noun", "foo or bar", data, False, None)
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"forms": [
-            {"form": "foo", "tags": ["canonical"]},
-            {"form": "bar", "tags": ["canonical"]},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"form": "foo", "tags": ["canonical"]},
+                    {"form": "bar", "tags": ["canonical"]},
+                ]
+            },
+        )
 
     def test_head21(self):
         data = {}
         self.wxr.wtp.start_page("index")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun", "foo f or n or bar m or c", data,
-                        False, None)
+        parse_word_head(
+            self.wxr, "noun", "foo f or n or bar m or c", data, False, None
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"forms": [
-            {"form": "foo", "tags": ["canonical", "feminine", "neuter"]},
-            {"form": "bar", "tags": ["canonical", "common-gender",
-                                     "masculine"]},
-        ]})
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {
+                        "form": "foo",
+                        "tags": ["canonical", "feminine", "neuter"],
+                    },
+                    {
+                        "form": "bar",
+                        "tags": ["canonical", "common-gender", "masculine"],
+                    },
+                ]
+            },
+        )
 
     def test_head22(self):
         data = {}
-        parse_word_head(self.wxr, "noun",
-                        "testpage f or testpage2 m; person",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "testpage f or testpage2 m; person",
+            data,
+            False,
+            None,
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"tags": ["person"],
-                                "forms": [
-                                    {"tags": ["canonical", "feminine"],
-                                     "form": "testpage"},
-                                    {"tags": ["canonical", "masculine"],
-                                     "form": "testpage2"},
-                                ]})
+        self.assertEqual(
+            data,
+            {
+                "tags": ["person"],
+                "forms": [
+                    {"tags": ["canonical", "feminine"], "form": "testpage"},
+                    {"tags": ["canonical", "masculine"], "form": "testpage2"},
+                ],
+            },
+        )
 
     def test_head23(self):
         data = {}
         self.wxr.wtp.start_page("indubitables")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Adjective")
-        parse_word_head(self.wxr, "adj", "indubitables m pl or f pl", data,
-                        False, None)
+        parse_word_head(
+            self.wxr, "adj", "indubitables m pl or f pl", data, False, None
+        )
         # print(json.dumps(data, indent=2))
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
@@ -312,77 +386,88 @@ class HeadTests(unittest.TestCase):
         self.wxr.wtp.start_page("foo")
         self.wxr.wtp.start_section("Japanese")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "foo (12 strokes)",
-                        data, False, None)
+        parse_word_head(self.wxr, "noun", "foo (12 strokes)", data, False, None)
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"forms": [
-            {"tags": ["strokes"],
-             "form": "12"},
-            ]})
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"tags": ["strokes"], "form": "12"},
+                ]
+            },
+        )
 
     def test_head25(self):
         data = {}
         self.wxr.wtp.start_page("smiley")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "smiley m (plural smileys, diminutive smileytje n)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "smiley m (plural smileys, diminutive smileytje n)",
+            data,
+            False,
+            None,
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"tags": ["masculine"],
-                                "forms": [
-            {"tags": ["plural"],
-             "form": "smileys"},
-            {"tags": ["diminutive", "neuter"],
-             "form": "smileytje"},
-            ]})
+        self.assertEqual(
+            data,
+            {
+                "tags": ["masculine"],
+                "forms": [
+                    {"tags": ["plural"], "form": "smileys"},
+                    {"tags": ["diminutive", "neuter"], "form": "smileytje"},
+                ],
+            },
+        )
 
     def test_head26(self):
         data = {}
         self.wxr.wtp.start_page("foos")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "foos (plural of foo)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr, "noun", "foos (plural of foo)", data, False, None
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {"forms": [
-            {"tags": ["plural-of"],
-             "form": "foo"},
-            ]})
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"tags": ["plural-of"], "form": "foo"},
+                ]
+            },
+        )
 
     def test_head27(self):
         data = {}
         self.wxr.wtp.start_page("أَبْلَعَ")
         self.wxr.wtp.start_section("Arabic")
         self.wxr.wtp.start_subsection("Verb")
-        parse_word_head(self.wxr, "verb",
-                        "أَبْلَعَ (ʾablaʿa) IV, non-past يُبْلِعُ‎‎ (yubliʿu)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "verb",
+            "أَبْلَعَ (ʾablaʿa) IV, non-past يُبْلِعُ‎‎ (yubliʿu)",
+            data,
+            False,
+            None,
+        )
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
-        self.assertEqual(data, {
-            "forms": [
-                {
-                  "form": "يُبْلِعُ‎‎",
-                  "roman": "yubliʿu",
-                  "tags": [
-                    "non-past"
-                  ]
-                },
-                {
-                  "form": "ʾablaʿa",
-                  "tags": [
-                    "romanization"
-                  ]
-                },
-            ],
-            "tags": ["form-iv"]
-            })
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"form": "يُبْلِعُ‎‎", "roman": "yubliʿu", "tags": ["non-past"]},
+                    {"form": "ʾablaʿa", "tags": ["romanization"]},
+                ],
+                "tags": ["form-iv"],
+            },
+        )
 
     def test_head28(self):
         data = {}
@@ -390,26 +475,34 @@ class HeadTests(unittest.TestCase):
         self.wxr.wtp.start_page("tell")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "tell (third-person singular simple present tells, present participle telling, simple past and past participle told or (dialectal or nonstandard) telled)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "tell (third-person singular simple present tells, present participle telling, simple past and past participle told or (dialectal or nonstandard) telled)",
+            data,
+            False,
+            None,
+        )
         print(json.dumps(data, indent=2, sort_keys=True))
-        self.assertEqual(data, {
-            "forms": [
-                {"form": "tells",
-                 "tags": ["present", "singular", "third-person"]},
-                {"form": "telling",
-                 "tags": ["participle", "present"]},
-                {"form": "told",
-                 "tags": ["participle", "past"]},
-                {"form": "told",
-                 "tags": ["past"]},
-                {"form": "telled",
-                 "tags": ["dialectal", "participle", "past"]},
-                {"form": "telled",
-                 "tags": ["dialectal", "past"]},
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {
+                        "form": "tells",
+                        "tags": ["present", "singular", "third-person"],
+                    },
+                    {"form": "telling", "tags": ["participle", "present"]},
+                    {"form": "told", "tags": ["participle", "past"]},
+                    {"form": "told", "tags": ["past"]},
+                    {
+                        "form": "telled",
+                        "tags": ["dialectal", "participle", "past"],
+                    },
+                    {"form": "telled", "tags": ["dialectal", "past"]},
                 ],
-            })
+            },
+        )
 
     def test_head29(self):
         data = {}
@@ -417,51 +510,33 @@ class HeadTests(unittest.TestCase):
         self.wxr.wtp.start_page("take")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "take (third-person singular simple present takes, present participle taking, simple past took, past participle taken or (archaic or Scotland) tane)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "take (third-person singular simple present takes, present participle taking, simple past took, past participle taken or (archaic or Scotland) tane)",
+            data,
+            False,
+            None,
+        )
         print(json.dumps(data, indent=2, sort_keys=True))
-        self.assertEqual(data, {
-            "forms": [
-              {
-                "form": "takes",
-                "tags": [
-                  "present",
-                  "singular",
-                  "third-person"
-                ]
-              },
-              {
-                "form": "taking",
-                "tags": [
-                  "participle",
-                  "present"
-                ]
-              },
-              {
-                "form": "took",
-                "tags": [
-                  "past"
-                ]
-              },
-              {
-                "form": "taken",
-                "tags": [
-                  "participle",
-                  "past"
-                ]
-              },
-              {
-                "form": "tane",
-                "tags": [
-                  "Scotland",
-                  "archaic",
-                  "participle",
-                  "past"
-                ]
-              },
-            ],
-        })
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {
+                        "form": "takes",
+                        "tags": ["present", "singular", "third-person"],
+                    },
+                    {"form": "taking", "tags": ["participle", "present"]},
+                    {"form": "took", "tags": ["past"]},
+                    {"form": "taken", "tags": ["participle", "past"]},
+                    {
+                        "form": "tane",
+                        "tags": ["Scotland", "archaic", "participle", "past"],
+                    },
+                ],
+            },
+        )
 
     def test_head30(self):
         data = {}
@@ -469,72 +544,39 @@ class HeadTests(unittest.TestCase):
         self.wxr.wtp.start_page("burn")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "burn (third-person singular simple present burns, present participle burning, simple past and past participle burned or (mostly Commonwealth) burnt or (obsolete) brent)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "burn (third-person singular simple present burns, present participle burning, simple past and past participle burned or (mostly Commonwealth) burnt or (obsolete) brent)",
+            data,
+            False,
+            None,
+        )
         print(json.dumps(data, indent=2, sort_keys=True))
-        self.assertEqual(data, {
-            "forms": [
-                {
-                  "form": "burns",
-                  "tags": [
-                    "present",
-                    "singular",
-                    "third-person"
-                  ]
-                },
-                {
-                  "form": "burning",
-                  "tags": [
-                    "participle",
-                    "present"
-                  ]
-                },
-                {
-                  "form": "burned",
-                  "tags": [
-                    "participle",
-                    "past"
-                  ]
-                },
-                {
-                  "form": "burned",
-                  "tags": [
-                    "past"
-                  ]
-                },
-                {
-                  "form": "burnt",
-                  "tags": [
-                    "Commonwealth",
-                    "participle",
-                    "past"
-                  ]
-                },
-                {
-                  "form": "burnt",
-                  "tags": [
-                    "Commonwealth",
-                    "past"
-                  ]
-                },
-                {
-                  "form": "brent",
-                  "tags": [
-                    "obsolete",
-                    "participle",
-                    "past"
-                  ]
-                },
-                {
-                  "form": "brent",
-                  "tags": [
-                    "obsolete",
-                    "past"
-                  ]
-                },
-            ],
-        })
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {
+                        "form": "burns",
+                        "tags": ["present", "singular", "third-person"],
+                    },
+                    {"form": "burning", "tags": ["participle", "present"]},
+                    {"form": "burned", "tags": ["participle", "past"]},
+                    {"form": "burned", "tags": ["past"]},
+                    {
+                        "form": "burnt",
+                        "tags": ["Commonwealth", "participle", "past"],
+                    },
+                    {"form": "burnt", "tags": ["Commonwealth", "past"]},
+                    {
+                        "form": "brent",
+                        "tags": ["obsolete", "participle", "past"],
+                    },
+                    {"form": "brent", "tags": ["obsolete", "past"]},
+                ],
+            },
+        )
 
     def test_head31(self):
         data = {}
@@ -542,55 +584,31 @@ class HeadTests(unittest.TestCase):
         self.wxr.wtp.start_page("grind")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "grind (third-person singular simple present grinds, present participle grinding, simple past and past participle ground or grinded) (see usage notes below)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "grind (third-person singular simple present grinds, present participle grinding, simple past and past participle ground or grinded) (see usage notes below)",
+            data,
+            False,
+            None,
+        )
         print(json.dumps(data, indent=2, sort_keys=True))
-        self.assertEqual(data, {
-            "forms": [
-                {
-                  "form": "grinds",
-                  "tags": [
-                    "present",
-                    "singular",
-                    "third-person"
-                  ]
-                },
-                {
-                  "form": "grinding",
-                  "tags": [
-                    "participle",
-                    "present"
-                  ]
-                },
-                {
-                  "form": "ground",
-                  "tags": [
-                    "participle",
-                    "past"
-                  ]
-                },
-                {
-                  "form": "ground",
-                  "tags": [
-                    "past"
-                  ]
-                },
-                {
-                  "form": "grinded",
-                  "tags": [
-                    "participle",
-                    "past"
-                  ]
-                },
-                {
-                  "form": "grinded",
-                  "tags": [
-                    "past"
-                  ]
-                },
-            ],
-        })
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {
+                        "form": "grinds",
+                        "tags": ["present", "singular", "third-person"],
+                    },
+                    {"form": "grinding", "tags": ["participle", "present"]},
+                    {"form": "ground", "tags": ["participle", "past"]},
+                    {"form": "ground", "tags": ["past"]},
+                    {"form": "grinded", "tags": ["participle", "past"]},
+                    {"form": "grinded", "tags": ["past"]},
+                ],
+            },
+        )
 
     def test_head32(self):
         data = {}
@@ -598,55 +616,47 @@ class HeadTests(unittest.TestCase):
         self.wxr.wtp.start_page("rive")
         self.wxr.wtp.start_section("Danish")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "rive (past tense rev, past participle revet, common gender attributive reven, plural or definite attributive revne)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "rive (past tense rev, past participle revet, common gender attributive reven, plural or definite attributive revne)",
+            data,
+            False,
+            None,
+        )
         print(json.dumps(data, indent=2, sort_keys=True))
-        self.assertEqual(data, {
-            "forms": [
-                {
-                  "form": "rev",
-                  "tags": [
-                    "past"
-                  ]
-                },
-                {
-                  "form": "revet",
-                  "tags": [
-                    "participle",
-                    "past"
-                  ]
-                },
-                {
-                  "form": "reven",
-                  "tags": [
-                    "attributive",
-                    "common-gender",
-                    "participle",
-                    "past"
-                  ]
-                },
-                {
-                  "form": "revne",
-                  "tags": [
-                    "attributive",
-                    "definite",
-                    "participle",
-                    "past",
-                    "singular"
-                  ]
-                },
-                {
-                  "form": "revne",
-                  "tags": [
-                    "attributive",
-                    "participle",
-                    "past",
-                    "plural"
-                  ]
-                },
-            ],
-        })
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"form": "rev", "tags": ["past"]},
+                    {"form": "revet", "tags": ["participle", "past"]},
+                    {
+                        "form": "reven",
+                        "tags": [
+                            "attributive",
+                            "common-gender",
+                            "participle",
+                            "past",
+                        ],
+                    },
+                    {
+                        "form": "revne",
+                        "tags": [
+                            "attributive",
+                            "definite",
+                            "participle",
+                            "past",
+                            "singular",
+                        ],
+                    },
+                    {
+                        "form": "revne",
+                        "tags": ["attributive", "participle", "past", "plural"],
+                    },
+                ],
+            },
+        )
 
     def test_head33(self):
         data = {}
@@ -654,55 +664,85 @@ class HeadTests(unittest.TestCase):
         self.wxr.wtp.start_page("rear admiral (lower half)")
         self.wxr.wtp.start_section("English")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "rear admiral (lower half) (plural rear admirals "
-                        "(lower half))",
-                        data, False, None)
+        parse_word_head(
+            self.wxr,
+            "noun",
+            "rear admiral (lower half) (plural rear admirals " "(lower half))",
+            data,
+            False,
+            None,
+        )
         print(json.dumps(data, indent=2, sort_keys=True))
-        self.assertEqual(data, {
-            "forms": [
-                {
-                  "form": "rear admirals (lower half)",
-                  "tags": [
-                    "plural"
-                  ]
-                }]})
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"form": "rear admirals (lower half)", "tags": ["plural"]}
+                ]
+            },
+        )
 
     def test_head34(self):
         data = {}
         self.wxr.wtp.start_page("foo or baz")
         self.wxr.wtp.start_section("Latin")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "foo or baz (plural)",
-                        data, False, None)
+        parse_word_head(
+            self.wxr, "noun", "foo or baz (plural)", data, False, None
+        )
         print(json.dumps(data, indent=2, sort_keys=True))
-        self.assertEqual(data, {
-                  # no 'canonical' because identical to title
-                  "tags": [
-                    "plural"
-                  ]
-                })
+        self.assertEqual(
+            data,
+            {
+                # no 'canonical' because identical to title
+                "tags": ["plural"]
+            },
+        )
 
     def test_head35(self):
         data = {}
         self.wxr.wtp.start_page("intueor")
         self.wxr.wtp.start_section("Latin")
         self.wxr.wtp.start_subsection("Noun")
-        parse_word_head(self.wxr, "noun",
-                        "intueor (plural)",
-                        data, False, None)
+        parse_word_head(self.wxr, "noun", "intueor (plural)", data, False, None)
         print(json.dumps(data, indent=2, sort_keys=True))
-        self.assertEqual(data, {
-                  # no 'canonical' because identical to title
-                  "tags": [
-                    "plural"
-                  ]
-                })
-
+        self.assertEqual(
+            data,
+            {
+                # no 'canonical' because identical to title
+                "tags": ["plural"]
+            },
+        )
 
     def test_head_templates_regex(self):
         # GitHub issue 405
         from wiktextract.extractor.en.page import HEAD_TAG_RE
 
         self.assertTrue(HEAD_TAG_RE.fullmatch("ru-noun+") is not None)
+
+    def test_head36(self):
+        data = {}
+        self.wxr.wtp.add_page("Template:en-noun", 10,
+            "[[big]], [[fat]], [[hairy]] [[deal]], "
+            "(plural [[big, fat, hairy deals]])"
+        )
+        self.wxr.wtp.start_page("big, fat, hairy deal")
+        self.wxr.wtp.start_section("English")
+        # self.wxr.wtp.start_subsection("Noun")
+        parsed = self.wxr.wtp.parse(
+            "==English==\n"
+            "====Noun====\n"
+            "{{en-noun}}\n\n"
+            "# test gloss"
+        )
+        # print(parsed)
+        langret = parse_language(self.wxr, parsed.children[0], "English", "en")
+        print(langret)
+        self.assertEqual(self.wxr.wtp.warnings, [])
+        self.assertEqual(self.wxr.wtp.debugs, [])
+        print(langret[0]["forms"][0])
+        self.assertEqual(
+            langret[0]["forms"][0],
+            # commas are missing, why?
+            {"tags": ["plural"], "form": "big fat hairy deals"},
+        )


### PR DESCRIPTION
Use the same `skipped` parameter that was introduced for linkage-parsing recently (for spit_at_semi_comma()) to not break up phrases and words with separators as long as they are links, when parsing heads.

Fixes #372