### PR TITLE
[ru] extract linkage data from "семантика" template in sense lists

### DIFF
--- a/src/wiktextract/extractor/fr/tags.py
+++ b/src/wiktextract/extractor/fr/tags.py
@@ -163,6 +163,7 @@ OTHER_GRAMMATICAL_TAGS: dict[str, str] = {
     "impersonnel": "impersonal",  # Modèle:impers
     "transitif": "transitive",  # Modèle:t
     "intransitif": "intransitive",  # Modèle:i
+    "injurieux": "offensive",  # Modèle:injurieux
 }
 
 # template text before gloss

--- a/src/wiktextract/extractor/ru/linkage.py
+++ b/src/wiktextract/extractor/ru/linkage.py
@@ -9,6 +9,7 @@ from wikitextprocessor.parser import (
 from ...page import clean_node
 from ...wxr_context import WiktextractContext
 from .models import Linkage, WordEntry
+from .section_titles import LINKAGE_TITLES
 from .tags import translate_raw_tags
 
 
@@ -172,3 +173,20 @@ def extract_phrase_section(
 
     for next_level in level_node.find_child(LEVEL_KIND_FLAGS):
         extract_phrase_section(wxr, word_entry, next_level)
+
+
+def process_semantics_template(
+    wxr: WiktextractContext,
+    word_entry: WordEntry,
+    template_node: TemplateNode,
+    sense_index: int,
+) -> None:
+    # https://ru.wiktionary.org/wiki/Шаблон:семантика
+    for key, value in template_node.template_parameters.items():
+        if key in LINKAGE_TITLES and isinstance(value, str):
+            for word in value.split(","):
+                word = word.strip()
+                if word not in ("", "-"):
+                    getattr(word_entry, LINKAGE_TITLES[key]).append(
+                        Linkage(word=word, sense_index=sense_index)
+                    )


### PR DESCRIPTION
"семантика" template is used after gloss text to generate linkage sections under gloss lists