### PR TITLE
Classify desc

### DIFF
--- a/src/wiktextract/config.py
+++ b/src/wiktextract/config.py
@@ -157,11 +157,11 @@ class WiktionaryConfig:
         #         self.pos_counts[k] += v
         #     for k, v in ret["section_counts"].items():
         #         self.section_counts[k] += v
-        if "errors" in ret and len(self.errors) < 100000:
+        if "errors" in ret and len(self.errors) < 100_000:
             self.errors.extend(ret.get("errors", []))
-        if "warnings" in ret and len(self.warnings) < 100000:
+        if "warnings" in ret and len(self.warnings) < 100_000:
             self.warnings.extend(ret.get("warnings", []))
-        if "debugs" in ret and len(self.debugs) < 300000:
+        if "debugs" in ret and len(self.debugs) < 300_000:
             self.debugs.extend(ret.get("debugs", []))
 
     def load_edition_settings(self) -> None:

--- a/src/wiktextract/english_words.py
+++ b/src/wiktextract/english_words.py
@@ -1879,7 +1879,7 @@ additional_words = set(
 
 # These words will never be treated as English words (overriding other
 # considerations, not just membership in the set)
-not_english_words = set(
+not_english_words_1 = set(
     [
         # This is a blacklist - these will not be treated as English words
         # even though they are in brown.words().  Adding a word on this list
@@ -1889,13 +1889,11 @@ not_english_words = set(
         "Frans",
         "Germani",
         "Germania",
-        "He",
         "J'habitais",
         "Kina",
         "Mal",
         "Mi",
         "Mihapjungguk",
-        "Ye",
         "al",
         "avec",
         "boo",
@@ -1910,6 +1908,15 @@ not_english_words = set(
         "que",
     ]
 )
+
+potentially_english_words = set(
+    [
+        "He",
+        "Ye",
+    ]
+)
+
+not_english_words = not_english_words_1 | potentially_english_words
 
 # Construct a set of (most) English words.  Multi-word expressions where we
 # do not want to include the components can also be put here space-separated.

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -567,6 +567,11 @@ ignored_descendants_templates_re = ignored_etymology_templates_re
 usex_templates: set[str] = {
     "afex",
     "affixusex",
+    "co", # {{collocation}} acts like a example template, specifically for
+          # pairs of combinations of words that are more common than you'd
+          # except would be randomly; hlavní#Czech
+    "coi",
+    "collocation",
     "el-example",
     "el-x",
     "example",


### PR DESCRIPTION
Allow more debug messages in extract.errors (I needed some data output by debug messages and spent an embarrassing amount of time trying to find a bug...)

Address some of the bad example classifications in #604.

- "He" was blacklisted as an English word
- Add certain templates to our list of example templates