### PR TITLE
[pl] extract adj forms table "odmiana-przymiotnik-polski" template

### DIFF
--- a/src/wiktextract/extractor/pl/inflection.py
+++ b/src/wiktextract/extractor/pl/inflection.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import dataclass
 
 from wikitextprocessor.parser import NodeKind, TemplateNode, WikiNode
 
@@ -28,6 +29,12 @@ def extract_inflection_section(
                 if node.template_name == "odmiana-rzeczownik-polski":
                     forms.extend(
                         extract_odmiana_rzeczownik_polski(
+                            wxr, node, sense_index
+                        )
+                    )
+                elif node.template_name == "odmiana-przymiotnik-polski":
+                    forms.extend(
+                        extract_odmiana_przymiotnik_polski(
                             wxr, node, sense_index
                         )
                     )
@@ -73,4 +80,106 @@ def extract_odmiana_rzeczownik_polski(
                             translate_raw_tags(form)
                             forms.append(form)
                     col_index += 1
+    return forms
+
+
+@dataclass
+class TableHeader:
+    text: str
+    start: int
+    end: int
+
+
+def extract_odmiana_przymiotnik_polski(
+    wxr: WiktextractContext, template_node: TemplateNode, sense_index: str
+) -> list[Form]:
+    # adj table
+    # https://pl.wiktionary.org/wiki/Szablon:odmiana-przymiotnik-polski
+    expanded_node = wxr.wtp.parse(
+        wxr.wtp.node_to_wikitext(template_node), expand_all=True
+    )
+    forms = []
+    for table_tag in expanded_node.find_html_recursively("table"):
+        forms.extend(
+            extract_odmiana_przymiotnik_polski_table(
+                wxr, table_tag, sense_index
+            )
+        )
+    return forms
+
+
+def extract_odmiana_przymiotnik_polski_table(
+    wxr: WiktextractContext, table_tag: WikiNode, sense_index: str
+) -> list[Form]:
+    forms = []
+    col_headers = []
+    for tr_tag in table_tag.find_html("tr"):
+        th_col_index = 0
+        for th_tag in tr_tag.find_html("th"):
+            if th_tag.contain_node(NodeKind.BOLD):
+                # comparative forms in the second and third table header
+                raw_tag_nodes = []
+                for th_child in th_tag.children:
+                    if (
+                        isinstance(th_child, WikiNode)
+                        and th_child.kind == NodeKind.BOLD
+                    ):
+                        form = Form(
+                            form=clean_node(wxr, None, th_child),
+                            raw_tags=[clean_node(wxr, None, raw_tag_nodes)],
+                            sense_index=sense_index,
+                        )
+                        translate_raw_tags(form)
+                        forms.append(form)
+                    else:
+                        raw_tag_nodes.append(th_child)
+            else:
+                th_text = clean_node(wxr, None, th_tag)
+                col_span = int(th_tag.attrs.get("colspan", "1"))
+                if th_text != "przypadek":
+                    col_headers.append(
+                        TableHeader(
+                            th_text,
+                            th_col_index,
+                            th_col_index + col_span,
+                        )
+                    )
+                    th_col_index += col_span
+
+        # td tags
+        th_col_index = 0
+        td_col_index = 0
+        row_header = ""
+        all_header_row = all(
+            td_tag.attrs.get("class", "") == "forma"
+            for td_tag in tr_tag.find_html("td")
+        )
+        for td_tag in tr_tag.find_html("td"):
+            if any(td_tag.find_html("table")):
+                break
+            td_text = clean_node(wxr, None, td_tag)
+            if all_header_row:
+                col_headers.append(
+                    TableHeader(td_text, th_col_index, th_col_index + 1)
+                )
+                th_col_index += 1
+            elif "forma" == td_tag.attrs.get("class", ""):
+                row_header = td_text
+            else:
+                col_span = int(td_tag.attrs.get("colspan", "1"))
+                if td_text == wxr.wtp.title:
+                    td_col_index += col_span
+                    continue
+                form = Form(form=td_text, sense_index=sense_index)
+                if row_header != "":
+                    form.raw_tags.append(row_header)
+                for col_header in col_headers:
+                    if (
+                        col_header.start < td_col_index + col_span
+                        and td_col_index < col_header.end
+                    ):
+                        form.raw_tags.append(col_header.text)
+                td_col_index += col_span
+                translate_raw_tags(form)
+                forms.append(form)
     return forms

--- a/src/wiktextract/extractor/pl/tags.py
+++ b/src/wiktextract/extractor/pl/tags.py
@@ -227,6 +227,13 @@ TAGS = {
     "narzędnik": "instrumental",
     "miejscownik": "locative",
     "wołacz": "vocative",
+    # "odmiana-przymiotnik-polski" template
+    "mos/mzw": ["masculine", "animate"],
+    "ż": "feminine",
+    "mos": "masculine",
+    "nmos": "nonvirile",
+    "stopień wyższy": "comparative",
+    "stopień najwyższy": "superlative",
 }
 
 TOPICS = {
@@ -390,10 +397,12 @@ def check_tag(data: WordEntry, raw_tag: str) -> bool:
     # return `True` if found tag or topic
     if raw_tag in TAGS and hasattr(data, "tags"):
         tag = TAGS[raw_tag]
-        if isinstance(tag, str):
+        if isinstance(tag, str) and tag not in data.tags:
             data.tags.append(tag)
         elif isinstance(tag, list):
-            data.tags.extend(tag)
+            for t in tag:
+                if t not in data.tags:
+                    data.tags.append(t)
     elif raw_tag in TOPICS and hasattr(data, "topics"):
         topic = TOPICS[raw_tag]
         if isinstance(topic, str):

--- a/tests/test_pl_inflection.py
+++ b/tests/test_pl_inflection.py
@@ -73,3 +73,85 @@ class TestPlInflection(TestCase):
                 },
             ],
         )
+
+    def test_odmiana_przymiotnik_polski(self):
+        self.wxr.wtp.add_page(
+            "Szablon:odmiana-przymiotnik-polski",
+            10,
+            """<div><table><tr><th rowspan="2">[[przypadek]]</th><th colspan="4">''liczba pojedyncza''</th><th colspan="2">''liczba mnoga''</th></tr><tr><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#M|<span><span>mos</span></span>]]</span>/<span>[[Aneks:Skróty używane w Wikisłowniku#M|<span><span>mzw</span></span>]]</span></td><td class="forma"><span >[[Aneks:Skróty używane w Wikisłowniku#M|<span><span>mrz</span></span>]]</span></td><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#Ż|<span><span>ż</span></span>]]</span></td><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#N|<span><span>n</span></span>]]</span></td><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#M|<span><span>mos</span></span>]]</span></td><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#N|<span><span>nmos</span></span>]]</span></td></tr><tr><td class="forma">[[mianownik]]</td><td colspan="2">smutny</td><td>smutna</td><td>smutne</td><td>smutni</td><td>smutne</td></tr><tr><td colspan="7"><table><tr><th colspan="7">&nbsp;stopień wyższy '''smutniejszy'''</th></tr><tr><th rowspan="2">[[przypadek]]</th><th colspan="4">''liczba pojedyncza''</th><th colspan="2">''liczba mnoga''</th></tr><tr><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#M|<span><span>mos</span></span>]]</span>/<span>[[Aneks:Skróty używane w Wikisłowniku#M|<span><span>mzw</span></span>]]</span></td><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#M|<span><span>mrz</span></span>]]</span></td><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#Ż|<span><span>ż</span></span>]]</span></td><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#N|<span><span >n</span></span>]]</span></td><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#M|<span ><span>mos</span></span>]]</span></td><td class="forma"><span>[[Aneks:Skróty używane w Wikisłowniku#N|<span><span>nmos</span></span>]]</span></td></tr><tr><td class="forma">[[mianownik]]</td><td colspan="2">smutniejszy</td><td>smutniejsza</td><td>smutniejsze</td><td>smutniejsi</td><td>smutniejsze</td></tr></table></td></tr></table></div>""",
+        )
+        self.wxr.wtp.start_page("smutny")
+        root = self.wxr.wtp.parse(
+            ": (1.1-3) {{odmiana-przymiotnik-polski|smutniejszy}}"
+        )
+        page_data = [
+            WordEntry(
+                word="smutny",
+                lang="język polski",
+                lang_code="pl",
+                pos="adj",
+                senses=[Sense(sense_index="1.1")],
+            ),
+        ]
+        extract_inflection_section(self.wxr, page_data, "pl", root)
+        self.assertEqual(
+            [f.model_dump(exclude_defaults=True) for f in page_data[0].forms],
+            [
+                {
+                    "form": "smutna",
+                    "tags": ["nominative", "singular", "feminine"],
+                    "sense_index": "1.1-3",
+                },
+                {
+                    "form": "smutne",
+                    "tags": ["nominative", "singular", "neuter"],
+                    "sense_index": "1.1-3",
+                },
+                {
+                    "form": "smutni",
+                    "tags": ["nominative", "plural", "masculine"],
+                    "sense_index": "1.1-3",
+                },
+                {
+                    "form": "smutne",
+                    "tags": ["nominative", "plural", "nonvirile"],
+                    "sense_index": "1.1-3",
+                },
+                {
+                    "form": "smutniejszy",
+                    "tags": ["comparative"],
+                    "sense_index": "1.1-3",
+                },
+                {
+                    "form": "smutniejszy",
+                    "tags": [
+                        "nominative",
+                        "singular",
+                        "masculine",
+                        "animate",
+                        "inanimate",
+                    ],
+                    "sense_index": "1.1-3",
+                },
+                {
+                    "form": "smutniejsza",
+                    "tags": ["nominative", "singular", "feminine"],
+                    "sense_index": "1.1-3",
+                },
+                {
+                    "form": "smutniejsze",
+                    "tags": ["nominative", "singular", "neuter"],
+                    "sense_index": "1.1-3",
+                },
+                {
+                    "form": "smutniejsi",
+                    "tags": ["nominative", "plural", "masculine"],
+                    "sense_index": "1.1-3",
+                },
+                {
+                    "form": "smutniejsze",
+                    "tags": ["nominative", "plural", "nonvirile"],
+                    "sense_index": "1.1-3",
+                },
+            ],
+        )


### PR DESCRIPTION
I though pl edition has two more forms tables then en edition but en edition has the same tables in the comparative form page, pl edition puts all tables to the base word page.