### PR TITLE
[zh] Set default `lang_code` to `unknown`

### DIFF
--- a/src/wiktextract/extractor/zh/page.py
+++ b/src/wiktextract/extractor/zh/page.py
@@ -197,6 +197,7 @@ def parse_page(
                 f"Unrecognized language name: {lang_name}",
                 sortid="extractor/zh/page/parse_page/509",
             )
+            lang_code = "unknown"
         if (
             wxr.config.capture_language_codes is not None
             and lang_code not in wxr.config.capture_language_codes


### PR DESCRIPTION
Low quality pages use nonsense language titles. Suppress these check JSON debug messages.