### PR TITLE
[fr] find etymology POS title text inside italic node

### DIFF
--- a/src/wiktextract/extractor/fr/etymology.py
+++ b/src/wiktextract/extractor/fr/etymology.py
@@ -151,6 +151,17 @@ def find_pos_in_etymology_list(
                         ).lstrip(") "),
                         categories.get("categories", []),
                     )
+            if index <= 1:  # first node is empty string
+                return (
+                    "",
+                    clean_node(wxr, None, node).strip("() "),
+                    clean_node(
+                        wxr,
+                        categories,
+                        list_item_node.children[index + 1 :],
+                    ),
+                    categories.get("categories", []),
+                )
 
 
 def insert_etymology_data(

--- a/src/wiktextract/extractor/zh/page.py
+++ b/src/wiktextract/extractor/zh/page.py
@@ -106,7 +106,7 @@ def parse_section(
         elif wxr.config.capture_linkages and subtitle in LINKAGE_TITLES:
             extract_linkages(
                 wxr,
-                page_data,
+                page_data if len(page_data) > 0 else [base_data],
                 node.children,
                 LINKAGE_TITLES[subtitle],
                 "",
@@ -118,17 +118,17 @@ def parse_section(
                 page_data.append(base_data.model_copy(deep=True))
             extract_translation(wxr, page_data, node)
         elif wxr.config.capture_inflections and subtitle in INFLECTION_TITLES:
-            if len(page_data) == 0:
-                page_data.append(base_data.model_copy(deep=True))
-            extract_inflections(wxr, page_data, node)
+            extract_inflections(
+                wxr, page_data if len(page_data) > 0 else [base_data], node
+            )
         elif wxr.config.capture_descendants and subtitle in DESCENDANTS_TITLES:
-            if len(page_data) == 0:
-                page_data.append(base_data.model_copy(deep=True))
-            extract_descendants(wxr, node, page_data[-1])
+            extract_descendants(
+                wxr, node, page_data[-1] if len(page_data) > 0 else base_data
+            )
         elif subtitle in NOTES_TITLES:
-            if len(page_data) == 0:
-                page_data.append(base_data.model_copy(deep=True))
-            extract_note(wxr, page_data, node)
+            extract_note(
+                wxr, page_data if len(page_data) > 0 else [base_data], node
+            )
         else:
             wxr.wtp.debug(
                 f"Unhandled subtitle: {subtitle}",

--- a/src/wiktextract/extractor/zh/section_titles.py
+++ b/src/wiktextract/extractor/zh/section_titles.py
@@ -408,4 +408,4 @@ TRANSLATIONS_TITLES: frozenset[str] = frozenset(["翻譯", "翻译"])
 
 DESCENDANTS_TITLES: frozenset[str] = frozenset(["派生語彙"])
 
-NOTES_TITLES: frozenset[str] = frozenset(["使用說明"])
+NOTES_TITLES: frozenset[str] = frozenset(["使用說明", "用法說明"])

--- a/tests/test_fr_etymology.py
+++ b/tests/test_fr_etymology.py
@@ -360,3 +360,16 @@ etymology text
                 ),
             },
         )
+
+    def test_italic_pos_title_no_id(self):
+        self.wxr.wtp.start_page("appel du pied")
+        root = self.wxr.wtp.parse(": ''(Locution nominale 1)'' etymology text.")
+        etymology_data = extract_etymology(self.wxr, root, None)
+        self.assertEqual(
+            etymology_data,
+            {
+                ("", "Locution nominale 1"): EtymologyData(
+                    texts=["etymology text."]
+                )
+            },
+        )

--- a/tests/test_zh_linkage.py
+++ b/tests/test_zh_linkage.py
@@ -4,6 +4,7 @@ from wikitextprocessor import Wtp
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.zh.linkage import extract_linkages
 from wiktextract.extractor.zh.models import Sense, WordEntry
+from wiktextract.extractor.zh.page import parse_page
 from wiktextract.thesaurus import close_thesaurus_db
 from wiktextract.wxr_context import WiktextractContext
 
@@ -87,5 +88,35 @@ class TestLinkage(TestCase):
             ],
             [
                 {"tags": ["figuratively"], "word": "沙漠之舟"},
+            ],
+        )
+
+    def test_linkage_above_pos(self):
+        self.wxr.wtp.add_page(
+            "Template:alter",
+            10,
+            '<span class="Latn" lang="en">[[Tec#英語|-{Tec}-]]</span>'
+        )
+        self.assertEqual(
+            parse_page(
+                self.wxr,
+                "'Tec",
+                """==英語==
+===替代形式===
+* {{alter|en|Tec}}
+
+===專有名詞===
+
+# 偵探漫畫""",
+            ),
+            [
+                {
+                    "lang": "英語",
+                    "lang_code": "en",
+                    "pos": "name",
+                    "senses": [{"glosses": ["偵探漫畫"]}],
+                    "synonyms": [{"word": "Tec"}],
+                    "word": "'Tec",
+                }
             ],
         )


### PR DESCRIPTION
Usually inside a link, but texts are also used.