### PR TITLE
[en] extract "zh-x" example templates properly

### DIFF
--- a/src/wiktextract/extractor/en/example.py
+++ b/src/wiktextract/extractor/en/example.py
@@ -1,0 +1,227 @@
+from copy import deepcopy
+from typing import Optional
+
+from wikitextprocessor.parser import NodeKind, TemplateNode, WikiNode
+
+from ...page import clean_node
+from ...tags import valid_tags
+from ...type_utils import ExampleData
+from ...wxr_context import WiktextractContext
+from ..ruby import extract_ruby
+
+
+def extract_example_list_item(
+    wxr: WiktextractContext,
+    list_item: WikiNode,
+    parent_data: Optional[ExampleData],
+) -> list[ExampleData]:
+    examples = []
+    for template_node in list_item.find_child(NodeKind.TEMPLATE):
+        if template_node.template_name == "zh-x":
+            examples.extend(
+                extract_template_zh_x(
+                    wxr,
+                    template_node,
+                    parent_data
+                    if parent_data is not None
+                    else ExampleData(raw_tags=[], tags=[]),
+                )
+            )
+        elif template_node.template_name in ["ja-usex", "ja-x"]:
+            examples.append(
+                extract_template_ja_usex(
+                    wxr,
+                    template_node,
+                    parent_data
+                    if parent_data is not None
+                    else ExampleData(raw_tags=[], tags=[]),
+                )
+            )
+        elif template_node.template_name.startswith(("quote-", "RQ:")):
+            q_example = extract_quote_templates(wxr, template_node)
+            if list_item.contain_node(NodeKind.LIST):
+                for next_list_item in list_item.find_child_recursively(
+                    NodeKind.LIST_ITEM
+                ):
+                    for key in ["tags", "raw_tags"]:
+                        q_example[key] = []
+                    examples.extend(
+                        extract_example_list_item(
+                            wxr, next_list_item, q_example
+                        )
+                    )
+            else:
+                examples.append(q_example)
+
+    return examples
+
+
+def extract_quote_templates(
+    wxr: WiktextractContext, node: TemplateNode
+) -> ExampleData:
+    expanded_node = wxr.wtp.parse(
+        wxr.wtp.node_to_wikitext(node), expand_all=True
+    )
+    ref = ""
+    text = ""
+    translation = ""
+    for span_tag in expanded_node.find_html_recursively("span"):
+        span_class = span_tag.attrs.get("class", "")
+        if "cited-source" == span_class:
+            ref = clean_node(wxr, None, span_tag)
+        elif "cited-passage" in span_class:
+            text = clean_node(wxr, None, span_tag)
+        elif "e-translation" in span_class:
+            translation = clean_node(wxr, None, span_tag)
+    return ExampleData(text=text, ref=ref, english=translation, type="quote")
+
+
+def extract_template_ja_usex(
+    wxr: WiktextractContext, node: TemplateNode, example_data: ExampleData
+) -> ExampleData:
+    # https://en.wiktionary.org/wiki/Template:ja-usex
+    expanded_node = wxr.wtp.parse(
+        wxr.wtp.node_to_wikitext(node), expand_all=True
+    )
+    for span_tag in expanded_node.find_html(
+        "span", attr_name="class", attr_value="Jpan"
+    ):
+        ruby_data, node_without_ruby = extract_ruby(wxr, span_tag)
+        example_data["text"] = clean_node(wxr, None, node_without_ruby)
+        example_data["ruby"] = ruby_data
+    for span_tag in expanded_node.find_html_recursively(
+        "span", attr_name="class", attr_value="tr"
+    ):
+        example_data["roman"] = clean_node(wxr, None, span_tag)
+    example_data["english"] = clean_node(
+        wxr, None, node.template_parameters.get(3, "")
+    )
+    example_data["literal_meaning"] = clean_node(
+        wxr, None, node.template_parameters.get("lit", "")
+    )
+
+
+def extract_template_zh_x(
+    wxr: WiktextractContext,
+    template_node: TemplateNode,
+    parent_example: ExampleData,
+) -> list[ExampleData]:
+    # https://en.wiktionary.org/wiki/Template:zh-x
+    expanded_node = wxr.wtp.parse(
+        wxr.wtp.node_to_wikitext(template_node), expand_all=True
+    )
+    has_dl_tag = False
+    results = []
+    for dl_tag in expanded_node.find_html_recursively("dl"):
+        has_dl_tag = True
+        ref = ""
+        roman = ""
+        translation = clean_node(
+            wxr, None, template_node.template_parameters.get(2, "")
+        )
+        roman_raw_tags = []
+        for dd_tag in dl_tag.find_html("dd"):
+            dd_text = clean_node(wxr, None, dd_tag)
+            if dd_text.startswith("From:"):
+                ref = dd_text.removeprefix("From:")
+            else:
+                for span_tag in dd_tag.find_html_recursively(
+                    "span", attr_name="lang", attr_value="Latn"
+                ):
+                    roman = clean_node(wxr, None, span_tag)
+                    for span_tag in dd_tag.find_html_recursively("span"):
+                        span_text = clean_node(wxr, None, span_tag)
+                        if span_text.startswith("[") and span_text.endswith(
+                            "]"
+                        ):
+                            roman_raw_tags.append(span_text.strip("[]"))
+
+        example_text = ""
+        last_span_is_exmaple = False
+        for span_tag in dl_tag.find_html_recursively("span"):
+            if span_tag.attrs.get("class", "") in ["Hant", "Hans"]:
+                example_text = clean_node(wxr, None, span_tag)
+                last_span_is_exmaple = True
+            elif last_span_is_exmaple:
+                last_span_is_exmaple = False
+                if len(example_text) > 0:
+                    example = deepcopy(parent_example)
+                    # dialect and character variant tag
+                    for link_node in span_tag.find_child_recursively(
+                        NodeKind.LINK
+                    ):
+                        example["raw_tags"].append(
+                            clean_node(wxr, None, link_node)
+                        )
+                    example["text"] = example_text
+                    example["roman"] = roman
+                    example["english"] = translation
+                    example["raw_tags"].extend(roman_raw_tags)
+                    if len(ref) > 0:  # don't override parent quote-* template
+                        example["ref"] = ref
+                    clean_example_empty_data(example)
+                    results.append(example)
+
+    # no source, single line example
+    if not has_dl_tag:
+        roman = ""
+        raw_tags = []
+        for span_tag in expanded_node.find_html(
+            "span", attr_name="lang", attr_value="Latn"
+        ):
+            roman = clean_node(wxr, None, span_tag)
+        for span_tag in expanded_node.find_html("span"):
+            span_text = clean_node(wxr, None, span_tag)
+            if span_text.startswith("[") and span_text.endswith("]"):
+                raw_tags.append(span_text.strip("[]"))
+        translation = clean_node(
+            wxr, None, template_node.template_parameters.get(2, "")
+        )
+        literal_meaning = clean_node(
+            wxr, None, template_node.template_parameters.get("lit", "")
+        )
+        for span_tag in expanded_node.find_html("span"):
+            span_lang = span_tag.attrs.get("lang", "")
+            if span_lang in ["zh-Hant", "zh-Hans"]:
+                example_text = clean_node(wxr, None, span_tag)
+                if len(example_text) > 0:
+                    example_data = deepcopy(parent_example)
+                    example_data["text"] = example_text
+                    example_data["roman"] = roman
+                    example_data["tags"].append(
+                        "Traditional Chinese"
+                        if span_lang == "zh-Hant"
+                        else "Simplified Chinese"
+                    )
+                    example_data["english"] = translation
+                    example_data["literal_meaning"] = literal_meaning
+                    example_data["raw_tags"].extend(raw_tags)
+                    clean_example_empty_data(example_data)
+                    results.append(example_data)
+    return results
+
+
+ZH_X_TAGS = {
+    "trad.": "Traditional Chinese",
+    "simp.": "Simplified Chinese",
+}
+
+
+def clean_example_empty_data(data: ExampleData) -> ExampleData:
+    raw_tags = data.get("raw_tags", [])
+    new_raw_tags = []
+    for raw_tag in raw_tags:
+        if raw_tag in valid_tags:
+            data["tags"].append(raw_tag)
+        elif raw_tag in ZH_X_TAGS:
+            data["tags"].append(ZH_X_TAGS[raw_tag])
+        else:
+            new_raw_tags.append(raw_tag)
+    data["raw_tags"] = new_raw_tags
+    if len(data.get("ref", "")) > 0:
+        data["type"] = "quote"
+    else:
+        data["type"] = "example"
+    for key, value in data.copy().items():
+        if len(value) == 0:
+            del data[key]

--- a/src/wiktextract/extractor/en/example.py
+++ b/src/wiktextract/extractor/en/example.py
@@ -18,7 +18,7 @@ def extract_example_list_item(
 ) -> list[ExampleData]:
     examples = []
     for template_node in list_item.find_child(NodeKind.TEMPLATE):
-        if template_node.template_name == "zh-x":
+        if template_node.template_name in ["zh-x", "zh-q"]:
             examples.extend(
                 extract_template_zh_x(
                     wxr,
@@ -145,15 +145,16 @@ def extract_template_zh_x(
                             "]"
                         ):
                             roman_raw_tags.append(span_text.strip("[]"))
+                    break
 
         example_text = ""
-        last_span_is_exmaple = False
+        last_span_is_example = False
         for span_tag in dl_tag.find_html_recursively("span"):
             if span_tag.attrs.get("class", "") in ["Hant", "Hans"]:
                 example_text = clean_node(wxr, None, span_tag)
-                last_span_is_exmaple = True
-            elif last_span_is_exmaple:
-                last_span_is_exmaple = False
+                last_span_is_example = True
+            elif last_span_is_example:
+                last_span_is_example = False
                 if len(example_text) > 0:
                     example = deepcopy(parent_example)
                     # dialect and character variant tag
@@ -221,10 +222,10 @@ def clean_example_empty_data(data: ExampleData) -> ExampleData:
     raw_tags = data.get("raw_tags", [])
     new_raw_tags = []
     for raw_tag in raw_tags:
-        if raw_tag in valid_tags:
-            data["tags"].append(raw_tag)
-        elif raw_tag in ZH_X_TAGS:
+        if raw_tag in ZH_X_TAGS:
             data["tags"].append(ZH_X_TAGS[raw_tag])
+        elif raw_tag in valid_tags:
+            data["tags"].append(raw_tag)
         else:
             new_raw_tags.append(raw_tag)
     data["raw_tags"] = new_raw_tags

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1849,7 +1849,6 @@ def parse_language(
         if len(subglosses) == 0:
             return False
 
-
         if any(s.startswith("#") for s in subglosses):
             subtree = wxr.wtp.parse(rawgloss)
             # from wikitextprocessor.parser import print_tree
@@ -1858,8 +1857,7 @@ def parse_language(
             new_subentries = [
                 x
                 for x in subtree.children
-                if isinstance(x, WikiNode)
-                and x.kind == NodeKind.LIST
+                if isinstance(x, WikiNode) and x.kind == NodeKind.LIST
             ]
 
             new_others = [
@@ -1895,7 +1893,6 @@ def parse_language(
             if rawgloss.endswith(x):
                 rawgloss = rawgloss[: -len(x)].strip()
                 break
-
 
         # A single gloss, or possibly an outer gloss.
         # Check if the possible outer gloss starts with
@@ -3655,7 +3652,9 @@ def parse_language(
                 example_template_names = []
                 taxons = set()
 
-                new_example_lists = extract_example_list_item(wxr, item, None)
+                new_example_lists = extract_example_list_item(
+                    wxr, item, sense_base, None
+                )
                 if len(new_example_lists) > 0:
                     examples.extend(new_example_lists)
                     continue

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -23,6 +23,7 @@ from mediawiki_langcodes import get_all_names, name_to_code
 from wikitextprocessor import NodeKind, WikiNode
 from wikitextprocessor.core import TemplateArgs, TemplateFnCallable
 from wikitextprocessor.parser import GeneralNode, TemplateNode
+
 from wiktextract.clean import clean_template_args, clean_value
 from wiktextract.datautils import (
     data_append,
@@ -63,6 +64,7 @@ from wiktextract.wxr_logging import logger
 
 from ..ruby import extract_ruby, parse_ruby
 from ..share import strip_nodes
+from .example import extract_example_list_item
 from .info_templates import (
     INFO_TEMPLATE_FUNCS,
     parse_info_template_arguments,
@@ -3652,6 +3654,11 @@ def parse_language(
                 example_template_args = []
                 example_template_names = []
                 taxons = set()
+
+                new_example_lists = extract_example_list_item(wxr, item, None)
+                if len(new_example_lists) > 0:
+                    examples.extend(new_example_lists)
+                    continue
 
                 def usex_template_fn(
                     name: str, ht: TemplateArgs

--- a/src/wiktextract/type_utils.py
+++ b/src/wiktextract/type_utils.py
@@ -36,6 +36,9 @@ class ExampleData(TypedDict, total=False):
     ruby: Union[list[tuple[str, str]], list[Sequence[str]]]
     text: str
     type: str
+    literal_meaning: str
+    tags: list[str]
+    raw_tags: list[str]
 
 
 class FormOf(TypedDict, total=False):


### PR DESCRIPTION
Most code are copied from zh edition code with some modifications.

Separate Traditional Chinese, Simplified Chinese, dialect and other tag properly.

Also handle the common "zh-x" and "ja-x" template under "quote-*" template layout.

Example pages: [大家](https://en.wiktionary.org/wiki/%E5%A4%A7%E5%AE%B6), [尋釁滋事](https://en.wiktionary.org/wiki/%E5%B0%8B%E9%87%81%E6%BB%8B%E4%BA%8B)

The code could also be reused for example templates in Chengyu pages, like [買櫝還珠](https://en.wiktionary.org/wiki/%E8%B2%B7%E6%AB%9D%E9%82%84%E7%8F%A0)