### PR TITLE
Synch with changes to Template:+obj

### DIFF
--- a/src/wiktextract/extractor/en/info_templates.py
+++ b/src/wiktextract/extractor/en/info_templates.py
@@ -11,7 +11,7 @@ from typing import Callable, Optional, Union
 from wikitextprocessor import WikiNode
 from wikitextprocessor.core import TemplateArgs
 from wikitextprocessor.parser import TemplateNode
-from wiktextract.clean import clean_template_args
+from wiktextract.clean import clean_template_args, clean_value
 from wiktextract.form_descriptions import decode_tags
 from wiktextract.type_utils import PlusObjTemplateData, TemplateData
 from wiktextract.wxr_context import WiktextractContext
@@ -35,7 +35,7 @@ InfoTemplateFunc = Callable[
     InfoReturnTuple,
 ]
 
-PLUSOBJ_RE = re.compile(r"\[\+([^][=]+)( = ([^][]+))?\]")
+PLUSOBJ_RE = re.compile(r"\[with ([^][=]+)( = ([^][]+))?\]")
 
 
 def plusobj_func(
@@ -51,8 +51,9 @@ def plusobj_func(
         )
         return None, None
 
-    text = wxr.wtp.expand(wxr.wtp.node_to_wikitext(node))
-    m = re.search(PLUSOBJ_RE, text)
+    text = clean_value(wxr, wxr.wtp.expand(wxr.wtp.node_to_wikitext(node)))
+    # print(f"cleaned: {text=}")
+    m = PLUSOBJ_RE.search(text)
     if not m:
         wxr.wtp.error(
             f"INFO-TEMPLATES: `Template:+obj` expansion does not "

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -685,7 +685,7 @@ foo
         return_value=Page(
             title="Template:+obj",
             namespace_id=10,
-            body="[+accusative blu or ergative = MEANING]",
+            body="[with accusative blu or ergative = MEANING]",
         ),
     )
     def test_plusobj_template(self, mock_get_page):
@@ -695,6 +695,7 @@ foo
         databases for testing.
 
         GitHub issue #667
+        GitHub issue #760
         """
         data = parse_page(
             self.wxr,
@@ -724,7 +725,7 @@ foo {{+obj|cs|accusative|blu|or|ergative|means=MEANING}}
                                 "5": "ergative",
                                 "means": "MEANING",
                             },
-                            "expansion": "[+accusative blu or "
+                            "expansion": "[with accusative blu or "
                             "ergative = MEANING]",
                             "extra_data": {
                                 "meaning": "MEANING",
@@ -740,7 +741,7 @@ foo {{+obj|cs|accusative|blu|or|ergative|means=MEANING}}
                     "senses": [
                         {
                             "glosses": [
-                                "foobar [+accusative blu or "
+                                "foobar [with accusative blu or "
                                 "ergative = MEANING]",
                                 "foobar",
                             ],
@@ -754,7 +755,7 @@ foo {{+obj|cs|accusative|blu|or|ergative|means=MEANING}}
                                         "5": "ergative",
                                         "means": "MEANING",
                                     },
-                                    "expansion": "[+accusative blu or "
+                                    "expansion": "[with accusative blu or "
                                     "ergative = "
                                     "MEANING]",
                                     "extra_data": {
@@ -766,7 +767,7 @@ foo {{+obj|cs|accusative|blu|or|ergative|means=MEANING}}
                                 }
                             ],
                             "raw_glosses": [
-                                "foobar [+accusative blu or ergative = "
+                                "foobar [with accusative blu or ergative = "
                                 "MEANING]"
                             ],
                         }


### PR DESCRIPTION
Template:+obj's output has been changed (and become more complicated), but as a stopgap this should work for a while until more complex stuff emerges in actual practice.

Remove the literal plus "\+" from the regex, that's been removed; for the purposes of +obj, I think every output starts with `[with`, but there might also be `along with` and `and` in the mix somehow.

Clean the template output value of all the style pseudo-HTML wikitext elements and other HTML stuff.