### PR TITLE
Don't remove namespace prefix in a link from `clean_value()`

### DIFF
--- a/src/wiktextract/clean.py
+++ b/src/wiktextract/clean.py
@@ -1372,13 +1372,19 @@ def clean_value(
         return " ".join(args[i:])
 
     def repl_link(m: re.Match) -> str:
+        before_colon = m.group(1)
+        after_colon = m.group(3)
         if (
-            m.group(1) is not None
-            and IMAGE_LINK_RE.match(m.group(1)) is not None
+            before_colon is not None
+            and IMAGE_LINK_RE.match(before_colon) is not None
         ):
             return ""
-        v = m.group(3).split("|")
-        return clean_value(wxr, v[0], no_strip=True)
+        if before_colon is not None and before_colon.strip(": ") in ("w", "s"):
+            # Wikipedia or Wikisource link
+            v = after_colon.split("|")[0]
+        else:
+            v = m.group(0).strip("[] ").split("|")[0]
+        return clean_value(wxr, v, no_strip=True)
 
     def repl_link_bars(m: re.Match) -> str:
         link = m.group(1)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -372,3 +372,9 @@ class WiktExtractTests(unittest.TestCase):
             clean_value(self.wxr, "FOO\n{| {| inner table |} |}\nBAR"),
             "FOO\nBAR",
         )
+
+    def test_clean_flexion_ns_link(self):
+        # https://de.wiktionary.org/wiki/Flexion:sehen
+        self.assertEqual(
+            clean_value(self.wxr, "[[Flexion:sehend]]"), "Flexion:sehend"
+        )


### PR DESCRIPTION
Should only remove "w:" and "s:" prefixes.

Found this wikitext in https://de.wiktionary.org/wiki/Flexion:sehen , remove the namespace causes the de edition code add an extra form data: #644