### PR TITLE
[en] No need to use .strip() chaining

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1560,7 +1560,7 @@ def parse_language(
             # tags, you can add them to WORD_LEVEL_HEAD_TEMPLATES
             for templ_data in term_label_templates:
                 print(templ_data)
-                expan = templ_data.get("expansion", "").strip("(").strip(")")
+                expan = templ_data.get("expansion", "").strip("().,; ")
                 if not expan:
                     continue
                 tlb_tagsets, tlb_topics = decode_tags(expan)


### PR DESCRIPTION
I forgot Python strip() takes a string of characters, which are all stripped from both ends.