### PR TITLE
[zh] fix the rest pydantic errors in `extract_ja_inf_table()`

### DIFF
--- a/src/wiktextract/extractor/zh/inflection.py
+++ b/src/wiktextract/extractor/zh/inflection.py
@@ -74,10 +74,16 @@ def extract_ja_inf_table(
                 elif row_child.kind == NodeKind.TABLE_CELL:
                     if cell_node_index >= 3:
                         break
+                    for bold_node in row_child.find_child(NodeKind.BOLD):
+                        # is row header
+                        raw_tags.append(clean_node(wxr, None, bold_node))
+                        continue
                     for span_tag in row_child.find_html("span"):
                         span_text = clean_node(wxr, None, row_child)
                         span_class = span_tag.attrs.get("class", "")
                         for line in span_text.splitlines():
+                            if line == "-":
+                                continue
                             if line.endswith(("¹", "²")):
                                 if cell_node_index == 0:
                                     small_tags.append(line[-1])
@@ -95,6 +101,8 @@ def extract_ja_inf_table(
             for form, hiragana, roman, small_tag in zip_longest(
                 form_list, hiragana_list, roman_list, small_tags
             ):
+                if form is None:
+                    continue
                 form_data = Form(
                     raw_tags=[table_header] + raw_tags,
                     source="inflection table",

--- a/tests/test_zh_inflection.py
+++ b/tests/test_zh_inflection.py
@@ -167,3 +167,41 @@ class TestInflection(TestCase):
                 }
             ],
         )
+
+    def test_ja_verbconj(self):
+        self.wxr.wtp.add_page(
+            "Template:ja-verbconj",
+            10,
+            """<div>
+{|
+|-
+! colspan="4" | '''語幹形態'''
+|-
+! '''未然形'''
+| | <span class="Jpan" lang="ja-Jpan">-</span>
+| <span class="Latn" lang="ja-Latn">-</span>
+|-
+| '''假定形'''
+| | <span class="Jpan" lang="ja-Jpan">ね</span>
+| <span class="Latn" lang="ja-Latn">ne</span>
+|}
+</div>""",
+        )
+        page_data = [
+            WordEntry(lang="日語", lang_code="ja", word="ぬ", pos="suffix")
+        ]
+        wikitext = "{{ja-verbconj|ぬ}}"
+        self.wxr.wtp.start_page("ぬ")
+        node = self.wxr.wtp.parse(wikitext)
+        extract_inflections(self.wxr, page_data, node)
+        self.assertEqual(
+            [d.model_dump(exclude_defaults=True) for d in page_data[0].forms],
+            [
+                {
+                    "form": "ね",
+                    "roman": "ne",
+                    "source": "inflection table",
+                    "raw_tags": ["語幹形態", "假定形"],
+                }
+            ],
+        )


### PR DESCRIPTION
skip empty rows and use cell node as header node if is has bold node