### PR TITLE
[zh] extract Hiragana data from headword HTML tags

### DIFF
--- a/tests/test_zh_headword.py
+++ b/tests/test_zh_headword.py
@@ -147,6 +147,11 @@ class TestHeadword(TestCase):
                     "lang_code": "ja",
                     "lang": "日語",
                     "forms": [
+                        {
+                            "form": "大家",
+                            "ruby": [("大", "おお"), ("家", "や")],
+                            "tags": ["canonical"],
+                        },
                         {"form": "ōya", "tags": ["romanization"]},
                         {"form": "おほや", "roman": "ofoya"},
                     ],


### PR DESCRIPTION
Some Japanese header line templates put the `strong` tag inside another `span` tag.