### PR TITLE
[en] extract forms data and literal meaning from "zh-forms" template

### DIFF
--- a/src/wiktextract/extractor/en/pronunciations.py
+++ b/src/wiktextract/extractor/en/pronunciations.py
@@ -1,8 +1,8 @@
 import hashlib
 import re
 import urllib
-
 from typing import Iterator, Optional, Union
+
 from wikitextprocessor import NodeKind, WikiNode
 from wiktextract.datautils import data_append, split_at_comma_semi
 from wiktextract.form_descriptions import (

--- a/src/wiktextract/type_utils.py
+++ b/src/wiktextract/type_utils.py
@@ -67,6 +67,7 @@ class FormData(TypedDict, total=False):
     ruby: Union[list[tuple[str, str]], list[Sequence[str]]]
     source: str
     tags: list[str]
+    raw_tags: list[str]
     topics: list[str]
 
 
@@ -157,6 +158,7 @@ class WordData(TypedDict, total=False):
     instances: list[LinkageData]
     lang: str
     lang_code: str
+    literal_meaning: str
     meronyms: list[LinkageData]
     original_title: str
     pos: str


### PR DESCRIPTION
The code is modified from the zh edition code. The new function adds two tags("Simplified Chinese", "Traditional Chinese") and a new "literal_meaning" JSON field. The literal meaning data is commonly provided in Chengyu pages.

Data are added to `base_data` because "zh-forms" is above POS sections and should be included to all the following POS sections data.

Since the code are mostly the same as the zh edition code, tests are not added.

Example pages:
- https://en.wiktionary.org/wiki/未雨綢繆  (Chengyu, has `lit` parameter)
- https://en.wiktionary.org/wiki/僥倖  (has two POS sections)

GitHub issue #676