### PR TITLE
[zh] fix pydantic error in `extract_ja_inf_table()`

### DIFF
--- a/src/wiktextract/extractor/zh/descendant.py
+++ b/src/wiktextract/extractor/zh/descendant.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 from wikitextprocessor import NodeKind, WikiNode
+
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 

--- a/src/wiktextract/extractor/zh/note.py
+++ b/src/wiktextract/extractor/zh/note.py
@@ -1,4 +1,5 @@
 from wikitextprocessor import NodeKind, WikiNode
+
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 

--- a/src/wiktextract/extractor/zh/translation.py
+++ b/src/wiktextract/extractor/zh/translation.py
@@ -3,6 +3,7 @@ from typing import Optional, Union
 from mediawiki_langcodes import code_to_name, name_to_code
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.parser import LEVEL_KIND_FLAGS, TemplateNode
+
 from wiktextract.page import clean_node
 from wiktextract.wxr_context import WiktextractContext
 

--- a/tests/test_zh_descendant.py
+++ b/tests/test_zh_descendant.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from wikitextprocessor import Wtp
+
 from wiktextract.extractor.zh.descendant import extract_descendants
 from wiktextract.extractor.zh.models import WordEntry
 from wiktextract.thesaurus import close_thesaurus_db

--- a/tests/test_zh_etymology.py
+++ b/tests/test_zh_etymology.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from wikitextprocessor import Wtp
+
 from wiktextract.extractor.zh.etymology import extract_etymology
 from wiktextract.extractor.zh.models import WordEntry
 from wiktextract.thesaurus import close_thesaurus_db

--- a/tests/test_zh_example.py
+++ b/tests/test_zh_example.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from wikitextprocessor import Wtp
+
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.zh.example import extract_examples
 from wiktextract.extractor.zh.models import Sense

--- a/tests/test_zh_gloss.py
+++ b/tests/test_zh_gloss.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from wikitextprocessor import NodeKind, WikiNode, Wtp
+
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.zh.models import Sense, WordEntry
 from wiktextract.extractor.zh.page import (

--- a/tests/test_zh_headword.py
+++ b/tests/test_zh_headword.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from wikitextprocessor import Wtp
+
 from wiktextract.extractor.zh.headword_line import extract_headword_line
 from wiktextract.extractor.zh.models import WordEntry
 from wiktextract.thesaurus import close_thesaurus_db

--- a/tests/test_zh_inflection.py
+++ b/tests/test_zh_inflection.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from wikitextprocessor import Wtp
+
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.zh.inflection import extract_inflections
 from wiktextract.extractor.zh.models import WordEntry
@@ -22,40 +23,6 @@ class TestInflection(TestCase):
         self.wxr.wtp.close_db_conn()
         close_thesaurus_db(
             self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
-        )
-
-    def test_ja_i_template(self) -> None:
-        self.wxr.wtp.add_page(
-            "Template:ja-i",
-            10,
-            """{|
-|-
-! 基本形
-|-
-! 未然形
-| 可笑しかろ
-| おかしかろ
-| okashikaro
-|}""",
-        )
-        page_data = [
-            WordEntry(lang="日語", lang_code="ja", word="可笑しい", pos="adj")
-        ]
-        wikitext = "{{ja-i|可笑し|おかし|okashi}}"
-        self.wxr.wtp.start_page("可笑しい")
-        node = self.wxr.wtp.parse(wikitext)
-        extract_inflections(self.wxr, page_data, node)
-        self.assertEqual(
-            [d.model_dump(exclude_defaults=True) for d in page_data[0].forms],
-            [
-                {
-                    "form": "可笑しかろ",
-                    "hiragana": "おかしかろ",
-                    "roman": "okashikaro",
-                    "source": "inflection table",
-                    "raw_tags": ["基本形", "未然形"],
-                },
-            ],
         )
 
     def test_zh_forms(self):
@@ -162,5 +129,41 @@ class TestInflection(TestCase):
                     "source": "inflection table",
                     "raw_tags": ["活用形", "命令形", "口語"],
                 },
+            ],
+        )
+
+    def test_ja_suru_two_columns(self):
+        self.wxr.wtp.add_page(
+            "Template:ja-suru",
+            10,
+            """<div>
+{|
+|-
+! colspan="4" | 活用形
+|-
+! <span class="Jpan" lang="ja">[[未然形#日語|-{未然形}-]]</span>
+||<span class="Jpan" lang="ja-Jpan">あさがえりし</span>
+| <span class="Latn" lang="ja-Latn">asagaeri shi</span>
+|}
+</div>""",
+        )
+        page_data = [
+            WordEntry(
+                lang="日語", lang_code="ja", word="あさがえり", pos="verb"
+            )
+        ]
+        wikitext = "{{ja-suru}}"
+        self.wxr.wtp.start_page("あさがえり")
+        node = self.wxr.wtp.parse(wikitext)
+        extract_inflections(self.wxr, page_data, node)
+        self.assertEqual(
+            [d.model_dump(exclude_defaults=True) for d in page_data[0].forms],
+            [
+                {
+                    "form": "あさがえりし",
+                    "roman": "asagaeri shi",
+                    "source": "inflection table",
+                    "raw_tags": ["活用形", "未然形"],
+                }
             ],
         )

--- a/tests/test_zh_linkage.py
+++ b/tests/test_zh_linkage.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from wikitextprocessor import Wtp
+
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.zh.linkage import extract_linkages
 from wiktextract.extractor.zh.models import Sense, WordEntry

--- a/tests/test_zh_note.py
+++ b/tests/test_zh_note.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from wikitextprocessor import Wtp
+
 from wiktextract.extractor.zh.models import WordEntry
 from wiktextract.extractor.zh.note import extract_note
 from wiktextract.thesaurus import close_thesaurus_db

--- a/tests/test_zh_pronunciation.py
+++ b/tests/test_zh_pronunciation.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from wikitextprocessor import Wtp
+
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.zh.models import WordEntry
 from wiktextract.extractor.zh.page import parse_page

--- a/tests/test_zh_thesaurus.py
+++ b/tests/test_zh_thesaurus.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from wikitextprocessor import Page, Wtp
+
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.zh.thesaurus import extract_thesaurus_page
 from wiktextract.thesaurus import ThesaurusTerm, close_thesaurus_db

--- a/tests/test_zh_translation.py
+++ b/tests/test_zh_translation.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from wikitextprocessor import Wtp
+
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.zh.models import WordEntry
 from wiktextract.extractor.zh.translation import extract_translation


### PR DESCRIPTION
Some pages only have two columns, `zip_longest` will use `None` causes the error. Check `<span>` tag's class name to find roman data.

Remove simplified test `test_ja_i_template` that doesn't have `span` tag.