### PR TITLE
[en] Disable stray debug print; learned a new Python trick

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1565,7 +1565,7 @@ def parse_language(
             # of templates in headers that you want to squash and apply as
             # tags, you can add them to WORD_LEVEL_HEAD_TEMPLATES
             for templ_data in term_label_templates:
-                print(templ_data)
+                # print(templ_data)
                 expan = templ_data.get("expansion", "").strip("().,; ")
                 if not expan:
                     continue


### PR DESCRIPTION
https://stackoverflow.com/q/10742501

This is very helpful for hunting down forgotten prints.

I first tried to use pbd and `break print` to make a breakpoint on `print()` calls, but that doesn't
work for builtins, but the above Stackoverflow question had a suggestion that worked out. Just add the class and the code into wiktwords and reassign `sys.stdout` in `main()`, and it will at least tell you the
function that is generating the print.