### PR TITLE
Remove taxonomy in classify_desc()

### DIFF
--- a/src/wiktextract/form_descriptions.py
+++ b/src/wiktextract/form_descriptions.py
@@ -51,7 +51,7 @@ from .tags import (
     xlat_head_map,
     xlat_tags_map,
 )
-from .taxondata import known_species
+from .taxondata import known_species, known_species_re
 from .topics import topic_generalize_map, valid_topics
 from .type_utils import TranslationData
 
@@ -3258,6 +3258,11 @@ def classify_desc(
             # English
             if have_non_english >= len(lst) - 1 and have_non_english > 0:
                 return "taxonomic"
+
+    # Get rid of taxonomic species names so that they don't mess up
+    # the heuristics for whether something is "English"; you can have
+    # these in English text (and not).
+    desc1 = known_species_re.sub("", desc1)
 
     # If all words are in our English dictionary, interpret as English.
     # [ -~] is regex black magic, "all characters from space to tilde"


### PR DESCRIPTION
This is a horrible way to do this, because it's
pretty costly. Loading and compiling the regex
pattern from the data in taxondata.py takes many seconds; happily, at least tests seem to only take a marginally longer time than before because it only needs to be done once, but still. Compiling half a million+ lines into a regex pattern takes time, and I'm just committing this to show how horrible it is.

This is meant to handle examples such as:

ucho/Czech
```
.##: {{coi|cs|babí ucho|lit=granny's ear|t=greater plaintain ({{taxfmt|Plantago major|species}})}}
.##: {{coi|cs|volské ucho|lit=ox's ear|t=greater plaintain ({{taxfmt|Plantago major|species}})}}
.##: {{coi|cs|babské ucho|lit=granny's ear|t=common sage ({{taxfmt|Salvia officinalis|species}})}}
.##: {{coi|cs|lví ucho|lit=lion's ear|t={{taxlink|Leonotis nepetifolia|species}}}}
.##: {{coi|cs|sloní ucho|lit=elephant's ear|t=''[[Haemanthus albiflos]]''}}
.##: {{coi|cs|mořské ucho|lit=sea ear|t={{taxlink|Haliotis tuberculata|species}}}}
```

with outputs like `greater plaintain (Plantago major) (literally, “granny's ear”)`

The taxonomic names block classify_desc from determining that this is "english". By removing them (after handling all the other taxonomy special cases in the code before this) the heuristics work properly again.