### PR TITLE
[de] extract verb inflection tables in "Flexion" namespace

### DIFF
--- a/src/wiktextract/extractor/de/flexion.py
+++ b/src/wiktextract/extractor/de/flexion.py
@@ -9,7 +9,7 @@ from .models import Form, WordEntry
 from .tags import translate_raw_tags
 
 
-def parse_adj_flexion_page(
+def parse_flexion_page(
     wxr: WiktextractContext, word_entry: WordEntry, page_title: str
 ) -> None:
     # https://de.wiktionary.org/wiki/Hilfe:Flexionsseiten
@@ -26,10 +26,14 @@ def parse_adj_flexion_page(
             process_deklinationsseite_template(
                 wxr, word_entry, flexion_template, page_title
             )
+        elif flexion_template.template_name.startswith("Deutsch Verb"):
+            process_deutsch_verb_template(
+                wxr, word_entry, flexion_template, page_title
+            )
 
 
 @dataclass
-class ColspanHeader:
+class SpanHeader:
     text: str
     index: int
     span: int
@@ -72,7 +76,7 @@ def process_deklinationsseite_template(
                                 has_article = False
                                 col_headers.clear()
                             col_headers.append(
-                                ColspanHeader(cell_text, col_index, col_span)
+                                SpanHeader(cell_text, col_index, col_span)
                             )
                             col_index += col_span
                         else:
@@ -102,3 +106,103 @@ def process_deklinationsseite_template(
                                 translate_raw_tags(form)
                                 word_entry.forms.append(form)
                         col_index += int(cell_node.attrs.get("colspan", "1"))
+
+
+def process_deutsch_verb_template(
+    wxr: WiktextractContext,
+    word_entry: WordEntry,
+    template_node: TemplateNode,
+    page_tite: str,
+) -> None:
+    # Vorlage:Deutsch Verb regelmäßig
+    expanded_template = wxr.wtp.parse(
+        wxr.wtp.node_to_wikitext(template_node), expand_all=True
+    )
+    for table in expanded_template.find_child_recursively(NodeKind.TABLE):
+        col_headers = []
+        for row in table.find_child(NodeKind.TABLE_ROW):
+            row_header = ""
+            col_index = 0
+            col_header_index = 0
+            is_bold_col_header = all(
+                c.contain_node(NodeKind.BOLD)
+                for c in row.find_child(NodeKind.TABLE_CELL)
+                if clean_node(wxr, None, c) != ""
+            )
+            if (
+                len(
+                    list(
+                        row.find_child(
+                            NodeKind.TABLE_HEADER_CELL | NodeKind.TABLE_CELL
+                        )
+                    )
+                )
+                == 1
+            ):
+                col_headers.clear()  # new table
+            for cell in row.find_child(
+                NodeKind.TABLE_HEADER_CELL | NodeKind.TABLE_CELL
+            ):
+                cell_text = clean_node(wxr, None, cell)
+                if cell_text in (
+                    "Flexion der Verbaladjektive",
+                    "(nichterweiterte) Infinitive",
+                ):
+                    break
+                elif (
+                    cell.kind == NodeKind.TABLE_HEADER_CELL
+                    and cell_text not in ("", "Person")
+                ):
+                    col_headers.append(
+                        SpanHeader(
+                            cell_text,
+                            col_header_index,
+                            int(cell.attrs.get("colspan", "1")),
+                        )
+                    )
+                    col_header_index += 1
+                elif cell.kind == NodeKind.TABLE_CELL:
+                    if cell_text in (
+                        "",
+                        "—",
+                        "Text",
+                        "Person",
+                    ) or cell_text.startswith("Flexion:"):
+                        col_index += 1
+                    elif (
+                        cell.contain_node(NodeKind.BOLD)
+                        or len(list(cell.find_html("small"))) > 0
+                    ):  # header in cell
+                        colspan = int(cell.attrs.get("colspan", "1"))
+                        if is_bold_col_header:
+                            for bold_node in cell.find_child(NodeKind.BOLD):
+                                col_headers.append(
+                                    SpanHeader(
+                                        clean_node(wxr, None, bold_node),
+                                        col_header_index,
+                                        colspan,
+                                    )
+                                )
+                        else:
+                            row_header = cell_text
+                        col_header_index += colspan
+                    else:
+                        for form_text in cell_text.splitlines():
+                            form_text = form_text.strip(", ")
+                            form = Form(form=form_text, source=page_tite)
+                            if row_header != "":
+                                form.raw_tags.append(row_header)
+                            for col_header in col_headers:
+                                if (
+                                    col_index >= col_header.index
+                                    and col_index
+                                    < col_header.index + col_header.span
+                                ):
+                                    if col_header.text.endswith("I"):
+                                        form.raw_tags.append(col_header.text)
+                                    else:
+                                        for raw_tag in col_header.text.split():
+                                            form.raw_tags.append(raw_tag)
+                            translate_raw_tags(form)
+                            word_entry.forms.append(form)
+                        col_index += 1

--- a/src/wiktextract/extractor/de/tags.py
+++ b/src/wiktextract/extractor/de/tags.py
@@ -233,6 +233,8 @@ DECLENSION_TAGS = {
 OTHER_TAGS = {
     # Vorlage:Deklinationsseite Adjektiv
     "Prädikativ": "predicative",
+    "erweiterte": "extended",
+    "Höflichkeitsform": "honorific",
 }
 
 TENSE_TAGS = {
@@ -240,18 +242,46 @@ TENSE_TAGS = {
     "Präsens": "present",
     "Präteritum": "past",
     "Perfekt": "perfect",
+    "Futur I": "future-i",
+    "Futur II": "future-ii",
 }
 
 MOOD_TAGS = {
     # Vorlage:Deutsch Verb Übersicht
-    "Konjunktiv II": "subjunctive",
+    # Vorlage:Deutsch Verb regelmäßig
+    "Konjunktiv I": "subjunctive-i",
+    "Konjunktiv II": "subjunctive-ii",
     "Imperativ": "imperative",
+    "Imperative": "imperative",
+    "Indikativ": "indicative",
 }
 
 VERB_FORM_TAGS = {
     # Vorlage:Deutsch Verb Übersicht
-    "Partizip II": "participle",
+    "Partizip II": "participle-2",
     "Hilfsverb": "auxiliary",
+    "Infinitive": "infinitive",
+    "Infinitiv": "infinitive",
+    "Partizipien": "participle",
+}
+
+VOICE_TAGS = {
+    # Vorlage:Deutsch Verb unregelmäßig
+    "Aktiv": "active",
+    "Vorgangspassiv": "processual passive",
+    "Zustandspassiv": "statal passive",
+    "Passiv": "passive",
+    "Gerundivum": "gerundive",
+}
+
+PERSON_TAGS = {
+    # Vorlage:Deutsch Verb unregelmäßig
+    "1. Person Singular": ["first-person", "singular"],
+    "1. Person Plural": ["first-person", "plural"],
+    "2. Person Singular": ["second-person", "singular"],
+    "2. Person Plural": ["second-person", "plural"],
+    "3. Person Singular": ["third-person", "singular"],
+    "3. Person Plural": ["third-person", "plural"],
 }
 
 GRAMMATICAL_TAGS = {
@@ -265,6 +295,8 @@ GRAMMATICAL_TAGS = {
     **TENSE_TAGS,
     **MOOD_TAGS,
     **VERB_FORM_TAGS,
+    **VOICE_TAGS,
+    **PERSON_TAGS,
 }
 
 

--- a/src/wiktextract/extractor/zh/section_titles.py
+++ b/src/wiktextract/extractor/zh/section_titles.py
@@ -372,6 +372,7 @@ IGNORED_TITLES: frozenset[str] = frozenset(
         "易位構詞",
         "外部鏈接",
         "外部链接",
+        "外部連結",
     ]
 )
 

--- a/tests/test_de_forms.py
+++ b/tests/test_de_forms.py
@@ -239,7 +239,49 @@ class TestDeForms(TestCase):
 | style="text-align:right" colspan="3" | [[gesehen|gesehen]]<br />sehen
 | [[haben|haben]]
 |-
-! colspan="5" | <div>''Alle weiteren Formen:'' [[Flexion:sehen|Flexion:sehen]]</div>
+! colspan="5" | <div>''All other forms:'' [[Flexion:sehen|Flexion:sehen]]</div>
+|}""",
+        )
+        self.wxr.wtp.add_page(
+            "Flexion:sehen",
+            108,
+            """== sehen (Konjugation) ({{Verbkonjugation|Deutsch}}) ==
+{{Abgeleitete Verben|[[ansehen]], [[aufsehen]], [[umsehen]], [[versehen]]}}
+
+{{Deutsch Verb unregelmäßig|2=seh|3=sah|4=säh|5=gesehen|6=sieh|8=i|vp=ja|zp=ja|gerund=ja
+|Imperativ (du)=sieh!<br />siehe}}""",
+        )
+        self.wxr.wtp.add_page(
+            "Vorlage:Deutsch Verb unregelmäßig",
+            10,
+            """==== Infinitive und Partizipien ====
+{|
+|-
+!colspan="3" bgcolor=#CCCCFF|[[Hilfe:Infinitiv|(nichterweiterte) Infinitive]]
+|-
+|bgcolor=#F4F4F4|
+|bgcolor=#F4F4F4 align=center|'''[[Hilfe:Präsens|Infinitiv Präsens]]'''
+|bgcolor=#F4F4F4 align=center|'''[[Hilfe:Perfekt|Infinitiv Perfekt]]'''
+|-
+|bgcolor=#F4F4F4 align=center|'''[[Hilfe:Aktiv|Aktiv]]'''
+| sehen
+| gesehen haben
+|-
+!colspan="3" bgcolor=#CCCCFF|[[Hilfe:Partizip|Partizipien]]
+|-
+|bgcolor=#F4F4F4|'''[[Hilfe:Präsens|Präsens Aktiv]]'''
+|bgcolor=#F4F4F4|'''[[Hilfe:Perfekt|Perfekt Passiv]]'''
+|bgcolor=#F4F4F4|'''[[Hilfe:Gerundivum|Gerundivum]]'''<br><small>Nur attributive Verwendung</small>
+|-
+| sehend
+| gesehen
+| zu&#32;sehender,<br/>zu&#32;sehende&#32;…
+|-
+!colspan="3" bgcolor=#CCCCFF|[[Hilfe:Verbaladjektiv|Flexion der Verbaladjektive]]
+|-
+| [[Flexion:sehend|Flexion:sehend]]
+| [[Flexion:gesehen#gesehen (Deklination) (Deutsch)|Flexion:gesehen]]
+| [[Flexion:sehen/Gerundivum|Flexion:Gerundivum]]
 |}""",
         )
         root = self.wxr.wtp.parse("{{Deutsch Verb Übersicht}}")
@@ -256,12 +298,42 @@ class TestDeForms(TestCase):
                 {"form": "sie sieht", "tags": ["present"]},
                 {"form": "es sieht", "tags": ["present"]},
                 {"form": "ich sah", "tags": ["past"]},
-                {"form": "ich sähe", "tags": ["subjunctive"]},
+                {"form": "ich sähe", "tags": ["subjunctive-ii"]},
                 {"form": "siehe!", "tags": ["imperative", "singular"]},
                 {"form": "sieh!", "tags": ["imperative", "singular"]},
                 {"form": "seht!", "tags": ["imperative", "plural"]},
-                {"form": "gesehen", "tags": ["participle", "perfect"]},
-                {"form": "sehen", "tags": ["participle", "perfect"]},
+                {"form": "gesehen", "tags": ["participle-2", "perfect"]},
+                {"form": "sehen", "tags": ["participle-2", "perfect"]},
                 {"form": "haben", "tags": ["auxiliary", "perfect"]},
+                {
+                    "form": "sehen",
+                    "tags": ["active", "infinitive", "present"],
+                    "source": "Flexion:sehen",
+                },
+                {
+                    "form": "gesehen haben",
+                    "tags": ["active", "infinitive", "perfect"],
+                    "source": "Flexion:sehen",
+                },
+                {
+                    "form": "sehend",
+                    "tags": ["participle", "present", "active"],
+                    "source": "Flexion:sehen",
+                },
+                {
+                    "form": "gesehen",
+                    "tags": ["participle", "perfect", "passive"],
+                    "source": "Flexion:sehen",
+                },
+                {
+                    "form": "zu sehender",
+                    "tags": ["participle", "gerundive"],
+                    "source": "Flexion:sehen",
+                },
+                {
+                    "form": "zu sehende …",
+                    "tags": ["participle", "gerundive"],
+                    "source": "Flexion:sehen",
+                },
             ],
         )


### PR DESCRIPTION
I think `clean_node()` doesn't return the correct string for `[[Flexion:sehend]]`, it returns `sehand` but should be `Flexion:sehend`.