### PR TITLE
Add a comment of why ignore E501 rule in tests directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ select = [
 "src/wiktextract/taxondata.py" = ["E501"]
 "src/wiktextract/tags.py" = ["E501"]
 "src/wiktextract/table_headers_heuristics_data.py" = ["E501"]
+# ignore long line rule in tests because spaces before HTML tag are
+# parsed as "preformatted" node
 "tests/*" = ["E501"]
 
 [tool.mypy]


### PR DESCRIPTION
Test files should still be formatted with `ruff format` command, ruff could format long line code.