### PR TITLE
Ignore "Statistics" sections to suppress "fi-stats-surname" Lua error

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -3294,7 +3294,9 @@ def parse_language(
             # gets discarded: Search STATISTICS_IMPLEMENTATION
             wxr.config.section_counts[t] += 1
             # print("PROCESS_CHILDREN: T:", repr(t))
-            if t.startswith(PRONUNCIATION_TITLE):
+            if t in IGNORED_TITLES:
+                pass
+            elif t.startswith(PRONUNCIATION_TITLE):
                 if t.startswith(PRONUNCIATION_TITLE + " "):
                     # Pronunciation 1, etc, are used in Chinese Glyphs,
                     # and each of them may have senses under Definition
@@ -3333,8 +3335,6 @@ def parse_language(
             elif t == TRANSLATIONS_TITLE:
                 data = select_data()
                 parse_translations(data, node)
-            elif t in IGNORED_TITLES:
-                pass
             elif t in INFLECTION_TITLES:
                 parse_inflection(node, t, pos)
             else:

--- a/src/wiktextract/extractor/en/section_titles.py
+++ b/src/wiktextract/extractor/en/section_titles.py
@@ -236,7 +236,7 @@ COMPOUNDS_TITLE = "compounds"
 ETYMOLOGY_TITLES: frozenset[str] = frozenset(["etymology", "glyph origin"])
 
 IGNORED_TITLES: frozenset[str] = frozenset(
-    ["anagrams", "further reading", "references", "quotations"]
+    ["anagrams", "further reading", "references", "quotations", "statistics"]
 )
 
 INFLECTION_TITLES: frozenset[str] = frozenset(


### PR DESCRIPTION
en edition templates "fi-stats-given-name" and "fi-stats-surname" put the end of wikitext link `]]` inside `#switch` parser function break our parser.

Error: https://kaikki.org/dictionary/All%20languages%20combined/errors/details-Invalid-source-given-for-fi-stats-surn-NnZNGQei.html
Template pages:
- https://en.wiktionary.org/wiki/Template:fi-stats-surname
- https://en.wiktionary.org/wiki/Template:fi-stats-given-name