### PR TITLE
[en] Adjustment to form_description heuristics

### DIFF
--- a/src/wiktextract/extractor/en/form_descriptions.py
+++ b/src/wiktextract/extractor/en/form_descriptions.py
@@ -2447,16 +2447,25 @@ def parse_word_head(
                     if (
                         i > 1
                         and len(parts[i - 1]) >= 4
-                        and distw(titleparts, parts[i - 1]) <= 0.4
-                        # Fixes wiktextract #983, where "participle"
-                        # was too close to "Martinize" and so this accepted
-                        # ["participle", "Martinize"] as matching; this
-                        # kludge prevents this from happening if titleparts
-                        # is shorter than what would be 'related'.
-                        # This breaks if we want to detect stuff that
-                        # actually gets an extra space-separated word when
-                        # 'inflected'.
-                        and len(titleparts) >= len(parts[i - 1:])
+                        and (
+                            distw(titleparts, parts[i - 1]) <= 0.4
+                            # Fixes wiktextract #983, where "participle"
+                            # was too close to "Martinize" and so this accepted
+                            # ["participle", "Martinize"] as matching; this
+                            # kludge prevents this from happening if titleparts
+                            # is shorter than what would be 'related'.
+                            # This breaks if we want to detect stuff that
+                            # actually gets an extra space-separated word when
+                            # 'inflected'.
+                            or (
+                                wxr.wtp.section == "English"
+                                and any(
+                                    parts[i - 1].startswith(title)
+                                    for title in titleparts
+                                )
+                            )
+                        )
+                        and len(titleparts) >= len(parts[i - 1 :])
                     ):
                         # print(f"Reached; {parts=}, {parts[i-1]=}")
                         alt_related = related

--- a/tests/test_en_head.py
+++ b/tests/test_en_head.py
@@ -803,3 +803,40 @@ class HeadTests(unittest.TestCase):
             )[0]["forms"],
             [{"form": "chuunibyou", "tags": ["plural"]}],
         )
+
+    def test_english_forms_that_are_also_tag_words1(self):
+        # Issue #967
+        # Specifically only for English words
+        # "clipping" is in valid tags...
+        # Check if language section is "English", then if the checked
+        # word starts with the title ([clip]ping) accept that even if
+        # the distw is high (in this case, clipping and clip -> 0.5 distw())
+        data = {}
+        self.maxDiff = 10000
+        self.wxr.wtp.start_page("clip")
+        self.wxr.wtp.start_section("English")
+        self.wxr.wtp.start_subsection("verb")
+        parse_word_head(
+            self.wxr,
+            "verb",
+            "clip (third-person singular simple present clips, present participle clipping, simple past and past participle clipped)",
+            data,
+            False,
+            None,
+        )
+        # print(json.dumps(data, indent=2, sort_keys=True))
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {
+                        "form": "clips",
+                        "tags": ["present", "singular", "third-person"],
+                    },
+                    {"form": "clipping", "tags": ["participle", "present"]},
+                    {"form": "clipped", "tags": ["participle", "past"]},
+                    {"form": "clipped", "tags": ["past"]},
+                ],
+            },
+        )
+


### PR DESCRIPTION
"clipping" was skipped because it had too high distw() with "clip" (0.5), so I added yet another kludge for when the language section is English: if something starts with the title, accept it in this case. This will cause problems elsewhere, but we'll hunt those down...

Fixes #967