### PR TITLE
Fix exceptions caused by None passed to unicodedata.normalize

### DIFF
--- a/src/wiktextract/inflection.py
+++ b/src/wiktextract/inflection.py
@@ -625,7 +625,7 @@ def extract_cell_content(
             if ref:
                 deflst.append((ref, col[ofs : m.start()].strip()))
             ref = unicodedata.normalize(
-                "NFKD", m.group(3) or m.group(5) or m.group(6)
+                "NFKD", m.group(3) or m.group(5) or m.group(6) or ""
             )
             ofs = m.end()
         if ref:


### PR DESCRIPTION
92 exceptions is not a lot, but enough to stop
the kaikki regen.

This call to unicodedata.normalize() seems to be
the only one that could have had None (others
are either in filtering `if` blocks or would
cause an exception due to the out of bound string
indexing).

I tried to find a final 93rd exception in extract.log (because I got that from `wc -l`) and it was the line "TOO MANY EXCEPTIONS DETECTED"... Which is weird, shouldn't this be in regenerate.log?