### PR TITLE
[fr] exclude the "pos_id" field from model serialization

### DIFF
--- a/src/wiktextract/extractor/fr/models.py
+++ b/src/wiktextract/extractor/fr/models.py
@@ -115,7 +115,9 @@ class WordEntry(FrenchBaseModel):
     pos_title: str = Field(
         "", description="Original POS title for matching etymology texts"
     )
-    pos_id: str = Field("", description="POS id for matching etymology texts")
+    pos_id: str = Field(
+        "", description="POS id for matching etymology texts", exclude=True
+    )
     etymology_texts: list[str] = Field([], description="Etymology list")
     etymology_examples: list[Example] = Field(
         [], description="Data in 'Attestations historiques' section"

--- a/tests/test_fr_etymology.py
+++ b/tests/test_fr_etymology.py
@@ -80,7 +80,6 @@ class TestEtymology(TestCase):
                     "lang": "Français",
                     "pos": "noun",
                     "pos_title": "Nom commun 1",
-                    "pos_id": "br-nom-1",
                     "etymology_texts": [
                         "Du vieux breton lin (« lac, étang ; liquide, humeur »).",
                         "Du moyen breton lenn.",
@@ -92,7 +91,6 @@ class TestEtymology(TestCase):
                     "lang": "Français",
                     "pos": "noun",
                     "pos_title": "Nom commun 2",
-                    "pos_id": "br-nom-2",
                     "etymology_texts": [
                         "Du vieux breton lenn (« pièce de toile, voile, manteau, rideau »)."
                     ],
@@ -165,7 +163,6 @@ class TestEtymology(TestCase):
                     "lang": "Français",
                     "pos": "noun",
                     "pos_title": "Nom commun 1",
-                    "pos_id": "fr-nom-1",
                     "etymology_texts": [
                         "Du latin domina (« maîtresse de maison »)."
                     ],
@@ -176,7 +173,6 @@ class TestEtymology(TestCase):
                     "lang": "Français",
                     "pos": "noun",
                     "pos_title": "Nom commun 2",
-                    "pos_id": "fr-nom-2",
                     "etymology_texts": [
                         "Du moyen néerlandais dam (« digue »)."
                     ],
@@ -187,7 +183,6 @@ class TestEtymology(TestCase):
                     "lang": "Français",
                     "pos": "intj",
                     "pos_title": "Interjection",
-                    "pos_id": "fr-interj-1",
                     "etymology_texts": [
                         "Abréviation de « Notre-Dame ! » ou de « dame Dieu ! » (« Seigneur Dieu ! »)."
                     ],
@@ -241,7 +236,6 @@ class TestEtymology(TestCase):
                     "lang": "Français",
                     "pos": "intj",
                     "pos_title": "Interjection",
-                    "pos_id": "fr-interj-1",
                     "etymology_texts": [
                         "XIIe siècle, elas ; composé de hé et de las, au sens ancien de « malheureux »."
                     ],
@@ -252,7 +246,6 @@ class TestEtymology(TestCase):
                     "lang": "Français",
                     "pos": "noun",
                     "pos_title": "Nom commun",
-                    "pos_id": "fr-nom-1",
                     "etymology_texts": [
                         "Par substantivation de l’interjection."
                     ],


### PR DESCRIPTION
This field is only used for matching etymology texts, should be removed from the finally JSON data. "pos_title" is kept in case the POS type is unknown.