### PR TITLE
[nl] fix `AttributeError` in page "Waal"

### DIFF
--- a/src/wiktextract/extractor/nl/inflection.py
+++ b/src/wiktextract/extractor/nl/inflection.py
@@ -45,7 +45,7 @@ def extract_noun_adj_table(
                     ).splitlines():
                         if form_str not in ["", "-", wxr.wtp.title]:
                             form = Form(form=form_str)
-                            if row_header not in ["", "naamwoord"]:
+                            if row_header not in ["", "naamwoord", "demoniem"]:
                                 form.raw_tags.append(row_header)
                             if col_index - 1 < len(column_headers):
                                 form.raw_tags.append(

--- a/src/wiktextract/extractor/nl/inflection.py
+++ b/src/wiktextract/extractor/nl/inflection.py
@@ -158,7 +158,7 @@ def extract_nlverb_template(
                 cell_rowspan_str = cell_node.attrs.get("rowspan", "1")
                 if re.fullmatch(r"\d+", cell_rowspan_str):
                     cell_rowspan = int(cell_rowspan_str)
-                cell_str = clean_node(wxr, None, cell_node)
+                cell_str = clean_node(wxr, None, cell_node).strip("| ")
                 if cell_str in ["", wxr.wtp.title]:
                     col_index += cell_colspan
                     is_row_first_node = False

--- a/src/wiktextract/extractor/nl/page.py
+++ b/src/wiktextract/extractor/nl/page.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 from mediawiki_langcodes import name_to_code
@@ -39,6 +40,7 @@ def parse_section(
     # title templates
     # https://nl.wiktionary.org/wiki/Categorie:Lemmasjablonen
     title_text = clean_node(wxr, None, level_node.largs)
+    title_text = re.sub(r"\s+#?\d+:?$", "", title_text)
     wxr.wtp.start_subsection(title_text)
     etymology_data = []
     if title_text in POS_DATA:

--- a/src/wiktextract/extractor/nl/section_titles.py
+++ b/src/wiktextract/extractor/nl/section_titles.py
@@ -46,6 +46,7 @@ POS_DATA = {
     "Achtervoegsel": {"pos": "suffix", "tags": ["morpheme"]},
     "Symbool": {"pos": "symbol"},
     "Werkwoord": {"pos": "verb"},
+    "Betrekkelijk naamwoord": {"pos": "noun", "tags": ["relative"]},
 }
 
 

--- a/src/wiktextract/extractor/nl/tags.py
+++ b/src/wiktextract/extractor/nl/tags.py
@@ -375,7 +375,7 @@ def translate_raw_tags(data: WordEntry) -> None:
                 data.tags.append(tr_tag)
             elif isinstance(tr_tag, list):
                 data.tags.extend(tr_tag)
-        elif raw_tag in TOPICS:
+        elif raw_tag in TOPICS and hasattr(data, "topics"):
             tr_topic = TOPICS[raw_tag]
             if isinstance(tr_topic, str):
                 data.topics.append(tr_topic)


### PR DESCRIPTION
"-nlnoun-" template doc doesn't say the fifth param is used in table header if provided