### PR TITLE
Use example template args to determine example

### DIFF
--- a/src/wiktextract/english_words.py
+++ b/src/wiktextract/english_words.py
@@ -1874,6 +1874,12 @@ additional_words = set(
         "zealotry",
         "zoospores",
         "zygosperm",
+        "chamomile",
+        "peppermint",
+        "x-axis",
+        "y-axis",
+        "z-axis",
+        "maté",
     ]
 )
 

--- a/src/wiktextract/form_descriptions.py
+++ b/src/wiktextract/form_descriptions.py
@@ -3266,12 +3266,10 @@ def classify_desc(
             )
             for x in tokens
         )
-        print(lst_bool)
         cnt = lst_bool.count(True)
         rejected_words = tuple(
             x for i, x in enumerate(tokens) if not lst_bool[i]
         )
-        print(f"{rejected_words}")
         if (
             any(
                 lst_bool[i] and x[0].isalpha() and len(x) > 1


### PR DESCRIPTION
Previously, we would expand everything with clean_node and use heuristics to check whether it was an example or not.

However, seeing as how we have access to template
arguments, we can bypass some of these heuristics
early by checking if the text we're checking has
one template, from the example templates set,
with arguments that are the same as what is part
of the clean_node output. In this case, we can just assume this is an example.