### PR TITLE
[pl] extract "furi" Japanese templates in translation lists

### DIFF
--- a/src/wiktextract/extractor/pl/models.py
+++ b/src/wiktextract/extractor/pl/models.py
@@ -42,6 +42,7 @@ class Translation(PolishBaseModel):
     tags: list[str] = []
     raw_tags: list[str] = []
     roman: str = ""
+    ruby: list[tuple[str, ...]] = []
 
 
 class Sound(PolishBaseModel):

--- a/src/wiktextract/extractor/pl/translation.py
+++ b/src/wiktextract/extractor/pl/translation.py
@@ -50,6 +50,8 @@ def process_translation_list_item(
     lang_code = ""
     sense_index = ""
     last_tr_data = None
+    last_node = None
+    raw_tags = []
     for index, node in enumerate(list_item.children):
         if isinstance(node, str):
             if index == 0 and ":" in node:
@@ -69,17 +71,75 @@ def process_translation_list_item(
                 last_tr_data.roman = m_roman.group(0).strip("()")
         elif isinstance(node, WikiNode) and node.kind == NodeKind.LINK:
             word = clean_node(wxr, None, node)
-            if len(word) > 0:
+            if len(word) == 0:
+                continue
+            if (
+                isinstance(last_node, WikiNode)
+                and last_node.kind == NodeKind.LINK
+                and last_tr_data is not None
+            ):
+                # two links directly next to each other form one word
+                last_tr_data.word += word
+            else:
                 new_tr_data = Translation(
                     word=word,
                     sense_index=sense_index,
                     lang=lang_name,
                     lang_code=lang_code,
+                    raw_tags=raw_tags,
                 )
+                translate_raw_tags(new_tr_data)
                 translations[sense_index].append(new_tr_data)
                 last_tr_data = new_tr_data
-        elif isinstance(node, TemplateNode) and last_tr_data is not None:
-            raw_tag = clean_node(wxr, None, node)
-            if len(raw_tag) > 0:
-                last_tr_data.raw_tags.append(raw_tag)
-                translate_raw_tags(last_tr_data)
+                raw_tags.clear()
+        elif isinstance(node, TemplateNode):
+            if node.template_name == "furi":
+                word, furigana = extract_furi_template(wxr, node)
+                if (
+                    isinstance(last_node, WikiNode)
+                    and last_node.kind == NodeKind.LINK
+                    and last_tr_data is not None
+                ):
+                    last_tr_data.word += word
+                    last_tr_data.ruby = [(word, furigana)]
+                else:
+                    new_tr_data = Translation(
+                        word=word,
+                        sense_index=sense_index,
+                        lang=lang_name,
+                        lang_code=lang_code,
+                        raw_tags=raw_tags,
+                        ruby=[(word, furigana)],
+                    )
+                    translate_raw_tags(new_tr_data)
+                    translations[sense_index].append(new_tr_data)
+                    last_tr_data = new_tr_data
+                    raw_tags.clear()
+            elif isinstance(last_node, str) and (
+                "," in last_node or ";" in last_node
+            ):
+                raw_tag = clean_node(wxr, None, node)
+                if len(raw_tag) > 0:
+                    raw_tags.append(raw_tag)
+            elif last_tr_data is not None:
+                raw_tag = clean_node(wxr, None, node)
+                if len(raw_tag) > 0:
+                    last_tr_data.raw_tags.append(raw_tag)
+                    translate_raw_tags(last_tr_data)
+        last_node = node
+
+
+def extract_furi_template(
+    wxr: WiktextractContext, node: TemplateNode
+) -> tuple[str, str]:
+    # https://pl.wiktionary.org/wiki/Szablon:furi
+    expanded_node = wxr.wtp.parse(
+        wxr.wtp.node_to_wikitext(node), expand_all=True
+    )
+    kanji = clean_node(wxr, None, node.template_parameters.get(1, ""))
+    furigana = ""
+    for span_tag in expanded_node.find_html_recursively(
+        "span", attr_name="class", attr_value="furigana-caption"
+    ):
+        furigana = clean_node(wxr, None, span_tag).strip("()")
+    return kanji, furigana

--- a/tests/test_pl_translation.py
+++ b/tests/test_pl_translation.py
@@ -70,3 +70,94 @@ class TestPlTranslation(TestCase):
                 },
             ],
         )
+
+    def test_close_links(self):
+        self.wxr.wtp.add_page(
+            "Szablon:furi",
+            10,
+            '<span class="furigana-wrapper" lang="ja" xml:lang="ja">[[語]]<span class="furigana-caption">(ご)</span></span>',
+        )
+        self.wxr.wtp.start_page("polski")
+        page_data = parse_page(
+            self.wxr,
+            "polski",
+            """== polski ({{język polski}}) ==
+===znaczenia===
+''przymiotnik relacyjny''
+: (1.1) gloss 1
+
+''rzeczownik, rodzaj męskorzeczowy''
+: (2.1) gloss 2
+
+===tłumaczenia===
+* japoński: (1.1) [[ポーランド]][[の]]; (2.1) [[ポーランド]]{{furi|語|ご}}""",
+        )
+        self.assertEqual(
+            page_data[0]["translations"],
+            [
+                {
+                    "lang": "japoński",
+                    "lang_code": "ja",
+                    "word": "ポーランドの",
+                    "sense_index": "1.1",
+                }
+            ],
+        )
+        self.assertEqual(
+            page_data[1]["translations"],
+            [
+                {
+                    "lang": "japoński",
+                    "lang_code": "ja",
+                    "word": "ポーランド語",
+                    "sense_index": "2.1",
+                    "ruby": [("語", "ご")],
+                },
+            ],
+        )
+
+    def test_furi(self):
+        self.wxr.wtp.add_page(
+            "Szablon:przest",
+            10,
+            '<span class="short-container">[[Wikisłownik:Użycie szablonów daw, hist, przest, stpol|<span class="short-wrapper" title="przestarzałe, przestarzały" data-expanded="przestarzałe, przestarzały"><span class="short-content">przest.</span></span>]]</span>',
+        )
+        self.wxr.wtp.add_page(
+            "Szablon:furi",
+            10,
+            '<span class="furigana-wrapper" lang="ja" xml:lang="ja">[[{{{1}}}]]<span class="furigana-caption">({{{2}}})</span></span>',
+        )
+        self.wxr.wtp.start_page("umierać")
+        page_data = parse_page(
+            self.wxr,
+            "umierać",
+            """== polski ({{język polski}}) ==
+===znaczenia===
+''czasownik''
+: (1.1) gloss 1
+
+===tłumaczenia===
+* japoński: (1.1) {{furi|死亡する|[[しぼうする]]}} (shibō suru), {{przest}} {{furi|死する|[[しする]]}} (shi suru)""",
+        )
+        self.assertEqual(
+            page_data[0]["translations"],
+            [
+                {
+                    "lang": "japoński",
+                    "lang_code": "ja",
+                    "word": "死亡する",
+                    "ruby": [("死亡する", "しぼうする")],
+                    "sense_index": "1.1",
+                    "roman": "shibō suru",
+                },
+                {
+                    "lang": "japoński",
+                    "lang_code": "ja",
+                    "word": "死する",
+                    "ruby": [("死する", "しする")],
+                    "sense_index": "1.1",
+                    "roman": "shi suru",
+                    "tags": ["obsolete"],
+                },
+            ],
+        )


### PR DESCRIPTION
and combine links next to each other to one word

The "furi" template doesn't expand to `ruby` tags like other editions. 