### PR TITLE
Zhexamples

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -550,6 +550,13 @@ ignored_etymology_templates: list[str] = [
     "cln",
     "langname-lite",
     "no deprecated lang param usage",
+    "mention",
+    "m",
+    "m-self",
+    "link",
+    "l",
+    "ll",
+    "l-self",
 ]
 # Regexp for matching ignored etymology template names.  This adds certain
 # prefixes to the names listed above.

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -3413,6 +3413,7 @@ def parse_language(
                     continue
                 usex_type = None
                 example_template_args = []
+                example_template_names = []
 
                 def usex_template_fn(name, ht):
                     nonlocal usex_type
@@ -3421,6 +3422,7 @@ def parse_language(
                     if name in usex_templates:
                         usex_type = "example"
                         example_template_args.append(ht)
+                        example_template_names.append(name)
                     elif name in quotation_templates:
                         usex_type = "quotation"
                     for prefix in template_linkages:
@@ -3540,7 +3542,7 @@ def parse_language(
                 elif len(lines) > 1:
                     if (
                         any(re.search(r"[]\d:)]\s*$", x) for x in lines[:-1])
-                        and lang_code != "zh"
+                        and example_template_names != ["zh-x"]
                     ):
                         ref = []
                         for i in range(len(lines)):
@@ -3633,7 +3635,7 @@ def parse_language(
                                 i -= 1
                             tr = "\n".join(lines[i:])
                             lines = lines[:i]
-                    elif len(lines) > 2 and lang_code == "zh":
+                    elif len(lines) > 2 and example_template_names == ["zh-x"]:
                         original_lines = []
                         for i, line in enumerate(lines):
                             if not line:

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1596,7 +1596,6 @@ def parse_language(
                 "uxi",
                 "usex",
                 "afex",
-                "zh-x",
                 "prefixusex",
                 "ko-usex",
                 "ko-x",
@@ -3540,10 +3539,9 @@ def parse_language(
                             lines = [parts[0].strip()]
                             tr = parts[1].strip()
                 elif len(lines) > 1:
-                    if (
-                        any(re.search(r"[]\d:)]\s*$", x) for x in lines[:-1])
-                        and example_template_names != ["zh-x"]
-                    ):
+                    if any(
+                        re.search(r"[]\d:)]\s*$", x) for x in lines[:-1]
+                    ) and example_template_names in (["zh-x"], ["zh-usex"]):
                         ref = []
                         for i in range(len(lines)):
                             if re.match(r"^[#*]*:+(\s*$|\s+)", lines[i]):
@@ -3635,7 +3633,10 @@ def parse_language(
                                 i -= 1
                             tr = "\n".join(lines[i:])
                             lines = lines[:i]
-                    elif len(lines) > 2 and example_template_names == ["zh-x"]:
+                    elif len(lines) > 2 and example_template_names in (
+                        ["zh-x"],
+                        ["zh-usex"],
+                    ):
                         original_lines = []
                         for i, line in enumerate(lines):
                             if not line:

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -3548,7 +3548,10 @@ def parse_language(
                 elif len(lines) > 1:
                     if any(
                         re.search(r"[]\d:)]\s*$", x) for x in lines[:-1]
-                    ) and example_template_names in (["zh-x"], ["zh-usex"]):
+                    ) and not (
+                        len(example_template_names) == 1
+                        and example_template_names[0] in ("zh-x", "zh-usex")
+                    ):
                         ref = []
                         for i in range(len(lines)):
                             if re.match(r"^[#*]*:+(\s*$|\s+)", lines[i]):
@@ -3640,9 +3643,14 @@ def parse_language(
                                 i -= 1
                             tr = "\n".join(lines[i:])
                             lines = lines[:i]
-                    elif len(lines) > 2 and example_template_names in (
-                        ["zh-x"],
-                        ["zh-usex"],
+                    elif (
+                        len(lines) > 2
+                        and len(example_template_names)
+                        and example_template_names[0]
+                        in (
+                            "zh-x",
+                            "zh-usex",
+                        )
                     ):
                         original_lines = []
                         for i, line in enumerate(lines):
@@ -3892,7 +3900,11 @@ def fix_subtitle_hierarchy(wxr: WiktextractContext, text: str) -> str:
                 skip_level_title = True
             level = 3
         elif lc.startswith(PRONUNCIATION_TITLE):
-            level = 3
+            if prev_level == 3:
+                level = 4
+            else:
+                level = 3
+            print(f"Pron level is: {level=}")
         elif lc in POS_TITLES:
             level = 4
         elif lc == TRANSLATIONS_TITLE:
@@ -3915,7 +3927,7 @@ def fix_subtitle_hierarchy(wxr: WiktextractContext, text: str) -> str:
         else:
             parts.append("{}{}{}".format("=" * level, title, "=" * level))
             parts.append(part)
-        # print("=" * level, title)
+        print("=" * level, title)
         # if level != len(left):
         #     print("  FIXED LEVEL OF {} {} -> {}"
         #           .format(title, len(left), level))

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -3538,7 +3538,10 @@ def parse_language(
                             lines = [parts[0].strip()]
                             tr = parts[1].strip()
                 elif len(lines) > 1:
-                    if any(re.search(r"[]\d:)]\s*$", x) for x in lines[:-1]):
+                    if (
+                        any(re.search(r"[]\d:)]\s*$", x) for x in lines[:-1])
+                        and lang_code != "zh"
+                    ):
                         ref = []
                         for i in range(len(lines)):
                             if re.match(r"^[#*]*:+(\s*$|\s+)", lines[i]):
@@ -3630,6 +3633,21 @@ def parse_language(
                                 i -= 1
                             tr = "\n".join(lines[i:])
                             lines = lines[:i]
+                    elif len(lines) > 2 and lang_code == "zh":
+                        original_lines = []
+                        for i, line in enumerate(lines):
+                            if not line:
+                                continue
+                            cl = classify_desc(line.split("[")[0])
+                            if line.startswith("From:"):
+                                ref += line
+                            elif cl == "other":
+                                original_lines.append(i)
+                            elif cl == "romanization":
+                                roman += line
+                            elif cl == "english":
+                                tr += line
+                        lines = [lines[i] for i in original_lines]
 
                 roman = re.sub(r"[ \t\r]+", " ", roman).strip()
                 roman = re.sub(r"\[\s*…\s*\]", "[…]", roman)

--- a/usertools/json-check-diffs.py
+++ b/usertools/json-check-diffs.py
@@ -1,0 +1,83 @@
+# Compare two wiktextract output files to each other to find differences
+# SLOW AND USES TONS OF MEMORY
+
+import json
+from jsondiff import diff
+from collections import defaultdict
+from sys import argv
+
+if len(argv) != 3:
+    print("Need two arguments: file1 and file2")
+
+file1, file2 = argv[1], argv[2]
+
+words1: dict[str, list] = defaultdict(list)
+counter1: dict[str, int] = defaultdict(int)
+words2: dict[str, list] = defaultdict(list)
+
+for file, words in ((file1, words1), (file2, words2)):
+    with open(file, "r") as f:
+        for line in f.readlines():
+            data = json.loads(line)
+            if "title" in data:
+                continue
+            if "word" not in data:
+                # print("'word' not in {data=}")
+                word = "MISSINGWORD"
+            else:
+                word = data["word"]
+            if "pos" not in data:
+                # print("'pos missing from {data=}")
+                pos = "MISSINGPOS"
+            else:
+                pos = data["pos"]
+            if "lang" not in data and "lang_code" not in data:
+                # print("neither 'lang' nor 'lang_code' in {data=}")
+                lang = "MISSINGLANG"
+            else:
+                lang = data.get("lang", None) or data.get("lang_code", None)
+            # words1[lang].append(pos+word)
+            # counter1[f"{lang}:{word}:{pos}"] += 1
+            words[f"{lang}:{word}:{pos}"].append(data)
+            # if counter1[f"{lang}:{word}:{pos}"] > 1:
+            #     print(f"More than one: {lang}:{word}:{pos}")
+            #     print(data)
+            #     print("------")
+
+i = 0
+for k, datas1 in words1.items():
+    if i > 100_000:
+        break
+    i += 1
+    if k not in words2:
+        print(f"====== {k=} not found in words2!")
+        continue
+    datas2 = words2[k]
+    if len(datas1) != len(datas2):
+        print(f"======= Len mismatch with {k=}")
+        continue
+    for x, y in zip(datas1, datas2):
+        d = diff(x, y, syntax="symmetric")
+        if "senses" in d.keys() and len(d) == 1:
+        # kludge to handle a 'bug' with a quotation template: if a day is not
+        # specified, we apparently add a day number after the month based on
+        # the current date.
+            cur = next(iter(d["senses"].values()))
+            if cur and "examples" in cur.keys():
+                ref = next(iter(cur["examples"].values()))
+                if "ref" in ref:
+                    continue
+        # print(f"jsondiff: {d=}")
+        if d:
+            print("==================")
+            print(d, " ->")
+            print("-----")
+            print(x)
+            print("------")
+            print(y)
+
+# for i, (k, v) in enumerate(words1.items()):
+#     if i > 1000:
+#         break
+#     print(f"{k}:  {v}")
+print("Finished")


### PR DESCRIPTION
I've added one more branch to the extract_example multi-line if-tree to account for how `Template:zh-x` formats its examples. Because it's a special case, it's simpler than usual (just using `classify_desc` to put each line into a box).

For example in: https://en.wiktionary.org/wiki/%E6%9C%AA%E9%9B%A8%E7%B6%A2%E7%B9%86

Note that each line is split on square brackets because `[` interferes with `classify_desc`, most probably on purpose (it classifies it as 'other' instead of 'romanization'). `zh-x` uses a lot of "text [Specific Chinese language, trad. or simp.]" style qualifiers, which we're going to ignore and add as part of the text itself. Examples inside senses don't have a `tags` field, and I don't want to add them unless there's a lot more need for it.

The `[` also broke the heuristics for the original code, so I also added a negative condition regarding `zh-x` up in the first if condition to counteract that. If there are more Chinese templates like this, or maybe if all Chinese examples have this exact format, then we can expand the condition or make it more general (with "lang_code == 'zh'", for example).

It took me too long messing with this code to realize it would be a royal mess to integrate this stuff into the 'general' branches, and adding a special case isn't going to be that expensive. Just makes the code even longer.