### PR TITLE
[en] don't extract "span" tag in example source "dd" tags

### DIFF
--- a/src/wiktextract/extractor/en/example.py
+++ b/src/wiktextract/extractor/en/example.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
-from typing import Optional
 
-from wikitextprocessor.parser import NodeKind, TemplateNode, WikiNode
+from wikitextprocessor import HTMLNode, NodeKind, TemplateNode, WikiNode
 
 from ...page import clean_node
 from ...tags import valid_tags
@@ -14,7 +13,7 @@ def extract_example_list_item(
     wxr: WiktextractContext,
     list_item: WikiNode,
     sense_data: SenseData,
-    parent_data: Optional[ExampleData],
+    parent_data: ExampleData,
 ) -> list[ExampleData]:
     examples = []
     for template_node in list_item.find_child(NodeKind.TEMPLATE):
@@ -24,9 +23,7 @@ def extract_example_list_item(
                     wxr,
                     template_node,
                     sense_data,
-                    parent_data
-                    if parent_data is not None
-                    else ExampleData(raw_tags=[], tags=[]),
+                    parent_data,
                 )
             )
         elif template_node.template_name in ["ja-usex", "ja-x"]:
@@ -35,9 +32,7 @@ def extract_example_list_item(
                     wxr,
                     template_node,
                     sense_data,
-                    parent_data
-                    if parent_data is not None
-                    else ExampleData(raw_tags=[], tags=[]),
+                    parent_data,
                 )
             )
         elif (
@@ -50,7 +45,8 @@ def extract_example_list_item(
                     NodeKind.LIST_ITEM
                 ):
                     for key in ["tags", "raw_tags"]:
-                        q_example[key] = []
+                        if key not in q_example:
+                            q_example[key] = []
                     examples.extend(
                         extract_example_list_item(
                             wxr, next_list_item, sense_data, q_example
@@ -139,71 +135,46 @@ def extract_template_zh_x(
     results = []
     for dl_tag in expanded_node.find_html_recursively("dl"):
         has_dl_tag = True
-        ref = ""
-        roman = ""
-        translation = clean_node(
+        example_data = deepcopy(parent_example)
+        example_data["english"] = clean_node(
             wxr, None, template_node.template_parameters.get(2, "")
         )
-        roman_raw_tags = []
         for dd_tag in dl_tag.find_html("dd"):
             dd_text = clean_node(wxr, None, dd_tag)
             if dd_text.startswith("From:"):
-                ref = dd_text.removeprefix("From:")
+                example_data["ref"] = dd_text.removeprefix("From:")
             else:
                 for span_tag in dd_tag.find_html_recursively(
                     "span", attr_name="lang", attr_value="Latn"
                 ):
-                    roman = clean_node(wxr, None, span_tag)
+                    example_data["roman"] = clean_node(wxr, None, span_tag)
                     for span_tag in dd_tag.find_html_recursively("span"):
                         span_text = clean_node(wxr, None, span_tag)
                         if span_text.startswith("[") and span_text.endswith(
                             "]"
                         ):
-                            roman_raw_tags.append(span_text.strip("[]"))
+                            example_data["raw_tags"].append(
+                                span_text.strip("[]")
+                            )
                     break
-
-        example_text = ""
-        last_span_is_example = False
-        for span_tag in dl_tag.find_html_recursively("span"):
-            if span_tag.attrs.get("class", "") in ["Hant", "Hans"]:
-                example_text = clean_node(wxr, None, span_tag)
-                last_span_is_example = True
-            elif last_span_is_example:
-                last_span_is_example = False
-                if len(example_text) > 0:
-                    example = deepcopy(parent_example)
-                    # dialect and character variant tag
-                    for link_node in span_tag.find_child_recursively(
-                        NodeKind.LINK
-                    ):
-                        example["raw_tags"].append(
-                            clean_node(wxr, None, link_node)
-                        )
-                    example["text"] = example_text
-                    example["roman"] = roman
-                    example["english"] = translation
-                    example["raw_tags"].extend(roman_raw_tags)
-                    if len(ref) > 0:  # don't override parent quote-* template
-                        example["ref"] = ref
-                    clean_example_empty_data(example)
-                    results.append(example)
+        results.extend(extract_zh_x_dl_span_tag(wxr, dl_tag, example_data))
 
     # no source, single line example
     if not has_dl_tag:
-        roman = ""
-        raw_tags = []
+        example_data = deepcopy(parent_example)
         for span_tag in expanded_node.find_html(
             "span", attr_name="lang", attr_value="Latn"
         ):
-            roman = clean_node(wxr, None, span_tag)
+            example_data["roman"] = clean_node(wxr, None, span_tag)
+            break
         for span_tag in expanded_node.find_html("span"):
             span_text = clean_node(wxr, None, span_tag)
             if span_text.startswith("[") and span_text.endswith("]"):
-                raw_tags.append(span_text.strip("[]"))
-        translation = clean_node(
+                example_data["raw_tags"].append(span_text.strip("[]"))
+        example_data["english"] = clean_node(
             wxr, None, template_node.template_parameters.get(2, "")
         )
-        literal_meaning = clean_node(
+        example_data["literal_meaning"] = clean_node(
             wxr, None, template_node.template_parameters.get("lit", "")
         )
         for span_tag in expanded_node.find_html("span"):
@@ -211,19 +182,54 @@ def extract_template_zh_x(
             if span_lang in ["zh-Hant", "zh-Hans"]:
                 example_text = clean_node(wxr, None, span_tag)
                 if len(example_text) > 0:
-                    example_data = deepcopy(parent_example)
-                    example_data["text"] = example_text
-                    example_data["roman"] = roman
-                    example_data["tags"].append(
+                    new_example = deepcopy(example_data)
+                    new_example["text"] = example_text
+                    new_example["tags"].append(
                         "Traditional Chinese"
                         if span_lang == "zh-Hant"
                         else "Simplified Chinese"
                     )
-                    example_data["english"] = translation
-                    example_data["literal_meaning"] = literal_meaning
-                    example_data["raw_tags"].extend(raw_tags)
-                    clean_example_empty_data(example_data)
-                    results.append(example_data)
+                    clean_example_empty_data(new_example)
+                    results.append(new_example)
+    return results
+
+
+def extract_zh_x_dl_span_tag(
+    wxr: WiktextractContext, dl_tag: HTMLNode, example: ExampleData
+) -> list[ExampleData]:
+    # process example text span tag and dialect span tag
+    results = []
+    is_first_hide = True
+    for span_tag in dl_tag.find_html("span"):
+        span_lang = span_tag.attrs.get("lang", "")
+        if span_lang in ["zh-Hant", "zh-Hans"]:
+            new_example = deepcopy(example)
+            new_example["text"] = clean_node(wxr, None, span_tag)
+            results.append(new_example)
+        elif "vsHide" in span_tag.attrs.get("class", ""):
+            # template has arg "collapsed=y"
+            results.extend(
+                extract_zh_x_dl_span_tag(
+                    wxr,
+                    span_tag,
+                    results[-1]
+                    if is_first_hide and len(results) > 0
+                    else example,
+                )
+            )
+            is_first_hide = False
+        elif "font-size:x-small" in span_tag.attrs.get("style", ""):
+            for link_node in span_tag.find_child_recursively(NodeKind.LINK):
+                raw_tag = clean_node(wxr, None, link_node)
+                if len(raw_tag) > 0:
+                    if len(results) > 0:
+                        results[-1]["raw_tags"].append(raw_tag)
+                    else:
+                        example["raw_tags"].append(raw_tag)
+
+    if dl_tag.tag == "dl":
+        for data in results:
+            clean_example_empty_data(data)
     return results
 
 

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -3651,7 +3651,7 @@ def parse_language(
                 # Bypass this function when parsing Chinese, Japanese and
                 # quotation templates.
                 new_example_lists = extract_example_list_item(
-                    wxr, item, sense_base, None
+                    wxr, item, sense_base, ExampleData(raw_tags=[], tags=[])
                 )
                 if len(new_example_lists) > 0:
                     examples.extend(new_example_lists)

--- a/src/wiktextract/extractor/zh/example.py
+++ b/src/wiktextract/extractor/zh/example.py
@@ -174,6 +174,7 @@ def extract_template_zh_x(
                             "]"
                         ):
                             example_data.raw_tags.append(span_text.strip("[]"))
+                    break
                 if not is_roman:
                     example_data.translation = dd_text
         results.extend(extract_zh_x_dl_span_tag(wxr, dl_tag, example_data))
@@ -185,6 +186,7 @@ def extract_template_zh_x(
             "span", attr_name="lang", attr_value="Latn"
         ):
             example_data.roman = clean_node(wxr, None, span_tag)
+            break
         for span_tag in expanded_node.find_html("span"):
             span_text = clean_node(wxr, None, span_tag)
             if span_text.startswith("[") and span_text.endswith("]"):


### PR DESCRIPTION
Similar to zh commit 4468de7, there is a small difference in expanded HTML nodes: "trad." and "simp." links after example text are inside an `<i>` tag, zh edition doesn't have it.

Test was added in the zh edition commit, I also tested some pages locally.