### PR TITLE
[en] Handle German tables preceded by a ";" list

### DIFF
--- a/src/wiktextract/extractor/en/inflection.py
+++ b/src/wiktextract/extractor/en/inflection.py
@@ -132,6 +132,7 @@ title_contains_global_map = {
     "variation of": "dummy-skip-this",  # a'/Scottish Gaelic
     "command form of": "imperative",  # a راتلل/Pashto
     "historical inflection of": "dummy-skip-this",  # kork/Norwegian Nynorsk
+    "obsolete declension": "obsolete",  # März/German 20241111
 }
 for k, v in title_contains_global_map.items():
     if any(t not in valid_tags for t in v.split()):
@@ -3389,6 +3390,7 @@ def parse_inflection_section(
     source = section
     tables = []
     titleparts = []
+    preceding_bolded_title = ""
 
     def process_tables():
         for kind, node, titles, after in tables:
@@ -3507,12 +3509,19 @@ def parse_inflection_section(
             else:
                 recurse(node.largs[0], titles, navframe)
             return
+        if kind == NodeKind.LIST and node.sarg == ";":
+            nonlocal preceding_bolded_title
+            from wiktextract.page import clean_node
+            preceding_bolded_title = clean_node(wxr, None, node).strip("; ")
         for x in node.children:
             recurse(x, titles, navframe)
 
     assert tree.kind == NodeKind.ROOT
     for x in tree.children:
-        recurse(x, [])
+        if preceding_bolded_title != "":
+            recurse(x, [preceding_bolded_title])
+        else:
+            recurse(x, [])
 
     # Process the tables we found
     process_tables()

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -2265,7 +2265,7 @@ def parse_language(
         # we can just count the single braces when those single
         # braces are part of a group.
 
-        # print(text)
+        # print(f"Parse inflection: {text=}")
         # print(repr(brace_matches))
         if len(brace_matches) > 1:
             tsection: list[str] = []
@@ -2275,7 +2275,12 @@ def parse_language(
             # otherwise, text
             # goes with preceding template
             for m in brace_matches:
-                if m.startswith("{{"):
+                if m.startswith("\n; ") and after_templates:
+                    after_templates = False
+                    template_sections.append(tsection)
+                    tsection = []
+                    tsection.append(m)
+                elif m.startswith("{{"):
                     if template_nesting == 0 and after_templates:
                         template_sections.append(tsection)
                         tsection = []


### PR DESCRIPTION
März/German 20241111

```
====Declension====
{{de-ndecl|m,-[predominant]:es[less common]}}
; Obsolete declension:
{{de-ndecl|m.weak}}
```

Previously, the definition list (WHICH SHOULD NOT BE USED FOR BOLDING/FORMATTING ACCORDING TO WIKITEXT GUIDELINES) was attached to the preceding template, instead of starting a new section.

Changes include: special handling for `;` lists in inflection sections, using the contents of those bolded lists as a title for the following template, and a new tagged title string in tags.py

Fixes #903