### PR TITLE
[en] Complicated case-by-case handling of missing forms

### DIFF
--- a/tests/test_en_head.py
+++ b/tests/test_en_head.py
@@ -21,7 +21,7 @@ class HeadTests(unittest.TestCase):
             Wtp(), WiktionaryConfig(capture_language_codes=None)
         )
         self.wxr.wtp.start_page("testpage")
-        self.wxr.wtp.start_section("English")
+        self.wxr.wtp.start_section("Finnish")
 
     def tearDown(self) -> None:
         self.wxr.wtp.close_db_conn()


### PR DESCRIPTION
Issue #967

In cases like "clipping" missing from the `forms` data for "clip", because of one reason or another the loop skips that section of the head forms, we instead check if the language is English and whether the article and the form are in a dict and let them through if so.

We also introduce a new debug message that warns when there seems like there should be a form with certain specific head-specific tags like "plural" or "present" or "participle". Empty cases cannot be reported because that would hit every "uncountable," style higher-level tag.