### PR TITLE
[ru] find pos data in form of template name

### DIFF
--- a/src/wiktextract/extractor/ru/page.py
+++ b/src/wiktextract/extractor/ru/page.py
@@ -306,6 +306,11 @@ def process_form_template(
 ) -> None:
     # https://ru.wiktionary.org/wiki/Шаблон:Форма-сущ
     # Шаблон:Форма-гл, "Шаблон:форма-гл en"
+    pos_data = get_pos_from_template(wxr, template_node)
+    if pos_data is not None:
+        base_data.pos = pos_data["pos"]
+        base_data.tags.extend(pos_data.get("tags", []))
+
     form_of = clean_node(
         wxr,
         None,


### PR DESCRIPTION
some pages like "Vakuen" put form of template in a list and can't be found by `get_pos()`