### PR TITLE
[de] rename `Example`'s "raw_ref" field to "ref"

### DIFF
--- a/src/wiktextract/extractor/de/models.py
+++ b/src/wiktextract/extractor/de/models.py
@@ -47,7 +47,7 @@ class Example(BaseModelWrap):
     )
     raw_tags: list[str] = []
     tags: list[str] = []
-    raw_ref: str = Field(default="", description="Raw reference string")
+    ref: str = Field(default="", description="Raw reference string")
     url: str = Field(
         default="", description="A web link. Not necessarily well-formated."
     )

--- a/tests/test_de_example.py
+++ b/tests/test_de_example.py
@@ -77,7 +77,7 @@ class TestDEExample(unittest.TestCase):
                     "examples": [
                         {
                             "text": "example1",
-                            "raw_ref": "ref1A",
+                            "ref": "ref1A",
                         },
                     ],
                     "sense_index": "1",
@@ -100,7 +100,7 @@ class TestDEExample(unittest.TestCase):
         self.assertEqual(
             example_data.model_dump(exclude_defaults=True),
             {
-                "raw_ref": "Expanded template, Seite 273. "
+                "ref": "Expanded template, Seite 273. "
                 "ISBN 978-3-89029-459-9.",
                 "title": "Viva Warszawa",
                 "author": "Steffen Möller",
@@ -128,7 +128,7 @@ class TestDEExample(unittest.TestCase):
         self.assertEqual(
             example_data.model_dump(exclude_defaults=True),
             {
-                "raw_ref": "Expanded template",
+                "ref": "Expanded template",
             },
         )
 


### PR DESCRIPTION
Same as other editions.

And limit extract example reference template args to "Literatur" template, currently there are too many debug message of unknown args and it's a maintenance nightmare to track all these templates.