### PR TITLE
Add `info_templates` field, handle `Template:+obj`

### DIFF
--- a/src/wiktextract/extractor/en/info_templates.py
+++ b/src/wiktextract/extractor/en/info_templates.py
@@ -1,0 +1,137 @@
+"""Handle specific templates, starting with `Template:+obj`.
+Each template should have a properly annotated function
+associated with its name in info_templates, and it should
+handle the given node based on where it is called from
+(`location`), like head or sense.
+"""
+
+import re
+from typing import Callable, Optional, Union
+
+from wikitextprocessor import WikiNode
+from wikitextprocessor.core import TemplateArgs
+from wikitextprocessor.parser import TemplateNode
+from wiktextract.clean import clean_template_args
+from wiktextract.form_descriptions import decode_tags
+from wiktextract.type_utils import PlusObjTemplateData, TemplateData
+from wiktextract.wxr_context import WiktextractContext
+
+InfoNode = Union[str, WikiNode]
+
+InfoReturnTuple = tuple[
+    Optional[TemplateData],  # template data field contents or None
+    Union[str, WikiNode, None],  # template output or None if it should
+    # not be expressed (like `+obj` in heads). Return the original
+    # WikiNode if nothing special needs to happen.
+]
+
+
+InfoTemplateFunc = Callable[
+    [
+        InfoNode,  # the node being checked
+        str,  # location from where this is called
+    ],
+    InfoReturnTuple,
+]
+
+PLUSOBJ_RE = re.compile(r"\[\+([^][=]+)( = ([^][]+))?\]")
+
+
+def plusobj_func(
+    wxr: WiktextractContext, node: InfoNode, loc: str
+) -> InfoReturnTuple:
+    """Parse the output of Template:+obj,
+    `[+infinitive or ergative = meaning]`"""
+
+    if not isinstance(node, TemplateNode):
+        wxr.wtp.error(
+            "plusobj_func: node is note a TemplateNode",
+            sortid="info_templates/45",
+        )
+        return None, None
+
+    text = wxr.wtp.expand(wxr.wtp.node_to_wikitext(node))
+    m = re.search(PLUSOBJ_RE, text)
+    if not m:
+        wxr.wtp.error(
+            f"INFO-TEMPLATES: `Template:+obj` expansion does not "
+            f"match regex: {text}",
+            sortid="info_templates: 78",
+        )
+        return None, None
+    taggers = m.group(1)
+    meaning = m.group(3)
+
+    extra_data: PlusObjTemplateData = {"words": [], "tags": []}
+    if meaning:
+        extra_data["meaning"] = meaning
+
+    for ortags in re.split(r",| or ", taggers):
+        tagsets, _ = decode_tags(ortags)
+        for tagset in tagsets:
+            if "error-unknown-tag" in tagset:
+                extra_data["words"].extend(ortags.split())
+            else:
+                extra_data["tags"].extend(tagset)
+    if not extra_data["words"]:
+        del extra_data["words"]
+    if not extra_data["tags"]:
+        del extra_data["tags"]
+    else:
+        extra_data["tags"] = sorted(set(extra_data["tags"]))
+
+    ret_template_data: TemplateData = {
+        "args": clean_template_args(wxr, node.template_parameters),
+        "name": "+obj",
+        "extra_data": extra_data,
+        "expansion": text,
+    }
+
+    if loc == "head":
+        return ret_template_data, None
+
+    # if "sense", keep text in sense
+    return ret_template_data, text
+
+
+INFO_TEMPLATE_FUNCS: dict[str, InfoTemplateFunc] = {
+    "+obj": plusobj_func,
+}
+
+
+def parse_info_template_node(
+    wxr: WiktextractContext, node: Union[str, WikiNode], loc: str
+) -> tuple[Optional[TemplateData], Optional[str]]:
+    if not isinstance(node, WikiNode):
+        return None, None
+    if (
+        not isinstance(node, TemplateNode)
+        or node.template_name not in INFO_TEMPLATE_FUNCS
+    ):
+        return None, None
+
+    return INFO_TEMPLATE_FUNCS[node.template_name](wxr, node, loc)
+
+
+def parse_info_template_arguments(
+    wxr: WiktextractContext, name: str, args: TemplateArgs, loc: str
+) -> tuple[Optional[TemplateData], Optional[str]]:
+    templ_s = "{{" + name
+    zipped = [(str(k), v) for k, v in args.items()]
+    for k, v in sorted(zipped):
+        if k.isnumeric():
+            templ_s += f"|{v}"
+        else:
+            templ_s += f"|{k}={v}"
+    templ_s += "}}"
+    templ_node = wxr.wtp.parse(templ_s)
+    if len(templ_node.children) > 0:
+        templ_node = wxr.wtp.parse(templ_s).children[0]
+    else:
+        return None, None
+
+    return parse_info_template_node(
+        wxr,
+        templ_node,
+        "sense",
+    )

--- a/src/wiktextract/type_utils.py
+++ b/src/wiktextract/type_utils.py
@@ -46,10 +46,20 @@ class FormOf(TypedDict, total=False):
 LinkData = list[Sequence[str]]
 
 
+class PlusObjTemplateData(TypedDict, total=False):
+    tags: list[str]
+    words: list[str]
+    meaning: str
+
+
+ExtraTemplateData = Union[PlusObjTemplateData]
+
+
 class TemplateData(TypedDict, total=False):
     args: TemplateArgs
     expansion: str
     name: str
+    extra: ExtraTemplateData
 
 
 class DescendantData(TypedDict, total=False):
@@ -155,6 +165,7 @@ class WordData(TypedDict, total=False):
     hypernyms: list[LinkageData]
     hyponyms: list[LinkageData]
     inflection_templates: list[TemplateData]
+    info_templates: list[TemplateData]
     instances: list[LinkageData]
     lang: str
     lang_code: str

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -676,3 +676,99 @@ foo
                 }
             ],
         )
+
+    @patch(
+        "wikitextprocessor.Wtp.get_page",
+        return_value=Page(
+            title="Template:+obj",
+            namespace_id=10,
+            body="[+accusative blu or ergative = MEANING]",
+        ),
+    )
+    def test_plusobj_template(self, mock_get_page):
+        """Testing info_templates, specifically Template:+obj. If +obj is ever
+        changed, this test won't be able to catch it; it would be handy to have
+        tests that check for this, but it's not feasible to require up-to-date
+        databases for testing.
+
+        GitHub issue #667
+        """
+        data = parse_page(
+            self.wxr,
+            "foo",
+            """
+==Czech==
+
+===Noun===
+foo {{+obj|cs|accusative|blu|or|ergative|means=MEANING}}
+
+# foobar {{+obj|cs|accusative|blu|or|ergative|means=MEANING}}
+""",
+        )
+        # from pprint import pp
+        # pp(data)
+        self.assertEqual(
+            data,
+            [
+                {
+                    "info_templates": [
+                        {
+                            "args": {
+                                "1": "cs",
+                                "2": "accusative",
+                                "3": "blu",
+                                "4": "or",
+                                "5": "ergative",
+                                "means": "MEANING",
+                            },
+                            "expansion": "[+accusative blu or "
+                            "ergative = MEANING]",
+                            "extra_data": {
+                                "meaning": "MEANING",
+                                "tags": ["ergative"],
+                                "words": ["accusative", "blu"],
+                            },
+                            "name": "+obj",
+                        }
+                    ],
+                    "lang": "Czech",
+                    "lang_code": "cs",
+                    "pos": "noun",
+                    "senses": [
+                        {
+                            "glosses": [
+                                "foobar [+accusative blu or "
+                                "ergative = MEANING]",
+                                "foobar",
+                            ],
+                            "info_templates": [
+                                {
+                                    "args": {
+                                        "1": "cs",
+                                        "2": "accusative",
+                                        "3": "blu",
+                                        "4": "or",
+                                        "5": "ergative",
+                                        "means": "MEANING",
+                                    },
+                                    "expansion": "[+accusative blu or "
+                                    "ergative = "
+                                    "MEANING]",
+                                    "extra_data": {
+                                        "meaning": "MEANING",
+                                        "tags": ["ergative"],
+                                        "words": ["accusative", "blu"],
+                                    },
+                                    "name": "+obj",
+                                }
+                            ],
+                            "raw_glosses": [
+                                "foobar [+accusative blu or ergative = "
+                                "MEANING]"
+                            ],
+                        }
+                    ],
+                    "word": "foo",
+                }
+            ],
+        )


### PR DESCRIPTION
`info_templates` is similar to etym_templates and
head_templates, but can also have an `extra_data`
field with more specific data relating to the
template in question.

For `+obj`, a vague template that generates text
like `[+accusative]` often meaning 'used with
accusative objects' or `[+dative = means this things]` meaning "if this is with dative it means `this
thing`", but sometimes not, this extra data consists of a `meaning` field from the `means=` parameter,
and `tags` and `words` for parsing the output that isn't the `means=` field.