### PR TITLE
Add "adnominal" as POS

### DIFF
--- a/src/wiktextract/extractor/en/section_titles.py
+++ b/src/wiktextract/extractor/en/section_titles.py
@@ -21,6 +21,7 @@ POS_TITLES: dict[str, POSSubtitleData] = {
     "adjective": {"pos": "adj"},
     "adjectuve": {"pos": "adj", "debug": "misspelled subtitle"},
     "adjectives": {"pos": "adj", "debug": "usually used in singular"},
+    "adnominal": {"pos": "adnominal"},
     "adverb": {"pos": "adv"},
     "adverbs": {"pos": "adv", "debug": "usually used in singular"},
     "adverbial phrase": {

--- a/src/wiktextract/parts_of_speech.py
+++ b/src/wiktextract/parts_of_speech.py
@@ -51,6 +51,9 @@ part_of_speech_map: dict[str, POSMap] = {
         "pos": "adj",
         "debug": "usually used in singular",
     },
+    "adnominal": {
+        "pos": "adnominal",
+    },
     "adverb": {
         "pos": "adv",
     },


### PR DESCRIPTION
Some Japanese entries depend on this, such as [この](https://en.wiktionary.org/wiki/%E3%81%93%E3%81%AE).