### PR TITLE
[en] Fix out-of-bound index error.

### DIFF
--- a/src/wiktextract/extractor/en/pronunciation.py
+++ b/src/wiktextract/extractor/en/pronunciation.py
@@ -897,7 +897,7 @@ def parse_pronunciation(
                 data_append(data, "sounds", audio)
         # if audios:
         #     have_pronunciations = True
-        audios = []
+    audios = []
 
     ## I have commented out the otherwise unused have_pronunciation
     ## toggles; uncomment them to use this debug print


### PR DESCRIPTION
Oops, indentation error... I am surprised I don't
do these more often.

Fixes a bunch of exceptions that killed kaikki extraction. For some reason, only relevant in Catalan entries, so maybe they did some bot work for those or a template changed. Not their fault, this bug is all mine.