### PR TITLE
[es] extract example text in "ejemplo" template's first parameter

### DIFF
--- a/src/wiktextract/extractor/es/example.py
+++ b/src/wiktextract/extractor/es/example.py
@@ -42,6 +42,11 @@ def process_ejemplo_template(
         elif "ref" == span_class:
             example_data.ref = clean_node(wxr, None, span_tag)
 
+    if len(example_data.text) == 0:
+        example_data.text = clean_node(
+            wxr, None, template_node.template_parameters.get(1, "")
+        )
+
     if len(example_data.text) > 0:
         template_data = TemplateData(
             expansion=clean_node(wxr, None, expanded_template)

--- a/tests/test_es_example.py
+++ b/tests/test_es_example.py
@@ -170,3 +170,17 @@ class TestESExample(unittest.TestCase):
                 }
             ],
         )
+
+    def test_ejemplo_no_ref(self):
+        self.wxr.wtp.start_page("read")
+        self.wxr.wtp.add_page(
+            "Plantilla:ejemplo",
+            10,
+            ":*'''Ejemplo:''' Do you read me?",
+        )
+        root = self.wxr.wtp.parse("{{ejemplo|Do you read me?}}")
+        sense_data = Sense()
+        extract_example(self.wxr, sense_data, root.children)
+        dump_data = sense_data.model_dump(exclude_defaults=True)["examples"]
+        del dump_data[0]["example_templates"]
+        self.assertEqual(dump_data, [{"text": "Do you read me?"}])


### PR DESCRIPTION
this template doesn't expand to HTML tags if source parameters are not used, fix #880