### PR TITLE
[de] add examples that don't have matched gloss

### DIFF
--- a/src/wiktextract/extractor/de/example.py
+++ b/src/wiktextract/extractor/de/example.py
@@ -3,7 +3,7 @@ from wikitextprocessor.parser import LevelNode
 
 from ...page import clean_node
 from ...wxr_context import WiktextractContext
-from .models import Example, WordEntry
+from .models import Example, Sense, WordEntry
 from .utils import find_and_remove_child, match_senseid
 
 REF_KEY_MAP = {
@@ -57,11 +57,15 @@ def extract_examples(
             if len(example_text) > 0:
                 example_data.text = example_text
                 if len(senseid) > 0:
+                    find_sense = False
                     for sense in word_entry.senses:
                         if sense.senseid == senseid:
-                            sense.examples.append(
-                                example_data.model_copy(deep=True)
-                            )
+                            sense.examples.append(example_data)
+                            find_sense = True
+                    if not find_sense:
+                        new_sense = Sense(senseid=senseid, tags=["no-gloss"])
+                        new_sense.examples.append(example_data)
+                        word_entry.senses.append(new_sense)
                 else:
                     wxr.wtp.debug(
                         f"Found example data without senseid: {example_data}",

--- a/tests/test_de_example.py
+++ b/tests/test_de_example.py
@@ -49,6 +49,11 @@ class TestDEExample(unittest.TestCase):
                     "examples": [{"text": "example2"}],
                     "senseid": "2",
                 },
+                {
+                    "examples": [{"text": "example3"}],
+                    "senseid": "3",
+                    "tags": ["no-gloss"],
+                },
             ],
         )
 
@@ -94,8 +99,8 @@ class TestDEExample(unittest.TestCase):
         self.assertEqual(
             example_data.model_dump(exclude_defaults=True),
             {
-                "raw_ref":  "Expanded template, Seite 273. "
-                            "ISBN 978-3-89029-459-9.",
+                "raw_ref": "Expanded template, Seite 273. "
+                "ISBN 978-3-89029-459-9.",
                 "title": "Viva Warszawa",
                 "author": "Steffen Möller",
                 "title_complement": "Polen für Fortgeschrittene",

--- a/tests/test_de_linkages.py
+++ b/tests/test_de_linkages.py
@@ -42,13 +42,13 @@ class TestDELinkages(unittest.TestCase):
             # Cleans explanatory text from expressions.
             {
                 "input": "====Redewendungen====\n:[[ein gutes Beispiel geben|"
-                        "ein gutes ''Beispiel'' geben]] – als [[Vorbild]] zur "
-                        "[[Nachahmung]] [[dienen]]/[[herausfordern]]",
+                "ein gutes ''Beispiel'' geben]] – als [[Vorbild]] zur "
+                "[[Nachahmung]] [[dienen]]/[[herausfordern]]",
                 "expected": {
                     "expressions": [
                         {
                             "note": "als Vorbild zur Nachahmung "
-                                    "dienen/herausfordern",
+                            "dienen/herausfordern",
                             "word": "ein gutes Beispiel geben",
                         }
                     ],


### PR DESCRIPTION
some pages only have example but no gloss, like "60-Jähriger"