### PR TITLE
[zh] find the "zh-x" template inside list in etymology section

### DIFF
--- a/src/wiktextract/extractor/zh/etymology.py
+++ b/src/wiktextract/extractor/zh/etymology.py
@@ -1,5 +1,9 @@
-from wikitextprocessor import WikiNode
-from wikitextprocessor.parser import LEVEL_KIND_FLAGS, TemplateNode
+from wikitextprocessor.parser import (
+    LEVEL_KIND_FLAGS,
+    NodeKind,
+    TemplateNode,
+    WikiNode,
+)
 
 from ...page import clean_node
 from ...wxr_context import WiktextractContext
@@ -31,6 +35,23 @@ def extract_etymology(
             for example_data in extract_template_zh_x(wxr, etymology_node):
                 base_data.etymology_examples.append(example_data)
             clean_node(wxr, page_data[-1], etymology_node)
+        elif (
+            isinstance(etymology_node, WikiNode)
+            and etymology_node.kind == NodeKind.LIST
+        ):
+            has_zh_x = False
+            for template_node in etymology_node.find_child_recursively(
+                NodeKind.TEMPLATE
+            ):
+                if template_node.template_name == "zh-x":
+                    has_zh_x = True
+                    for example_data in extract_template_zh_x(
+                        wxr, template_node
+                    ):
+                        base_data.etymology_examples.append(example_data)
+                    clean_node(wxr, page_data[-1], template_node)
+            if not has_zh_x:
+                etymology_nodes.append(etymology_node)
         else:
             etymology_nodes.append(etymology_node)
 

--- a/src/wiktextract/extractor/zh/example.py
+++ b/src/wiktextract/extractor/zh/example.py
@@ -159,8 +159,9 @@ def extract_template_zh_x(
         translation = ""
         for dd_tag in dl_tag.find_html("dd"):
             dd_text = clean_node(wxr, None, dd_tag)
-            if dd_text.startswith("來自："):
-                ref = dd_text.removeprefix("來自：")
+            # Module:Zh-usex uses "出自：" now: https://zh.wiktionary.org/w/index.php?title=Module:Zh-usex&diff=prev&oldid=8430896
+            if dd_text.startswith(("出自：", "來自：")):
+                ref = dd_text.removeprefix("出自：").removeprefix("來自：")
             else:
                 is_pinyin = False
                 for span_tag in dd_tag.find_html_recursively(

--- a/tests/test_zh_etymology.py
+++ b/tests/test_zh_etymology.py
@@ -58,3 +58,42 @@ class TestNote(TestCase):
                 },
             ],
         )
+
+    def test_zh_x_in_list(self):
+        self.wxr.wtp.start_page("焚膏繼晷")
+        self.wxr.wtp.add_page(
+            "Template:zh-x",
+            10,
+            """<div class="vsSwitcher" data-toggle-category="usage examples" style="border-left: 1px solid #930; border-left-width: 2px; padding-left: 0.8em;"><dl class="zhusex"><span lang="zh-Hant" class="Hant">[[焚#漢語|<b>焚]][[膏油#漢語|膏</b>油]][[以#漢語|以]][[繼#漢語|<b>繼]][[晷#漢語|晷</b>]]，[[恆#漢語|恆]][[兀兀#漢語|兀兀]][[以#漢語|以]][[窮#漢語|窮]][[年#漢語|年]]。</span><span class="vsHide"> <span style="color:darkgreen; font-size:x-small;">&#91;[[w:文言文|文言文]]，[[w:繁体中文|繁體]]&#93;</span></span><span class="vsToggleElement" style="color:darkgreen; font-size:x-small;padding-left:10px"></span><hr><span class="vsHide"><span lang="zh-Hans" class="Hans">[[焚#漢語|<b>焚]][[膏油#漢語|膏</b>油]][[以#漢語|以]][[继#漢語|<b>继]][[晷#漢語|晷</b>]]，[[恒#漢語|恒]][[兀兀#漢語|兀兀]][[以#漢語|以]][[穷#漢語|穷]][[年#漢語|年]]。</span> <span style="color:darkgreen; font-size:x-small;">&#91;[[w:文言文|文言文]]，[[w:简体中文|簡體]]&#93;</span></span><dd><span class="vsHide"><small>出自：'''813'''年，[[w:韓愈|韓愈]]《[[s:進學解|進學解]]》</small></span></dd><dd><span class="vsHide"><span lang="zh-Latn" style="color:#404D52"><i><b>Fén gāo</b>yóu yǐ <b>jì guǐ</b>, héng wùwù yǐ qióng nián.</i></span> <span style="color:darkgreen; font-size:x-small;">&#91;[[w:漢語拼音|漢語拼音]]&#93;</span></span></dd><dd>點燈燃燭夜以繼日，終年孜孜不倦刻苦用功。</dd></dl>[[Category:有引文的文言文詞]]</div>""",
+        )
+        root = self.wxr.wtp.parse("""===詞源===
+出自唐·韓愈《[[s:進學解|進學解]]》：
+: {{zh-x|'''焚 膏'''油 以 '''繼 晷'''，恆 兀兀 以 窮 年。|點燈燃燭夜以繼日，終年孜孜不倦刻苦用功。|CL|ref='''813'''年，{{w|韓愈}}《[[s:進學解|進學解]]》|collapsed=y}}""")
+        base_data = WordEntry(
+            lang="漢語", lang_code="zh", word="焚膏繼晷", pos="phrase"
+        )
+        page_data = [base_data]
+        extract_etymology(self.wxr, page_data, base_data, root.children[0])
+        self.assertEqual(page_data[0].etymology_text, "出自唐·韓愈《進學解》：")
+        self.assertEqual(
+            [
+                e.model_dump(exclude_defaults=True)
+                for e in page_data[0].etymology_examples
+            ],
+            [
+                {
+                    "ref": "813年，韓愈《進學解》",
+                    "raw_tags": ["文言文", "繁體"],
+                    "text": "焚膏油以繼晷，恆兀兀以窮年。",
+                    "roman": "Fén gāoyóu yǐ jì guǐ, héng wùwù yǐ qióng nián.",
+                    "translation": "點燈燃燭夜以繼日，終年孜孜不倦刻苦用功。",
+                },
+                {
+                    "ref": "813年，韓愈《進學解》",
+                    "raw_tags": ["文言文", "簡體"],
+                    "text": "焚膏油以继晷，恒兀兀以穷年。",
+                    "roman": "Fén gāoyóu yǐ jì guǐ, héng wùwù yǐ qióng nián.",
+                    "translation": "點燈燃燭夜以繼日，終年孜孜不倦刻苦用功。",
+                },
+            ],
+        )


### PR DESCRIPTION
most pages uses the ":" list to indent the source example block