### PR TITLE
In examples, "taxonomic" is the same as "english"

### DIFF
--- a/src/wiktextract/english_words.py
+++ b/src/wiktextract/english_words.py
@@ -1918,6 +1918,17 @@ not_english_words_1 = set(
         "novo",
         "pronto",
         "que",
+        "extortionary",
+        "democracy",
+        "Mrs",
+        "physical",
+        "property",
+        "ransomware",
+        "program",
+        "epiglottis",
+        "laryngeal",
+        "flap",
+        "literally",
     ]
 )
 

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -3621,7 +3621,12 @@ def parse_language(
                         ).strip()
                         == parts[0].strip()
                         and clean_value(
-                            wxr, example_template_args[0].get(3, "")
+                            wxr,
+                            (
+                                example_template_args[0].get(3)
+                                or example_template_args[0].get("translation")
+                                or example_template_args[0].get("t", "")
+                            ),
                         ).strip()
                         == parts[1].strip()
                     ):

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -2919,7 +2919,8 @@ def parse_language(
                         if pos.lower() not in POS_TITLES:
                             wxr.wtp.debug(
                                 "unhandled see translation subpage: "
-                                "language={} sub={} wxr.wtp.subsection={}".format(
+                                "language={} sub={} "
+                                "wxr.wtp.subsection={}".format(
                                     language, sub, wxr.wtp.subsection
                                 ),
                                 sortid="page/2478",
@@ -3615,7 +3616,16 @@ def parse_language(
                     if (
                         len(example_template_args) == 1
                         and len(parts) == 2
-                        and len(example_template_args[0]) == 3
+                        and len(example_template_args[0])
+                        - (
+                            # horrible kludge to ignore these arguments
+                            # when calculating how many there are
+                            sum(
+                                s in example_template_args[0]
+                                for s in ("inline", "noenum", "nocat", "sort")
+                            )
+                        )
+                        == 3
                         and clean_value(
                             wxr, example_template_args[0].get(2, "")
                         ).strip()

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -2399,10 +2399,7 @@ def parse_language(
                                     and v[0][0] == ":"
                                 ):
                                     v = [v[0][1:]] + list(v[1:])  # type:ignore
-                                if (
-                                    isinstance(v[0], str)
-                                    and not v[0].isalnum()
-                                ):
+                                if isinstance(v[0], str) and not v[0].isalnum():
                                     links_that_should_not_be_split.append(
                                         "".join(v[0])
                                     )  # type: ignore
@@ -2918,8 +2915,7 @@ def parse_language(
                         if pos.lower() not in POS_TITLES:
                             wxr.wtp.debug(
                                 "unhandled see translation subpage: "
-                                "language={} sub={} wxr.wtp.subsection={}"
-                                .format(
+                                "language={} sub={} wxr.wtp.subsection={}".format(
                                     language, sub, wxr.wtp.subsection
                                 ),
                                 sortid="page/2478",
@@ -3632,8 +3628,9 @@ def parse_language(
                         # and the output to each other.
                         lines = [parts[0].strip()]
                         tr = parts[1].strip()
-                    elif (
-                        len(parts) == 2 and classify_desc(parts[1]) == "english"
+                    elif len(parts) == 2 and classify_desc(parts[1]) in (
+                        "english",
+                        "taxonomic",
                     ):
                         # These other branches just do some simple heuristics w/
                         # the expanded output of the template (if applicable).
@@ -3643,16 +3640,16 @@ def parse_language(
                         len(parts) == 3
                         and classify_desc(parts[1])
                         in ("romanization", "english")
-                        and classify_desc(parts[2]) == "english"
+                        and classify_desc(parts[2]) in ("english", "taxonomic")
                     ):
                         lines = [parts[0].strip()]
                         roman = parts[1].strip()
                         tr = parts[2].strip()
                     else:
                         parts = re.split(r"\s+-\s+", lines[0])
-                        if (
-                            len(parts) == 2
-                            and classify_desc(parts[1]) == "english"
+                        if len(parts) == 2 and classify_desc(parts[1]) in (
+                            "english",
+                            "taxonomic",
                         ):
                             lines = [parts[0].strip()]
                             tr = parts[1].strip()
@@ -3675,12 +3672,13 @@ def parse_language(
                         if (
                             lang_code != "en"
                             and len(lines) >= 2
-                            and classify_desc(lines[-1]) == "english"
+                            and classify_desc(lines[-1])
+                            in ("english", "taxonomic")
                         ):
                             i = len(lines) - 1
-                            while (
-                                i > 1
-                                and classify_desc(lines[i - 1]) == "english"
+                            while i > 1 and classify_desc(lines[i - 1]) in (
+                                "english",
+                                "taxonomic",
                             ):
                                 i -= 1
                             tr = "\n".join(lines[i:])
@@ -3696,22 +3694,27 @@ def parse_language(
                     elif lang_code != "en" and len(lines) == 2:
                         cls1 = classify_desc(lines[0])
                         cls2 = classify_desc(lines[1])
-                        if cls2 == "english" and cls1 != "english":
+                        if (
+                            cls2 in ("english", "taxonomic")
+                            and cls1 != "english"
+                        ):
                             tr = lines[1]
                             lines = [lines[0]]
-                        elif cls1 == "english" and cls2 != "english":
+                        elif (
+                            cls1 in ("english", "taxonomic")
+                            and cls2 != "english"
+                        ):
                             tr = lines[0]
                             lines = [lines[1]]
-                        elif (
-                            re.match(r"^[#*]*:+", lines[1])
-                            and classify_desc(
-                                re.sub(r"^[#*:]+\s*", "", lines[1])
-                            )
-                            == "english"
-                        ):
+                        elif re.match(r"^[#*]*:+", lines[1]) and classify_desc(
+                            re.sub(r"^[#*:]+\s*", "", lines[1])
+                        ) in ("english", "taxonomic"):
                             tr = re.sub(r"^[#*:]+\s*", "", lines[1])
                             lines = [lines[0]]
-                        elif cls1 == "english" and cls2 == "english":
+                        elif cls1 == "english" and cls2 in (
+                            "english",
+                            "taxonomic",
+                        ):
                             # Both were classified as English, but
                             # presumably one is not.  Assume first is
                             # non-English, as that seems more common.
@@ -3727,7 +3730,7 @@ def parse_language(
                         cls3 = classify_desc(lines[2])
                         if (
                             cls3 == "english"
-                            and cls2 in ["english", "romanization"]
+                            and cls2 in ("english", "romanization")
                             and cls1 != "english"
                         ):
                             tr = lines[2].strip()
@@ -3747,9 +3750,9 @@ def parse_language(
                         cls1 = classify_desc(lines[-1])
                         if cls1 == "english":
                             i = len(lines) - 1
-                            while (
-                                i > 1
-                                and classify_desc(lines[i - 1]) == "english"
+                            while i > 1 and classify_desc(lines[i - 1]) == (
+                                "english",
+                                "taxonomic",
                             ):
                                 i -= 1
                             tr = "\n".join(lines[i:])
@@ -3774,7 +3777,7 @@ def parse_language(
                                 original_lines.append(i)
                             elif cl == "romanization":
                                 roman += line
-                            elif cl == "english":
+                            elif cl in ("english", "taxonomic"):
                                 tr += line
                         lines = [lines[i] for i in original_lines]
 
@@ -3796,14 +3799,16 @@ def parse_language(
                 subtext = "\n".join(x for x in lines if x)
                 if not tr and lang_code != "en":
                     m = re.search(r"([.!?])\s+\(([^)]+)\)\s*$", subtext)
-                    if m and classify_desc(m.group(2)) == "english":
+                    if m and classify_desc(m.group(2)) in (
+                        "english",
+                        "taxonomic",
+                    ):
                         tr = m.group(2)
                         subtext = subtext[: m.start()] + m.group(1)
                     elif lines:
                         parts = re.split(r"\s*[―—]+\s*", lines[0])
-                        if (
-                            len(parts) == 2
-                            and classify_desc(parts[1]) == "english"
+                        if len(parts) == 2 and classify_desc(parts[1]) in (
+                            "english, taxonomic"
                         ):
                             subtext = parts[0].strip()
                             tr = parts[1].strip()

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -82,6 +82,10 @@ from .section_titles import (
 )
 from .unsupported_titles import unsupported_title_map
 
+# When determining whether a string is 'english', classify_desc
+# might return 'taxonomic' which is English text 99% of the time.
+ENGLISH_TEXTS = ("english", "taxonomic")
+
 # Matches head tag
 HEAD_TAG_RE = re.compile(
     r"^(head|Han char|arabic-noun|arabic-noun-form|"
@@ -3628,9 +3632,9 @@ def parse_language(
                         # and the output to each other.
                         lines = [parts[0].strip()]
                         tr = parts[1].strip()
-                    elif len(parts) == 2 and classify_desc(parts[1]) in (
-                        "english",
-                        "taxonomic",
+                    elif (
+                        len(parts) == 2
+                        and classify_desc(parts[1]) in ENGLISH_TEXTS
                     ):
                         # These other branches just do some simple heuristics w/
                         # the expanded output of the template (if applicable).
@@ -3640,16 +3644,16 @@ def parse_language(
                         len(parts) == 3
                         and classify_desc(parts[1])
                         in ("romanization", "english")
-                        and classify_desc(parts[2]) in ("english", "taxonomic")
+                        and classify_desc(parts[2]) in ENGLISH_TEXTS
                     ):
                         lines = [parts[0].strip()]
                         roman = parts[1].strip()
                         tr = parts[2].strip()
                     else:
                         parts = re.split(r"\s+-\s+", lines[0])
-                        if len(parts) == 2 and classify_desc(parts[1]) in (
-                            "english",
-                            "taxonomic",
+                        if (
+                            len(parts) == 2
+                            and classify_desc(parts[1]) in ENGLISH_TEXTS
                         ):
                             lines = [parts[0].strip()]
                             tr = parts[1].strip()
@@ -3672,13 +3676,12 @@ def parse_language(
                         if (
                             lang_code != "en"
                             and len(lines) >= 2
-                            and classify_desc(lines[-1])
-                            in ("english", "taxonomic")
+                            and classify_desc(lines[-1]) in ENGLISH_TEXTS
                         ):
                             i = len(lines) - 1
-                            while i > 1 and classify_desc(lines[i - 1]) in (
-                                "english",
-                                "taxonomic",
+                            while (
+                                i > 1
+                                and classify_desc(lines[i - 1]) in ENGLISH_TEXTS
                             ):
                                 i -= 1
                             tr = "\n".join(lines[i:])
@@ -3694,27 +3697,22 @@ def parse_language(
                     elif lang_code != "en" and len(lines) == 2:
                         cls1 = classify_desc(lines[0])
                         cls2 = classify_desc(lines[1])
-                        if (
-                            cls2 in ("english", "taxonomic")
-                            and cls1 != "english"
-                        ):
+                        if cls2 in ENGLISH_TEXTS and cls1 != "english":
                             tr = lines[1]
                             lines = [lines[0]]
-                        elif (
-                            cls1 in ("english", "taxonomic")
-                            and cls2 != "english"
-                        ):
+                        elif cls1 in ENGLISH_TEXTS and cls2 != "english":
                             tr = lines[0]
                             lines = [lines[1]]
-                        elif re.match(r"^[#*]*:+", lines[1]) and classify_desc(
-                            re.sub(r"^[#*:]+\s*", "", lines[1])
-                        ) in ("english", "taxonomic"):
+                        elif (
+                            re.match(r"^[#*]*:+", lines[1])
+                            and classify_desc(
+                                re.sub(r"^[#*:]+\s*", "", lines[1])
+                            )
+                            in ENGLISH_TEXTS
+                        ):
                             tr = re.sub(r"^[#*:]+\s*", "", lines[1])
                             lines = [lines[0]]
-                        elif cls1 == "english" and cls2 in (
-                            "english",
-                            "taxonomic",
-                        ):
+                        elif cls1 == "english" and cls2 in ENGLISH_TEXTS:
                             # Both were classified as English, but
                             # presumably one is not.  Assume first is
                             # non-English, as that seems more common.
@@ -3750,9 +3748,9 @@ def parse_language(
                         cls1 = classify_desc(lines[-1])
                         if cls1 == "english":
                             i = len(lines) - 1
-                            while i > 1 and classify_desc(lines[i - 1]) == (
-                                "english",
-                                "taxonomic",
+                            while (
+                                i > 1
+                                and classify_desc(lines[i - 1]) == ENGLISH_TEXTS
                             ):
                                 i -= 1
                             tr = "\n".join(lines[i:])
@@ -3777,7 +3775,7 @@ def parse_language(
                                 original_lines.append(i)
                             elif cl == "romanization":
                                 roman += line
-                            elif cl in ("english", "taxonomic"):
+                            elif cl in ENGLISH_TEXTS:
                                 tr += line
                         lines = [lines[i] for i in original_lines]
 
@@ -3799,16 +3797,14 @@ def parse_language(
                 subtext = "\n".join(x for x in lines if x)
                 if not tr and lang_code != "en":
                     m = re.search(r"([.!?])\s+\(([^)]+)\)\s*$", subtext)
-                    if m and classify_desc(m.group(2)) in (
-                        "english",
-                        "taxonomic",
-                    ):
+                    if m and classify_desc(m.group(2)) in ENGLISH_TEXTS:
                         tr = m.group(2)
                         subtext = subtext[: m.start()] + m.group(1)
                     elif lines:
                         parts = re.split(r"\s*[―—]+\s*", lines[0])
-                        if len(parts) == 2 and classify_desc(parts[1]) in (
-                            "english, taxonomic"
+                        if (
+                            len(parts) == 2
+                            and classify_desc(parts[1]) in ENGLISH_TEXTS
                         ):
                             subtext = parts[0].strip()
                             tr = parts[1].strip()

--- a/src/wiktextract/extractor/ruby.py
+++ b/src/wiktextract/extractor/ruby.py
@@ -43,7 +43,7 @@ def parse_ruby(
 def extract_ruby(
     wxr: WiktextractContext,
     contents: GeneralNode,
-) -> tuple[list[tuple[str, ...]], list[Union[WikiNode, str]]]:
+) -> tuple[list[tuple[str, str]], list[Union[WikiNode, str]]]:
     # If contents is a list, process each element separately
     extracted = []
     new_contents = []

--- a/tests/test_en_misc.py
+++ b/tests/test_en_misc.py
@@ -1,0 +1,68 @@
+# Tests for miscellanous functions in the En extractor
+#
+# Copyright (c) 2021 Tatu Ylonen.  See file LICENSE and https://ylonen.org
+
+from unittest import TestCase
+
+from wiktextract.extractor.en.page import synch_splits_with_args
+
+
+class MiscTests(TestCase):
+    def test_synch_splits_with_args1(self) -> None:
+        # "―" and "—" are the accepted hyphens (somewhere in the high
+        # unicode range, so NOT "–", which looks identical...
+        res = synch_splits_with_args("Foo ― Bar", {2: "Foo", 3: "Bar"})
+        self.assertEqual(res, ["Foo", "Bar"])
+
+    def test_synch_splits_with_args2(self) -> None:
+        # The other accepted hyphen, "—"
+        res = synch_splits_with_args("Foo — Bar", {2: "Foo", 3: "Bar"})
+        self.assertEqual(res, ["Foo", "Bar"])
+
+    def test_synch_splits_with_args3(self) -> None:
+        # Somethings gone wrong
+        res = synch_splits_with_args("Foo Bar", {2: "Foo", 3: "Bar"})
+        self.assertEqual(res, None)
+
+    def test_synch_splits_with_args4(self) -> None:
+        # Result None because there's no " ― " in the arguments
+        res = synch_splits_with_args("Foo ―  ― Bar", {2: "Foo", 3: "Bar"})
+        self.assertEqual(res, None)
+
+    def test_synch_splits_with_args5(self) -> None:
+        res = synch_splits_with_args(
+            "Foo ― baz ― Bar", {2: "Foo ― baz", 3: "Bar"}
+        )
+        self.assertEqual(res, ["Foo ― baz", "Bar"])
+
+    def test_synch_splits_with_args6(self) -> None:
+        res = synch_splits_with_args(
+            "Foo ― baz ― Bar ― fizz", {2: "Foo ― baz", 3: "Bar ― fizz"}
+        )
+        self.assertEqual(res, ["Foo ― baz", "Bar ― fizz"])
+
+    def test_synch_splits_with_args7(self) -> None:
+        res = synch_splits_with_args(
+            "Foo baz ― Bar ― fizz", {2: "Foo baz", 3: "Bar ― fizz"}
+        )
+        self.assertEqual(res, ["Foo baz", "Bar ― fizz"])
+
+    def test_synch_splits_with_args8(self) -> None:
+        res = synch_splits_with_args(
+            "Foo baz ― Bar ― fizz ― three", {2: "Foo baz", 3: "Bar ― fizz"}
+        )
+        self.assertEqual(res, ["Foo baz", "Bar ― fizz", "three"])
+
+    def test_synch_splits_with_args9(self) -> None:
+        res = synch_splits_with_args(
+            "Foo baz ― Bar ― fizz ― three ― four",
+            {2: "Foo baz", 3: "Bar ― fizz"},
+        )
+        self.assertEqual(res, ["Foo baz", "Bar ― fizz", "three", "four"])
+
+    def test_synch_splits_with_args10(self) -> None:
+        res = synch_splits_with_args(
+            "Foo baz ― Bar ― fizz ― fuzz ― three ― four",
+            {2: "Foo baz", 3: "Bar ― fizz ― fuzz"},
+        )
+        self.assertEqual(res, ["Foo baz", "Bar ― fizz ― fuzz", "three", "four"])


### PR DESCRIPTION
Issue #604, Czech translations (continued)

In translations like

```
ví ucho ― Leonotis nepetifolia (literally, “lion's ear”)
```

the translation part starting with "Leonotis" is has its classification returned as "taxonomic" due to the heuristics used in classify_desc().

I've been trying to kludge something better here, but for this specifically the right call to make is to change it so that if a description is either "english" or "taxonomic", that counts as English. There is not meaningful distinction here in the examples when trying to figure out translation stuff.

The heuristics could be better, which is what I tried to figure out, but it works fine for now...