### PR TITLE
Use link text data in word head detection regex

### DIFF
--- a/tests/test_head.py
+++ b/tests/test_head.py
@@ -744,5 +744,5 @@ class HeadTests(unittest.TestCase):
         self.assertEqual(
             langret[0]["forms"][0],
             # commas are missing, why?
-            {"tags": ["plural"], "form": "big fat hairy deals"},
+            {"tags": ["plural"], "form": "big, fat, hairy deals"},
         )


### PR DESCRIPTION
I am really happy with this one. Minimal changes, after figuring out where the issue was.

The issue was: phrases and words with stuff like commas had their commas stripped away due to a general word-finding regex. The fix is to use a modified regex pattern if needed, when `links` data is provided.