### PR TITLE
Get es edition's translation language name from expanded template

### DIFF
--- a/src/wiktextract/extractor/de/page.py
+++ b/src/wiktextract/extractor/de/page.py
@@ -184,11 +184,13 @@ def parse_page(
             if subtitle_template.template_name == "Sprache":
                 lang_name = subtitle_template.template_parameters.get(1, "")
                 lang_code = name_to_code(lang_name, "de")
-                if lang_code == "" and lang_name != "Umschrift":
-                    wxr.wtp.warning(
-                        f"Unknown language: {lang_name}",
-                        sortid="extractor/de/page/parse_page/76",
-                    )
+                if lang_code == "":
+                    lang_code = "unknown"
+                    if lang_name != "Umschrift":
+                        wxr.wtp.warning(
+                            f"Unknown language: {lang_name}",
+                            sortid="extractor/de/page/parse_page/76",
+                        )
                 if (
                     wxr.config.capture_language_codes is not None
                     and lang_code not in wxr.config.capture_language_codes

--- a/src/wiktextract/extractor/es/translation.py
+++ b/src/wiktextract/extractor/es/translation.py
@@ -1,7 +1,6 @@
 import itertools
 from typing import Optional
 
-from mediawiki_langcodes import code_to_name
 from wikitextprocessor.parser import TemplateNode
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
@@ -37,7 +36,9 @@ def process_t_template(
 ) -> None:
     # https://es.wiktionary.org/wiki/Plantilla:t
     lang_code = template_node.template_parameters.get(1, "")
-    lang_name = code_to_name(lang_code, "es")
+    template_text = clean_node(wxr, word_entry, template_node)
+    lang_name = template_text[:template_text.find(":")].strip("* ")
+
     for tr_index in itertools.count(1):
         if "t" + str(tr_index) not in template_node.template_parameters:
             break
@@ -81,10 +82,9 @@ def process_t_plus_template(
 ) -> None:
     # obsolete template: https://es.wiktionary.org/wiki/Plantilla:t+
 
-    lang_code = template_node.template_parameters.get(1)  # Language code
-    lang = code_to_name(lang_code, "es")
-    if not lang:
-        lang = f"Unknown({lang_code})"
+    lang_code = template_node.template_parameters.get(1)
+    template_text = clean_node(wxr, word_entry, template_node)
+    lang_name = template_text[:template_text.find(":")].strip("* ")
 
     # Initialize variables
     current_translation: Optional[Translation] = None
@@ -154,7 +154,7 @@ def process_t_plus_template(
                     current_translation = Translation(
                         word=value,
                         lang_code=lang_code,
-                        lang=lang,
+                        lang=lang_name,
                         senseids=list(senseids),
                     )
         elif isinstance(key, str):

--- a/tests/test_de_page.py
+++ b/tests/test_de_page.py
@@ -119,7 +119,7 @@ class TestDEPage(unittest.TestCase):
             ),
             [
                 {
-                    "lang_code": "",
+                    "lang_code": "unknown",
                     "lang": "Umschrift",
                     "pos": "soft-redirect",
                     "redirects": ["行く", "幾", "𒃷"],

--- a/tests/test_es_translation.py
+++ b/tests/test_es_translation.py
@@ -28,6 +28,17 @@ class TestESTranslation(unittest.TestCase):
 
     def test_es_extract_translation(self):
         # Test cases from https://es.wiktionary.org/wiki/Plantilla:t+
+        self.wxr.wtp.add_page(
+            "Plantilla:t+",
+            10,
+            """* {{#switch:{{{1}}}
+| af = afrikáans
+| de = alemán
+| fr = francés
+| hy = armenio
+}}: {{{3}}}"""
+        )
+
         test_cases = [
             {
                 # https://es.wiktionary.org/wiki/calderón
@@ -150,6 +161,11 @@ class TestESTranslation(unittest.TestCase):
 
     def test_t_roman(self):
         self.wxr.wtp.start_page("hola")
+        self.wxr.wtp.add_page(
+            "Plantilla:t",
+            10,
+            "* Chino: &#91;1&#93;&nbsp;[[你好#Chino|你好]] <sup>[[:zh:你好|(zh)]]</sup> “nĭ hăo”[[Categoría:Español-Chino]], [[您好#Chino|您好]] <sup>[[:zh:您好|(zh)]]</sup> “nín hăo”&nbsp;(formal)"
+        )
         word_entry = WordEntry(word="hola", lang_code="es", lang="Español")
         root = self.wxr.wtp.parse(
             "{{t|zh|a1=1|t1=你好|tl1=nĭ hăo|t2=您好|tl2=nín hăo|nota2=formal}}"
@@ -162,14 +178,14 @@ class TestESTranslation(unittest.TestCase):
             ],
             [
                 {
-                    "lang": "chino",
+                    "lang": "Chino",
                     "lang_code": "zh",
                     "word": "你好",
                     "senseids": ["1"],
                     "roman": "nĭ hăo",
                 },
                 {
-                    "lang": "chino",
+                    "lang": "Chino",
                     "lang_code": "zh",
                     "word": "您好",
                     "roman": "nín hăo",
@@ -180,6 +196,11 @@ class TestESTranslation(unittest.TestCase):
 
     def test_t_gender(self):
         self.wxr.wtp.start_page("hola")
+        self.wxr.wtp.add_page(
+            "Plantilla:t",
+            10,
+            "* Tailandés: &#91;1&#93;&nbsp;[[สวัสดีครับ#Tailandés|สวัสดีครับ]] <sup>[[:th:สวัสดีครับ|(th)]]</sup>&nbsp;(''masculino'')[[Categoría:Español-Tailandés]], [[สวัสดีค่ะ#Tailandés|สวัสดีค่ะ]] <sup>[[:th:สวัสดีค่ะ|(th)]]</sup>&nbsp;(''femenino'')"
+        )
         word_entry = WordEntry(word="hola", lang_code="es", lang="Español")
         root = self.wxr.wtp.parse(
             "{{t|th|a1=1|t1=สวัสดีครับ|g1=m|t2=สวัสดีค่ะ|g2=f}}"
@@ -192,14 +213,14 @@ class TestESTranslation(unittest.TestCase):
             ],
             [
                 {
-                    "lang": "tailandés",
+                    "lang": "Tailandés",
                     "lang_code": "th",
                     "word": "สวัสดีครับ",
                     "senseids": ["1"],
                     "tags": ["masculine"],
                 },
                 {
-                    "lang": "tailandés",
+                    "lang": "Tailandés",
                     "lang_code": "th",
                     "word": "สวัสดีค่ะ",
                     "tags": ["feminine"],


### PR DESCRIPTION
I'll update the mediawiki_langcodes package to add language names and codes in the es edition in case we need these data later.