### PR TITLE
clean_value: Remove whitespace before Category links

### DIFF
--- a/src/wiktextract/clean.py
+++ b/src/wiktextract/clean.py
@@ -1529,7 +1529,7 @@ def clean_value(
         # Links may be nested, so keep replacing until there is no more change.
         orig = title
         title = re.sub(
-            rf"(?si)\[\[\s*{category_names_pattern}\s*:\s*([^]]+?)\s*\]\]",
+            rf"(?si)\s*\[\[\s*{category_names_pattern}\s*:\s*([^]]+?)\s*\]\]",
             "",
             title,
         )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -8,7 +8,7 @@ from wiktextract.thesaurus import close_thesaurus_db
 from wiktextract.wxr_context import WiktextractContext
 
 
-class WiktExtractTests(unittest.TestCase):
+class CleanTests(unittest.TestCase):
     def setUp(self) -> None:
         self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
 
@@ -138,6 +138,11 @@ class WiktExtractTests(unittest.TestCase):
         v = "[[  File  :Foo.jpg]]Bar"
         v = clean_value(self.wxr, v)
         self.assertEqual(v, "Bar")
+
+    def test_cv_link14(self):
+        v = "foo    \n\n[[Category:Bar]]Bar"
+        v = clean_value(self.wxr, v)
+        self.assertEqual(v, "fooBar")
 
     def test_cv_url1(self):
         v = "This is a [http://ylonen.org test]."

--- a/tests/test_en_page.py
+++ b/tests/test_en_page.py
@@ -461,7 +461,7 @@ foo
                     "senses": [
                         {
                             "categories": ["bar"],
-                            "glosses": ["sense 1 , baz"],
+                            "glosses": ["sense 1, baz"],
                             "links": [("baz", "bazlink")],
                         },
                     ],


### PR DESCRIPTION
Can't find any easy documentation, but wikitext behavior seems to be that if there is any whitespace, including newlines, before a [[Category:...]] link that is not a "displayed" [[:Category:...]] link, all whitespace before that is stripped away. So:

```
foo

[[Category:test]]bar
```
becomes `foobar`.