### PR TITLE
[zh] extract Japanese example template under "quote-*" template

### DIFF
--- a/src/wiktextract/extractor/zh/gloss.py
+++ b/src/wiktextract/extractor/zh/gloss.py
@@ -1,8 +1,8 @@
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.parser import TemplateNode
-from wiktextract.page import clean_node
-from wiktextract.wxr_context import WiktextractContext
 
+from ...page import clean_node
+from ...wxr_context import WiktextractContext
 from ..ruby import extract_ruby
 from .example import extract_examples
 from .models import AltForm, Sense, WordEntry

--- a/tests/test_zh_example.py
+++ b/tests/test_zh_example.py
@@ -118,3 +118,45 @@ translation text""",
                 },
             ],
         )
+
+    def test_example_under_example(self):
+        self.wxr.wtp.start_page("英語")
+        self.wxr.wtp.add_page("Template:quote-book", 10, "ref text")
+        self.wxr.wtp.add_page(
+            "Template:ja-usex",
+            10,
+            """<span lang="ja" class="Jpan">-{オレの<ruby>日<rp>(</rp><rt>に</rt><rp>)</rp></ruby><ruby>本<rp>(</rp><rt>ほん</rt><rp>)</rp></ruby><ruby>語<rp>(</rp><rt>ご</rt><rp>)</rp></ruby>どう？<ruby>悪<rp>(</rp><rt>わる</rt><rp>)</rp></ruby>くないだろ　<ruby>韓<rp>(</rp><rt>かん</rt><rp>)</rp></ruby><ruby>国<rp>(</rp><rt>こく</rt><rp>)</rp></ruby><ruby>語<rp>(</rp><rt>ご</rt><rp>)</rp></ruby>と'''<ruby>英<rp>(</rp><rt>えい</rt><rp>)</rp></ruby><ruby>語<rp>(</rp><rt>ご</rt><rp>)</rp></ruby>'''も<ruby>話<rp>(</rp><rt>はな</rt><rp>)</rp></ruby>すんだぜ　<ruby>趣<rp>(</rp><rt>しゅ</rt><rp>)</rp></ruby><ruby>味<rp>(</rp><rt>み</rt><rp>)</rp></ruby>だな<ruby>語<rp>(</rp><rt>ご</rt><rp>)</rp></ruby><ruby>学<rp>(</rp><rt>がく</rt><rp>)</rp></ruby>は　<ruby>寝<rp>(</rp><rt>ね</rt><rp>)</rp></ruby><ruby>泊<rp>(</rp><rt>とま</rt><rp>)</rp></ruby>りはどこ？<ruby>近<rp>(</rp><rt>ちか</rt><rp>)</rp></ruby>くのホテル？}-</span><dl><dd><i><span lang="la" class="tr">Ore no Nihongo dō? Waruku naidaro Kankokugo to '''Eigo''' mo hanasunda ze Shumi da na gogaku wa Netomari wa doko? Chikaku no hoteru?</span></i></dd><dd>我的日語怎麼樣？不差吧？我也會講韓語和英語。學習語言很有趣。你在哪裏住？附近的賓館嗎？</dd></dl>[[Category:有使用例的日語詞|廾65弋75]][[Category:有使用例的日語詞|廾65弋75]]""",
+        )
+        sense_data = Sense()
+        root = self.wxr.wtp.parse("""#* {{quote-book|ja}}\n#*: {{ja-usex}}""")
+        extract_examples(self.wxr, sense_data, root.children[0], [])
+        self.assertEqual(
+            [e.model_dump(exclude_defaults=True) for e in sense_data.examples],
+            [
+                {
+                    "ref": "ref text",
+                    "text": "オレの日本語どう？悪くないだろ 韓国語と英語も話すんだぜ 趣味だな語学は 寝泊りはどこ？近くのホテル？",
+                    "roman": "Ore no Nihongo dō? Waruku naidaro Kankokugo to Eigo mo hanasunda ze Shumi da na gogaku wa Netomari wa doko? Chikaku no hoteru?",
+                    "ruby": [
+                        ("日", "に"),
+                        ("本", "ほん"),
+                        ("語", "ご"),
+                        ("悪", "わる"),
+                        ("韓", "かん"),
+                        ("国", "こく"),
+                        ("語", "ご"),
+                        ("英", "えい"),
+                        ("語", "ご"),
+                        ("話", "はな"),
+                        ("趣", "しゅ"),
+                        ("味", "み"),
+                        ("語", "ご"),
+                        ("学", "がく"),
+                        ("寝", "ね"),
+                        ("泊", "とま"),
+                        ("近", "ちか"),
+                    ],
+                    "translation": "我的日語怎麼樣？不差吧？我也會講韓語和英語。學習語言很有趣。你在哪裏住？附近的賓館嗎？",
+                },
+            ],
+        )


### PR DESCRIPTION
Some Japanese pages use a separate "ja-x" template in a list under "quote-*" templates.