### PR TITLE
Add "Dependent noun" as POS

### DIFF
--- a/src/wiktextract/extractor/en/section_titles.py
+++ b/src/wiktextract/extractor/en/section_titles.py
@@ -56,6 +56,12 @@ POS_TITLES: dict[str, POSSubtitleData] = {
     "converb": {"pos": "converb"},
     "counter": {"pos": "counter"},
     "definitions": {"pos": "character"},
+    "dependent noun": {
+        "pos": "noun",
+        "tags": [
+            "dependent",
+        ],
+    },
     "determiner": {"pos": "det"},
     "diacritical mark": {"pos": "character", "tags": ["diacritic"]},
     "enclitic": {"pos": "suffix", "tags": ["clitic"]},

--- a/src/wiktextract/parts_of_speech.py
+++ b/src/wiktextract/parts_of_speech.py
@@ -13,8 +13,9 @@ POSMap = TypedDict(
         "pos": str,
         "debug": str,
         "tags": list[str],
-     },
-    total = False)
+    },
+    total=False,
+)
 
 part_of_speech_map: dict[str, POSMap] = {
     "abbreviation": {
@@ -121,6 +122,12 @@ part_of_speech_map: dict[str, POSMap] = {
     },
     "counter": {
         "pos": "counter",
+    },
+    "dependent noun": {
+        "pos": "noun",
+        "tags": [
+            "dependent",
+        ],
     },
     "definitions": {
         # This is used under chinese characters


### PR DESCRIPTION
Some Korean entries depend on this.

Fixes #790

Added to both parts_of_speech and POS_TITLES in extractor/ en/section_titles... Should clean this up, or import parts_of_speech into section_titles.