### PR TITLE
Switch from root Logger in logging to instance Logger

### DIFF
--- a/src/wiktextract/extractor/de/page.py
+++ b/src/wiktextract/extractor/de/page.py
@@ -1,10 +1,10 @@
-import logging
 from typing import Any
 
 from mediawiki_langcodes import name_to_code
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.parser import LevelNode, TemplateNode
 from wiktextract.page import clean_node
+from wiktextract.logging import logger
 from wiktextract.wxr_context import WiktextractContext
 
 from .example import extract_examples
@@ -161,7 +161,7 @@ def parse_page(
     wxr: WiktextractContext, page_title: str, page_text: str
 ) -> list[dict[str, Any]]:
     if wxr.config.verbose:
-        logging.info(f"Parsing page: {page_title}")
+        logger.info(f"Parsing page: {page_title}")
 
     wxr.config.word = page_title
     wxr.wtp.start_page(page_title)

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -4,7 +4,6 @@
 
 import copy
 import html
-import logging
 import re
 import sys
 from collections import defaultdict
@@ -39,6 +38,7 @@ from wiktextract.form_descriptions import (
 )
 from wiktextract.inflection import TableContext, parse_inflection_section
 from wiktextract.linkages import parse_linkage_item_text
+from wiktextract.logging import logger
 from wiktextract.page import (
     LEVEL_KINDS,
     clean_node,
@@ -3872,7 +3872,7 @@ def parse_page(
         return []
 
     if wxr.config.verbose:
-        logging.info(f"Parsing page: {word}")
+        logger.info(f"Parsing page: {word}")
 
     wxr.config.word = word
     wxr.wtp.start_page(word)

--- a/src/wiktextract/extractor/en/thesaurus.py
+++ b/src/wiktextract/extractor/en/thesaurus.py
@@ -3,7 +3,6 @@
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
-import logging
 import re
 from typing import Optional
 
@@ -12,6 +11,7 @@ from wikitextprocessor import NodeKind, Page, WikiNode
 from wikitextprocessor.core import NamespaceDataEntry
 from wiktextract.datautils import ns_title_prefix_tuple
 from wiktextract.form_descriptions import parse_sense_qualifier
+from wiktextract.logging import logger
 from wiktextract.page import LEVEL_KINDS, clean_node
 from wiktextract.thesaurus import ThesaurusTerm
 from wiktextract.wxr_context import WiktextractContext
@@ -131,7 +131,7 @@ def extract_thesaurus_page(
         kind = contents.kind
         if kind == NodeKind.LIST and not contents.contain_node(NodeKind.LIST):
             if lang is None:
-                logging.debug(
+                logger.debug(
                     f"{title=} {lang=} UNEXPECTED LIST WITHOUT LANG: "
                     + str(contents)
                 )
@@ -142,7 +142,7 @@ def extract_thesaurus_page(
                     continue
                 w = clean_node(wxr, None, node.children)
                 if "*" in w:
-                    logging.debug(f"{title=} {lang=} {pos=} STAR IN WORD: {w}")
+                    logger.debug(f"{title=} {lang=} {pos=} STAR IN WORD: {w}")
                 # Check for parenthesized sense at the beginning
                 m = re.match(r"(?s)^\(([^)]*)\):\s*(.*)$", w)
                 if m:
@@ -207,7 +207,7 @@ def extract_thesaurus_page(
                     if w1:
                         lang_code = name_to_code(lang, "en")
                         if lang_code is None:
-                            logging.debug(
+                            logger.debug(
                                 f"Linkage language {lang} not recognized"
                             )
                         thesaurus.append(
@@ -276,7 +276,7 @@ def extract_thesaurus_page(
             # possibly given additional tags
             subtitle_tags = IGNORED_SUBTITLE_TAGS_MAP[subtitle]
             return recurse(contents.children)
-        logging.debug(
+        logger.debug(
             f"{title=} {lang=} {pos=} {sense=} UNHANDLED SUBTITLE: "
             + "subtitle "
             + str(contents.sarg if contents.sarg else contents.largs)

--- a/src/wiktextract/extractor/es/page.py
+++ b/src/wiktextract/extractor/es/page.py
@@ -1,4 +1,3 @@
-import logging
 import re
 
 from wikitextprocessor import NodeKind, WikiNode
@@ -7,6 +6,7 @@ from wikitextprocessor.parser import (
     TemplateNode,
     WikiNodeChildrenList,
 )
+from wiktextract.logging import logger
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 
@@ -311,7 +311,7 @@ def parse_page(
     wxr: WiktextractContext, page_title: str, page_text: str
 ) -> list[dict[str, any]]:
     if wxr.config.verbose:
-        logging.info(f"Parsing page: {page_title}")
+        logger.info(f"Parsing page: {page_title}")
 
     wxr.config.word = page_title
     wxr.wtp.start_page(page_title)

--- a/src/wiktextract/extractor/fr/page.py
+++ b/src/wiktextract/extractor/fr/page.py
@@ -1,8 +1,8 @@
-import logging
 from typing import Any, Optional
 
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.parser import LEVEL_KIND_FLAGS
+from wiktextract.logging import logger
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 
@@ -191,7 +191,7 @@ def parse_page(
     wxr: WiktextractContext, page_title: str, page_text: str
 ) -> list[dict[str, Any]]:
     if wxr.config.verbose:
-        logging.info(f"Parsing page: {page_title}")
+        logger.info(f"Parsing page: {page_title}")
 
     wxr.config.word = page_title
     wxr.wtp.start_page(page_title)

--- a/src/wiktextract/extractor/ru/page.py
+++ b/src/wiktextract/extractor/ru/page.py
@@ -1,10 +1,10 @@
-import logging
 from typing import Any, Optional
 
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.parser import LEVEL_KIND_FLAGS, TemplateNode
 from wiktextract.config import POSSubtitleData
 from wiktextract.page import clean_node
+from wiktextract.logging import logger
 from wiktextract.wxr_context import WiktextractContext
 
 from .gloss import extract_gloss
@@ -203,7 +203,7 @@ def parse_page(
     # https://ru.wiktionary.org/wiki/Викисловарь:Правила_оформления_статей
 
     if wxr.config.verbose:
-        logging.info(f"Parsing page: {page_title}")
+        logger.info(f"Parsing page: {page_title}")
 
     wxr.config.word = page_title
     wxr.wtp.start_page(page_title)

--- a/src/wiktextract/extractor/zh/page.py
+++ b/src/wiktextract/extractor/zh/page.py
@@ -1,10 +1,10 @@
-import logging
 import re
 from typing import Any, Union
 
 from mediawiki_langcodes import name_to_code
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.parser import LEVEL_KIND_FLAGS, TemplateNode
+from wiktextract.logging import logger
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 
@@ -217,7 +217,7 @@ def parse_page(
         return []
 
     if wxr.config.verbose:
-        logging.info(f"Parsing page: {page_title}")
+        logger.info(f"Parsing page: {page_title}")
     wxr.config.word = page_title
     wxr.wtp.start_page(page_title)
 

--- a/src/wiktextract/extractor/zh/thesaurus.py
+++ b/src/wiktextract/extractor/zh/thesaurus.py
@@ -1,9 +1,9 @@
-import logging
 import re
 from typing import Optional, Union
 
 from mediawiki_langcodes import name_to_code
 from wikitextprocessor import NodeKind, Page, WikiNode
+from wiktextract.logging import logger
 
 from ...page import clean_node
 from ...thesaurus import ThesaurusTerm
@@ -160,7 +160,7 @@ def recursive_parse(
         lang_name = clean_node(wxr, None, node.largs)
         lang_code = name_to_code(lang_name, "zh")
         if lang_code is None:
-            logging.warning(
+            logger.warning(
                 f"Unrecognized language: {lang_name} in page Thesaurus:{entry}"
             )
         return recursive_parse(
@@ -172,7 +172,7 @@ def recursive_parse(
             return None
         english_pos = POS_TITLES.get(local_pos_name, {}).get("pos")
         if english_pos is None:
-            logging.warning(
+            logger.warning(
                 f"Unrecognized POS subtitle: {local_pos_name} in page "
                 f"Thesaurus:{entry}"
             )
@@ -190,7 +190,7 @@ def recursive_parse(
         local_linkage_name = clean_node(wxr, None, node.largs)
         english_linkage = LINKAGE_TITLES.get(local_linkage_name)
         if english_linkage is None:
-            logging.warning(
+            logger.warning(
                 f"Unrecognized linkage subtitle: {local_linkage_name} in page "
                 f"Thesaurus:{entry}"
             )

--- a/src/wiktextract/logging.py
+++ b/src/wiktextract/logging.py
@@ -1,0 +1,4 @@
+import logging
+
+logger = logging.getLogger("wiktextract")
+logger.setLevel(logging.DEBUG)

--- a/src/wiktextract/thesaurus.py
+++ b/src/wiktextract/thesaurus.py
@@ -2,7 +2,6 @@
 # merged into word linkages in later stages.
 #
 # Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
-import logging
 import os
 import sqlite3
 import tempfile
@@ -16,6 +15,7 @@ from typing import List, Optional, Set, TextIO, Tuple
 
 from mediawiki_langcodes import code_to_name
 from wikitextprocessor import Page
+from wiktextract.logging import logger
 
 from .import_utils import import_extractor_module
 from .wxr_context import WiktextractContext
@@ -79,7 +79,7 @@ def extract_thesaurus_data(
     from .wiktionary import init_worker_process
 
     start_t = time.time()
-    logging.info("Extracting thesaurus data")
+    logger.info("Extracting thesaurus data")
     thesaurus_ns_data = wxr.wtp.NAMESPACE_DATA.get("Thesaurus", {})
     thesaurus_ns_id = thesaurus_ns_data.get("id")
 
@@ -91,7 +91,7 @@ def extract_thesaurus_data(
         ):
             if not success:
                 # Print error in parent process - do not remove
-                logging.error(err)
+                logger.error(err)
                 continue
             if terms is not None:
                 for term in terms:
@@ -101,7 +101,7 @@ def extract_thesaurus_data(
     wxr.thesaurus_db_conn.commit()
     num_pages = wxr.wtp.saved_page_nums([thesaurus_ns_id], False)
     total = thesaurus_linkage_number(wxr.thesaurus_db_conn)
-    logging.info(
+    logger.info(
         "Extracted {} linkages from {} thesaurus pages (took {:.1f}s)".format(
             total, num_pages, time.time() - start_t
         )
@@ -229,7 +229,7 @@ def emit_words_in_thesaurus(
     # sometimes.
     from .wiktionary import write_json_data
 
-    logging.info("Emitting words that only occur in thesaurus")
+    logger.info("Emitting words that only occur in thesaurus")
     for entry_id, entry, pos, lang_code, sense in wxr.thesaurus_db_conn.execute(
         "SELECT id, entry, pos, language_code, sense FROM entries "
         "WHERE pos IS NOT NULL AND language_code IS NOT NULL"
@@ -238,13 +238,13 @@ def emit_words_in_thesaurus(
             continue
 
         if None in (entry, lang_code, pos):
-            logging.info(
+            logger.info(
                 f"'None' in entry, lang_code or"
                 f" pos: {entry}, {lang_code}, {pos}"
             )
             continue
 
-        logging.info(
+        logger.info(
             "Emitting thesaurus entry for "
             f"{entry}/{lang_code}/{pos} (not in main)"
         )

--- a/src/wiktextract/wiktionary.py
+++ b/src/wiktextract/wiktionary.py
@@ -6,7 +6,6 @@
 
 import io
 import json
-import logging
 import os
 import re
 import tarfile
@@ -19,6 +18,7 @@ from typing import Optional, TextIO
 
 from wikitextprocessor import Page
 from wikitextprocessor.dumpparser import process_dump
+from wiktextract.logging import logger
 
 from .page import parse_page
 from .thesaurus import (
@@ -61,7 +61,7 @@ def page_handler(page: Page) -> tuple[list[dict], dict]:
                 page_data = parse_page(wxr, title, page.body)
                 dur = time.time() - start_t
                 if dur > 100:
-                    logging.warning(
+                    logger.warning(
                         "====== WARNING: PARSING PAGE TOOK {:.1f}s: {}".format(
                             dur, title
                         )
@@ -99,7 +99,7 @@ def parse_wiktionary(
         for x in capture_language_codes:
             assert isinstance(x, str)
 
-    logging.info("First phase - extracting templates, macros, and pages")
+    logger.info("First phase - extracting templates, macros, and pages")
     if override_folders is not None:
         override_folders = [Path(folder) for folder in override_folders]
     if save_pages_path is not None:
@@ -140,7 +140,7 @@ def estimate_progress(
         estimate_seconds = (
             (current_time - start_time) / processed_pages * remaining_pages
         )
-        logging.info(
+        logger.info(
             "  ... {}/{} pages ({:.1%}) processed, "
             "{:02d}:{:02d}:{:02d} remaining".format(
                 processed_pages,
@@ -518,7 +518,7 @@ def reprocess_wiktionary(
     search_pattern: Optional[str] = None,
 ) -> None:
     """Reprocesses the Wiktionary from the sqlite db."""
-    logging.info("Second phase - processing pages")
+    logger.info("Second phase - processing pages")
 
     # Extract thesaurus data. This iterates over thesaurus pages,
     # but is very fast.
@@ -565,7 +565,7 @@ def reprocess_wiktionary(
             )
     if wxr.config.dump_file_lang_code == "en":
         emit_words_in_thesaurus(wxr, emitted, out_f, human_readable)
-    logging.info("Reprocessing wiktionary complete")
+    logger.info("Reprocessing wiktionary complete")
 
 
 def process_ns_page_title(page: Page, ns_name: str) -> tuple[str, str]:
@@ -585,7 +585,7 @@ def extract_namespace(
 ) -> None:
     """Extracts all pages in the given namespace and writes them to a .tar
     file with the given path."""
-    logging.info(
+    logger.info(
         f"Extracting pages from namespace {namespace} to tar file {path}"
     )
     ns_id = wxr.wtp.NAMESPACE_DATA.get(namespace, {}).get("id")

--- a/src/wiktextract/wiktwords.py
+++ b/src/wiktextract/wiktwords.py
@@ -36,6 +36,7 @@ from wiktextract import (
     reprocess_wiktionary,
 )
 from wiktextract.inflection import set_debug_cell_text
+from wiktextract.logging import logger
 from wiktextract.template_override import template_override_fns
 from wiktextract.thesaurus import (
     close_thesaurus_db,
@@ -68,7 +69,7 @@ def process_single_page(
         title = path_or_title
         text = wxr.wtp.get_page_body(title, 0)
         if text is None:
-            logging.error(f"Can't find page '{title}' in the database.")
+            logger.error(f"Can't find page '{title}' in the database.")
             return
 
     # Extract Thesaurus data (this is a bit slow for a single page, but
@@ -107,7 +108,8 @@ def main():
         "--errors", type=str, help="File in which to save error information"
     )
     parser.add_argument(
-        "--dump-file-language-code", "--edition",
+        "--dump-file-language-code",
+        "--edition",
         type=str,
         default="en",
         help="Language code of the dump file.",
@@ -152,7 +154,7 @@ def main():
         default=False,
         help="Skip the (usually lengthy) json data extraction "
         "procedure to do other things, like creating a database "
-        "file or other files."
+        "file or other files.",
     )
     parser.add_argument(
         "--translations",
@@ -304,7 +306,8 @@ def main():
 
     if not args.quiet:
         logging.basicConfig(
-            format="%(asctime)s %(levelname)s: %(message)s", level=logging.DEBUG
+            format="%(asctime)s %(levelname)s: %(message)s",
+            level=logging.DEBUG,
         )
 
     if args.debug_cell_text:
@@ -335,14 +338,14 @@ def main():
         for lang_code in args.language_code:
             lang_name = code_to_name(lang_code, args.dump_file_language_code)
             if lang_name == "":
-                logging.warning(f"Unknown language code: {lang_code}")
+                logger.warning(f"Unknown language code: {lang_code}")
             else:
                 capture_lang_codes.add(lang_code)
     if len(args.language_name) > 0:
         for lang_name in args.language_name:
             lang_code = name_to_code(lang_name, args.dump_file_language_code)
             if lang_code == "":
-                logging.warning(f"Unknown language name: {lang_name}")
+                logger.warning(f"Unknown language name: {lang_name}")
             else:
                 capture_lang_codes.add(lang_code)
     if len(capture_lang_codes) == 0:
@@ -350,9 +353,9 @@ def main():
 
     if args.all_languages:
         capture_lang_codes = None
-        logging.info("Capturing words for all available languages")
+        logger.info("Capturing words for all available languages")
     else:
-        logging.info(f"Capturing words for: {', '.join(capture_lang_codes)}")
+        logger.info(f"Capturing words for: {', '.join(capture_lang_codes)}")
 
     # Open output file.
     out_path = args.out
@@ -458,7 +461,7 @@ def main():
         if args.page and not args.skip_extraction:
             # Parse a single Wiktionary page (extracted using --pages-dir)
             if not args.db_path:
-                logging.warning(
+                logger.warning(
                     "NOTE: you probably want to use --db-path with --page or "
                     "otherwise processing will be very slow."
                 )
@@ -491,7 +494,7 @@ def main():
     if args.templates_file:
         extract_namespace(wxr, "Template", args.templates_file)
     if args.categories_file:
-        logging.info("Extracting category tree")
+        logger.info("Extracting category tree")
         tree = extract_categories(wxr)
         with open(args.categories_file, "w") as f:
             json.dump(tree, f, indent=2, sort_keys=True)


### PR DESCRIPTION
Because we were using logging.debug, logging.warning and logging.error, our logs are spammed by dependencies that shouldn't be sending debug messages (datetime, apparently).

Hopefully by switching to a instance of Logger instead using root, we can stop those messages.