### PR TITLE
More cleaning

### DIFF
--- a/src/wiktextract/english_words.py
+++ b/src/wiktextract/english_words.py
@@ -6,8 +6,8 @@
 #
 # Copyright (c) 2020-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
-import nltk
-from nltk.corpus import brown
+import nltk  # type: ignore[import-untyped]
+from nltk.corpus import brown  # type: ignore[import-untyped]
 
 from .form_descriptions_known_firsts import known_firsts  # w/ our additions
 

--- a/src/wiktextract/extractor/de/section_titles.py
+++ b/src/wiktextract/extractor/de/section_titles.py
@@ -1,7 +1,7 @@
 from ...config import POSSubtitleData
 
 # argument of title template https://de.wiktionary.org/wiki/Vorlage:Wortart
-POS_SECTIONS: POSSubtitleData = {
+POS_SECTIONS: dict[str, POSSubtitleData] = {
     "Abkürzung (Deutsch)": {"pos": "abbrev", "tags": ["abbreviation"]},
     "Abkürzung": {"pos": "abbrev", "tags": ["abbreviation"]},
     "Abtönungspartikel": {"pos": "particle"},

--- a/src/wiktextract/extractor/es/section_titles.py
+++ b/src/wiktextract/extractor/es/section_titles.py
@@ -1,7 +1,7 @@
 from wiktextract.config import POSSubtitleData
 
 # some are template names
-POS_TITLES: POSSubtitleData = {
+POS_TITLES: dict[str, POSSubtitleData] = {
     "abreviatura": {"pos": "abbrev"},
     "acrónimo": {"pos": "abbrev"},
     "adjetivo cardinal": {"pos": "num", "tags": ["cardinal"]},

--- a/src/wiktextract/extractor/fr/section_types.py
+++ b/src/wiktextract/extractor/fr/section_types.py
@@ -3,7 +3,7 @@ from wiktextract.config import POSSubtitleData
 # the keys are the first argument of the `S` template
 # https://fr.wiktionary.org/wiki/Modèle:S
 # https://fr.wiktionary.org/wiki/Wiktionnaire:Liste_des_sections
-POS_SECTIONS: POSSubtitleData = {
+POS_SECTIONS: dict[str, POSSubtitleData] = {
     "adj": {"pos": "adj"},
     "adj-dém": {"pos": "adj", "tags": ["demonstrative"]},
     "adj-excl": {"pos": "adj", "tags": ["exclamatory"]},

--- a/src/wiktextract/extractor/ru/section_titles.py
+++ b/src/wiktextract/extractor/ru/section_titles.py
@@ -1,6 +1,6 @@
 from wiktextract.config import POSSubtitleData
 
-POS_TITLES: POSSubtitleData = {
+POS_TITLES: dict[str, POSSubtitleData] = {
     "аббревиатура": {"pos": "abbrev"},
     "глагол": {"pos": "verb"},
     "деепричастие": {"pos": "gerund"},
@@ -16,7 +16,7 @@ POS_TITLES: POSSubtitleData = {
     "наречие": {"pos": "adv"},
 }
 
-POS_TEMPLATE_NAMES: POSSubtitleData = {
+POS_TEMPLATE_NAMES: dict[str, POSSubtitleData] = {
     "abbrev": {"pos": "abbrev", "tags": ["abbreviation"]},
     "adv": {"pos": "adv"},
     "affix": {"pos": "affix"},

--- a/src/wiktextract/extractor/ruby.py
+++ b/src/wiktextract/extractor/ruby.py
@@ -43,7 +43,7 @@ def parse_ruby(
 def extract_ruby(
     wxr: WiktextractContext,
     contents: GeneralNode,
-) -> tuple[list[tuple[str, str]], list[Union[WikiNode, str]]]:
+) -> tuple[list[tuple[str, ...]], list[Union[WikiNode, str]]]:
     # If contents is a list, process each element separately
     extracted = []
     new_contents = []

--- a/src/wiktextract/extractor/zh/section_titles.py
+++ b/src/wiktextract/extractor/zh/section_titles.py
@@ -1,6 +1,6 @@
 from wiktextract.config import POSSubtitleData
 
-POS_TITLES: POSSubtitleData = {
+POS_TITLES: dict[str, POSSubtitleData] = {
     "不及物动词": {"pos": "verb", "tags": ["intransitive"]},
     "不及物動詞": {
         "debug": "part-of-speech Intransitive verb is proscribed",

--- a/src/wiktextract/form_descriptions.py
+++ b/src/wiktextract/form_descriptions.py
@@ -53,6 +53,7 @@ from .tags import (
 )
 from .taxondata import known_species
 from .topics import topic_generalize_map, valid_topics
+from .type_utils import TranslationData
 
 # Tokenizer for classify_desc()
 tokenizer = TweetTokenizer()
@@ -2707,7 +2708,7 @@ def parse_pronunciation_tags(
 
 
 def parse_translation_desc(
-    wxr: WiktextractContext, lang: str, text: str, tr: str
+    wxr: WiktextractContext, lang: str, text: str, tr: TranslationData
 ) -> None:
     assert isinstance(wxr, WiktextractContext)
     assert isinstance(lang, str)  # The language of ``text``

--- a/src/wiktextract/translations.py
+++ b/src/wiktextract/translations.py
@@ -544,8 +544,8 @@ def parse_translation_item_text(
                 tr["code"] = langcode
             if tags:
                 tr["tags"] = list(tags)
-                for t in tagsets:
-                    tr["tags"].extend(t)
+                for ttup in tagsets:
+                    tr["tags"].extend(ttup)
             # topics is never populated, so it's always empty
             # if topics:
             #     tr["topics"] = list(topics)
@@ -568,8 +568,8 @@ def parse_translation_item_text(
                 cls = classify_desc(par, no_unknown_starts=True)
                 if cls == "tags":
                     tagsets2, topics2 = decode_tags(par)
-                    for t in tagsets2:
-                        data_extend(tr, "tags", t)
+                    for ttup in tagsets2:
+                        data_extend(tr, "tags", ttup)
                     data_extend(tr, "topics", topics2)
                     part = rest
 
@@ -583,8 +583,8 @@ def parse_translation_item_text(
                 cls = classify_desc(par, no_unknown_starts=True)
                 if cls == "tags":
                     tagsets2, topics2 = decode_tags(par)
-                    for t in tagsets2:
-                        data_extend(tr, "tags", t)
+                    for ttup in tagsets2:
+                        data_extend(tr, "tags", ttup)
                     data_extend(tr, "topics", topics2)
                     part = rest
 
@@ -600,8 +600,8 @@ def parse_translation_item_text(
                     # print("par={!r} cls={!r}".format(par, cls))
                     if cls == "tags":
                         tagsets2, topics2 = decode_tags(par)
-                        for t in tagsets2:
-                            data_extend(tr, "tags", t)
+                        for ttup in tagsets2:
+                            data_extend(tr, "tags", ttup)
                         data_extend(tr, "topics", topics2)
                         part = rest
                     elif cls == "english":
@@ -661,6 +661,8 @@ def parse_translation_item_text(
             # Certain values indicate it is not actually a translation.
             # See definition of tr_ignore_re to adjust.
             m = re.search(tr_ignore_re, part)
+            w: Optional[str] = None
+
             if m and (
                 m.start() != 0 or m.end() != len(part) or len(part.split()) > 1
             ):
@@ -721,22 +723,23 @@ def parse_translation_item_text(
                 continue
 
             # Split if it contains no spaces
-            alts = [w]
-            if " " not in w:
-                # If no spaces, split by separator
-                alts = re.split(r"/|／", w)
-            # Note: there could be remaining slashes, but they are
-            # sometimes used in ways we cannot resolve programmatically.
-            # Create translations for each alternative.
-            for alt in alts:
-                alt = alt.strip()
-                tr1 = copy.deepcopy(tr)
-                if alt.startswith("*") or alt.startswith(":"):
-                    alt = alt[1:].strip()
-                if not alt:
-                    continue
-                tr1["word"] = alt
-                data_append(data, "translations", tr1)
+            if w:
+                alts = [w]
+                if " " not in w:
+                    # If no spaces, split by separator
+                    alts = re.split(r"/|／", w)
+                # Note: there could be remaining slashes, but they are
+                # sometimes used in ways we cannot resolve programmatically.
+                # Create translations for each alternative.
+                for alt in alts:
+                    alt = alt.strip()
+                    tr1 = copy.deepcopy(tr)
+                    if alt.startswith("*") or alt.startswith(":"):
+                        alt = alt[1:].strip()
+                    if not alt:
+                        continue
+                    tr1["word"] = alt
+                    data_append(data, "translations", tr1)
 
     # Return the language name, in case we have subitems
     return lang

--- a/src/wiktextract/wiktwords.py
+++ b/src/wiktextract/wiktwords.py
@@ -68,7 +68,7 @@ def process_single_page(
     else:
         # Get page content from database
         title = path_or_title
-        text = wxr.wtp.get_page_body(title, 0)
+        text = wxr.wtp.get_page_body(title, 0)  # type: ignore[assignment]
         if text is None:
             logger.error(f"Can't find page '{title}' in the database.")
             return
@@ -79,7 +79,7 @@ def process_single_page(
     if (
         args.use_thesaurus
         and wxr.config.extract_thesaurus_pages
-        and thesaurus_linkage_number(wxr.thesaurus_db_conn) == 0
+        and thesaurus_linkage_number(wxr.thesaurus_db_conn) == 0  # type: ignore[arg-type]
     ):
         extract_thesaurus_data(wxr)
     # Parse the page

--- a/src/wiktextract/wxr_context.py
+++ b/src/wiktextract/wxr_context.py
@@ -25,8 +25,8 @@ class WiktextractContext:
         self.lang = None
         self.word = None
         self.pos = None
-        self.thesaurus_db_path = wtp.db_path.with_stem(
-            f"{wtp.db_path.stem}_thesaurus"
+        self.thesaurus_db_path = wtp.db_path.with_stem(  # type: ignore[union-attr]
+            f"{wtp.db_path.stem}_thesaurus"  # type: ignore[union-attr]
         )
         self.thesaurus_db_conn = (
             init_thesaurus_db(self.thesaurus_db_path)
@@ -43,17 +43,17 @@ class WiktextractContext:
                 self.thesaurus_db_path, check_same_thread=check_same_thread
             )
         self.wtp.db_conn = sqlite3.connect(
-            self.wtp.db_path, check_same_thread=check_same_thread
+            self.wtp.db_path, check_same_thread=check_same_thread  # type: ignore[arg-type]
         )
 
     def remove_unpicklable_objects(self) -> None:
         # remove these variables before passing the `WiktextractContext` object
         # to worker processes
         if self.config.extract_thesaurus_pages:
-            self.thesaurus_db_conn.close()
+            self.thesaurus_db_conn.close()  # type: ignore[union-attr]
         self.thesaurus_db_conn = None
         self.wtp.db_conn.close()
-        self.wtp.db_conn = None
+        self.wtp.db_conn = None  # type: ignore[assignment]
         self.wtp.lua = None
         self.wtp.lua_invoke = None
         self.wtp.lua_reset_env = None

--- a/tests/test_inflection_sh.py
+++ b/tests/test_inflection_sh.py
@@ -1148,7 +1148,7 @@ class InflTests(unittest.TestCase):
 |}
 
 </div></div>
-""")  # noqa: E501
+""")  # noqa: E501, W291
         expected = {
         "forms": [
             {


### PR DESCRIPTION
Fixing annotations, mostly.

I've looked a bit at mypy output for the other extractors, and it's helped to find issues with annotations in wikitextprocessor and elsewhere in wiktextract (for example adding some `@overload` stuff). @xxyzz do you mind if I start poking around in there? It should be non-destructive (hopefully).