### PR TITLE
Parse Template:+obj and add new `coincidence` field

### DIFF
--- a/src/wiktextract/type_utils.py
+++ b/src/wiktextract/type_utils.py
@@ -11,6 +11,12 @@ class AltOf(TypedDict, total=False):
     extra: str
 
 
+class CoincidenceData(TypedDict, total=False):
+    tags: list[str]
+    words: list[str]
+    meaning: str
+
+
 class LinkageData(TypedDict, total=False):
     alt: str
     english: str
@@ -139,6 +145,7 @@ class WordData(TypedDict, total=False):
     abbreviations: list[LinkageData]
     alt_of: list[AltOf]
     antonyms: list[LinkageData]
+    coincidence: CoincidenceData
     categories: list[str]
     coordinate_terms: list[LinkageData]
     derived: list[LinkageData]


### PR DESCRIPTION
The `Template:+obj` is used to generate formatting for constructions such as `[+accusative]` or
`[+foo = a meaning with bar]`, used to show that something is usually coincident or tied to an argument or
a specific word or something else.

These were not previously handled in parsing, which poisoned `forms` with 'canonical' entries like
`pro [+accusative]`.

Instead of creating new categories of tags like
`with-accusative` etc., Tatu gave the green light
to make a completely new field, which is here called "coincidence" because it's about coincident... things.

`coincidence` is a dict with a `tags` field, `words` field and `meaning` field (each optional).

Currently only used at the main entry level for
when a word head uses `+obj`; see pro/Czech.