### PR TITLE
[zh] add "Appendix" namespace pages

### DIFF
--- a/src/wiktextract/data/zh/config.json
+++ b/src/wiktextract/data/zh/config.json
@@ -1,6 +1,12 @@
 {
   "analyze_templates": false,
   "extract_thesaurus_pages": true,
-  "save_ns_names": ["Main", "Template", "Module", "Thesaurus"],
+  "save_ns_names": [
+    "Main",
+    "Template",
+    "Module",
+    "Thesaurus",
+    "Appendix"
+  ],
   "extract_ns_names": ["Main"]
 }


### PR DESCRIPTION
page "Appendix:Glossary" is used in "Module:Glossary/data"

Fix many Lua errors...