### PR TITLE
Fix issue with malformed regex in parse_word_head

### DIFF
--- a/src/wiktextract/form_descriptions.py
+++ b/src/wiktextract/form_descriptions.py
@@ -1742,7 +1742,11 @@ def parse_word_head(
         # if we have link data (that is, links with stuff like commas and
         # spaces, replace word_re with a modified local scope pattern
         word_re = re.compile(
-            r"|".join(sorted(links, key=lambda x: -len(x))) + r"|" + word_pattern
+            r"|".join(
+                sorted((re.escape(s) for s in links), key=lambda x: -len(x))
+            )
+            + r"|"
+            + word_pattern
         )
     else:
         word_re = word_re_global


### PR DESCRIPTION
Recently messed up some regex pattern generation things (didn't escape them), and I missed this one in the logs because the other exception was much more common.