### PR TITLE
[en] silence invalid uppercase tag check JSON debug messages

### DIFF
--- a/src/wiktextract/wiktionary.py
+++ b/src/wiktextract/wiktionary.py
@@ -245,17 +245,16 @@ def check_tags(
         # non-English editions).  Tag values should be standardized across
         # editions, except for uppercase tags (e.g., regional variants).
         if wxr.wtp.lang_code in ("en",):  # Check edition
-            from .tags import valid_tags
+            from .tags import uppercase_tags, valid_tags
 
-            if tag not in valid_tags:
+            if tag not in valid_tags and tag not in uppercase_tags:
                 check_error(
                     wxr,
                     dt,
                     word,
                     lang,
                     pos,
-                    "invalid tag {} not in valid_tags (or "
-                    "uppercase_tags)".format(repr(tag)),
+                    f"invalid tag {tag} not in valid_tags(or uppercase_tags)",
                 )
 
 


### PR DESCRIPTION
too many this kind of messages bury the real check JSON messages

`valid_tags` and `uppercase_tags` global variables should use uppercase, but en code import them in many places and website code could also be affected so I didn't rename them.