### PR TITLE
Fix pre-expanded templates being split by inflection section template detection

### DIFF
--- a/src/wiktextract/extractor/en/inflection.py
+++ b/src/wiktextract/extractor/en/inflection.py
@@ -3046,6 +3046,10 @@ def handle_wikitext_or_html_table(
     # Imported here to avoid a circular import
     from wiktextract.page import clean_node, recursively_extract
 
+    # from wikitextprocessor.parser import print_tree
+    # print_tree(tree)
+    # print("-------==========-------")
+
     if not tablecontext:
         tablecontext = TableContext()
 
@@ -3089,6 +3093,8 @@ def handle_wikitext_or_html_table(
 
         sub_ret = []
 
+        # from wikitextprocessor.parser import print_tree
+        # print_tree(tree)
         for node in tree.children:
             if not isinstance(node, WikiNode):
                 continue
@@ -3169,6 +3175,19 @@ def handle_wikitext_or_html_table(
                         colspan = 1
                     # print("COL:", col)
 
+                    if colspan > 30:
+                        wxr.wtp.error(
+                            f"Colspan {colspan} over 30, set to 1",
+                            sortid="inflection/20250113a",
+                        )
+                        colspan = 1
+                    if rowspan > 30:
+                        wxr.wtp.error(
+                            f"Rowspan {rowspan} over 30, set to 1",
+                            sortid="inflection/20250113b",
+                        )
+                        rowspan = 1
+
                     # Process any nested tables recursively.
                     tables, rest = recursively_extract(
                         col,
@@ -3179,6 +3198,7 @@ def handle_wikitext_or_html_table(
                     # Clean the rest of the cell.
                     celltext = clean_node(wxr, None, rest)
                     # print("CLEANED:", celltext)
+                    # print(f"SUBTABLES: {tables}")
 
                     # Handle nested tables.
                     for tbl in tables:
@@ -3391,6 +3411,10 @@ def parse_inflection_section(
     tables = []
     titleparts = []
     preceding_bolded_title = ""
+
+    # from wikitextprocessor.parser import print_tree
+    # print_tree(tree)
+    # print("--------------******************----------------")
 
     def process_tables():
         for kind, node, titles, after in tables:

--- a/src/wiktextract/extractor/en/inflectiondata.py
+++ b/src/wiktextract/extractor/en/inflectiondata.py
@@ -4030,6 +4030,10 @@ infl_map: dict[str, InflMapNode] = {
         "lang": ["Assyrian Neo-Aramaic",],
         "then": "stem",
     },
+    "base form": {
+        "lang": ["Assyrian Neo-Aramaic",],
+        "then": "stem",
+    },
     "Personal-pronoun- including forms": {
         "lang": [
             "Arabic",

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -322,6 +322,10 @@ ADDITIONAL_EXPAND_TEMPLATES: set[str] = {
     "ru-alt-ё",
     "inflection of",
     "no deprecated lang param usage",
+    # These separated top and bottom templates for inflection tables were
+    # introduced at the end of 2024...
+    "inflection-table-top",
+    "inflection-table-bottom",
 }
 
 # Inverse linkage for those that have them

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -2340,7 +2340,14 @@ def parse_language(
         text = wxr.wtp.node_to_wikitext(node.children)
 
         # Split text into separate sections for each to-level template
-        brace_matches = re.split("({{+|}}+)", text)  # ["{{", "template", "}}"]
+        brace_matches = re.split(r"((?:^|\n)\s*{\||\n\s*\|}|{{+|}}+)", text)
+        # ["{{", "template", "}}"] or ["^{|", "table contents", "\n|}"]
+        # The (?:...) creates a non-capturing regex group; if it was capturing,
+        # like the group around it, it would create elements in brace_matches,
+        # including None if it doesn't match.
+        # 20250114: Added {| and |} into the regex because tables were being
+        # cut into pieces by this code. Issue #973, introduction of two-part
+        # book-end templates similar to trans-top and tran-bottom.
         template_sections = []
         template_nesting = 0  # depth of SINGLE BRACES { { nesting } }
         # Because there is the possibility of triple curly braces
@@ -2352,9 +2359,13 @@ def parse_language(
         # about the outer-most delimiters (the highest level template)
         # we can just count the single braces when those single
         # braces are part of a group.
+        table_nesting = 0
+        # However, if we have a stray table ({| ... |}) that should always
+        # be its own section, and should prevent templates from cutting it
+        # into sections.
 
         # print(f"Parse inflection: {text=}")
-        # print(repr(brace_matches))
+        # print(f"Brace matches: {repr('///'.join(brace_matches))}")
         if len(brace_matches) > 1:
             tsection: list[str] = []
             after_templates = False  # kludge to keep any text
@@ -2368,25 +2379,49 @@ def parse_language(
                     template_sections.append(tsection)
                     tsection = []
                     tsection.append(m)
-                elif m.startswith("{{"):
-                    if template_nesting == 0 and after_templates:
+                elif m.startswith("{{") or m.endswith("{|"):
+                    if (
+                        template_nesting == 0
+                        and after_templates
+                        and table_nesting == 0
+                    ):
                         template_sections.append(tsection)
                         tsection = []
                         # start new section
                     after_templates = True
-                    template_nesting += len(m)
+                    if m.startswith("{{"):
+                        template_nesting += 1
+                    else:
+                        # m.endswith("{|")
+                        table_nesting += 1
                     tsection.append(m)
-                elif m.startswith("}}"):
-                    template_nesting -= len(m)
-                    if template_nesting < 0:
-                        wxr.wtp.error(
-                            "Negatively nested braces, "
-                            "couldn't split inflection templates, "
-                            "{}/{} section {}".format(word, language, section),
-                            sortid="page/1871",
-                        )
-                        template_sections = []  # use whole text
-                        break
+                elif m.startswith("}}") or m.endswith("|}"):
+                    if m.startswith("}}"):
+                        template_nesting -= 1
+                        if template_nesting < 0:
+                            wxr.wtp.error(
+                                "Negatively nested braces, "
+                                "couldn't split inflection templates, "
+                                "{}/{} section {}".format(
+                                    word, language, section
+                                ),
+                                sortid="page/1871",
+                            )
+                            template_sections = []  # use whole text
+                            break
+                    else:
+                        table_nesting -= 1
+                        if table_nesting < 0:
+                            wxr.wtp.error(
+                                "Negatively nested table braces, "
+                                "couldn't split inflection section, "
+                                "{}/{} section {}".format(
+                                    word, language, section
+                                ),
+                                sortid="page/20250114",
+                            )
+                            template_sections = []  # use whole text
+                            break
                     tsection.append(m)
                 else:
                     tsection.append(m)

--- a/tests/test_en_inflection_aii.py
+++ b/tests/test_en_inflection_aii.py
@@ -1,0 +1,242 @@
+# -*- fundamental -*-
+#
+# Tests for parsing inflection tables
+#
+# Copyright (c) 2021, 2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
+import unittest
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.en.inflection import parse_inflection_section
+from wiktextract.thesaurus import close_thesaurus_db
+from wiktextract.wxr_context import WiktextractContext
+
+
+class InflTests(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+        self.wxr = WiktextractContext(Wtp(), WiktionaryConfig())
+        self.wxr.wtp.start_page("testpage")
+        self.wxr.wtp.start_section("Assyrian Neo-Aramaic")
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+        close_thesaurus_db(
+            self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
+        )
+
+    def xinfl(self, word, lang, pos, section, text):
+        """Runs a single inflection table parsing test, and returns ``data``."""
+        self.wxr.wtp.start_page(word)
+        self.wxr.wtp.start_section(lang)
+        self.wxr.wtp.start_subsection(pos)
+        tree = self.wxr.wtp.parse(text)
+        data = {}
+        parse_inflection_section(self.wxr, data, word, lang, pos, section, tree)
+        return data
+
+    def test_aii_table(self):
+        ret = self.xinfl(
+            "ܛܠܐ",
+            "Assyrian Neo-Aramaic",
+            "prep",
+            "Conjugation",
+            """
+<div class="inflection-table-wrapper%2Binflection-table-narrow%2Binflection-table-red%2B%2Binflection-table-collapsible%2Binflection-table-collapsed%2Bno-vc%2B" style="width%253A%2Bfit-content" data-toggle-category="inflection"><templatestyles src="Template%253Ainflection-table-top%252Fstyle.css">
+
+
+{| class="inflection-table%2B"
+
+|+ 
+ class="inflection-table-title"
+ Inflection of <i class="Syrc%2Bmention" lang="aii">ܛܠܵܐ</i>
+
+
+|- 
+
+! colspan="3" class="outer" | base form
+
+
+
+
+| <span class="Syrc" lang="aii">[[ܛܠܐ#Assyrian&#95;Neo-Aramaic|ܛܠܵܐ]]</span> <span class="mention-gloss-paren+annotation-paren">(</span><span lang="aii-Latn" class="tr+Latn">ṭlā</span><span class="mention-gloss-paren+annotation-paren">)</span>
+
+
+
+
+|- 
+
+! colspan="999" class="separator" |
+
+
+
+
+|- 
+
+! colspan="4" class="outer" | Personal-pronoun including forms
+
+
+
+
+|- 
+
+! rowspan="2" class="outer" |
+
+
+
+
+! colspan="2" | singular
+
+
+
+
+! rowspan="2" | plural
+
+
+
+
+|- 
+
+! class="secondary" | <span class="gender"><abbr title="masculine+gender">m</abbr></span>
+
+
+
+
+! class="secondary" | <span class="gender"><abbr title="feminine+gender">f</abbr></span>
+
+
+
+
+|- 
+
+! class="outer" |1<sup>st</sup> person
+
+
+
+
+| colspan="2" | <span class="Syrc" lang="aii">[[ܛܠܬܝ#Assyrian&#95;Neo-Aramaic|ܛܠܵܬ݂ܝܼ]]</span> <span class="mention-gloss-paren+annotation-paren">(</span><span lang="aii-Latn" class="tr+Latn">ṭlāṯī</span><span class="mention-gloss-paren+annotation-paren">)</span>
+
+
+
+
+| <span class="Syrc" lang="aii">[[ܛܠܬܢ#Assyrian&#95;Neo-Aramaic|ܛܠܵܬ݂ܲܢ]]</span> <span class="mention-gloss-paren+annotation-paren">(</span><span lang="aii-Latn" class="tr+Latn">ṭlāṯan</span><span class="mention-gloss-paren+annotation-paren">)</span>
+
+
+
+
+|- class="vsHide"
+
+! class="outer" | 2<sup>nd</sup> person
+
+
+
+
+| <span class="Syrc" lang="aii">[[ܛܠܬܘܟ#Assyrian&#95;Neo-Aramaic|ܛܠܵܬ݂ܘܼܟ݂]]</span> <span class="mention-gloss-paren+annotation-paren">(</span><span lang="aii-Latn" class="tr+Latn">ṭlāṯūḵ</span><span class="mention-gloss-paren+annotation-paren">)</span>
+
+
+
+
+| <span class="Syrc" lang="aii">[[ܛܠܬܟܝ#Assyrian&#95;Neo-Aramaic|ܛܠܵܬ݂ܵܟ݂ܝ]]</span> <span class="mention-gloss-paren+annotation-paren">(</span><span lang="aii-Latn" class="tr+Latn">ṭlāṯāḵ</span><span class="mention-gloss-paren+annotation-paren">)</span>
+
+
+
+
+| <span class="Syrc" lang="aii">[[ܛܠܬܘܟܘܢ#Assyrian&#95;Neo-Aramaic|ܛܠܵܬ݂ܵܘܟ݂ܘܿܢ]]</span> <span class="mention-gloss-paren+annotation-paren">(</span><span lang="aii-Latn" class="tr+Latn">ṭlāṯāwḵōn</span><span class="mention-gloss-paren+annotation-paren">)</span>
+
+
+
+
+|- 
+
+! class="outer" | 3<sup>rd</sup> person
+
+
+
+
+| <span class="Syrc" lang="aii">[[ܛܠܬܗ#Assyrian&#95;Neo-Aramaic|ܛܠܵܬ݂ܹܗ]]</span> <span class="mention-gloss-paren+annotation-paren">(</span><span lang="aii-Latn" class="tr+Latn">ṭlāṯēh</span><span class="mention-gloss-paren+annotation-paren">)</span>
+
+
+
+
+| <span class="Syrc" lang="aii">[[ܛܠܬܗ#Assyrian&#95;Neo-Aramaic|ܛܠܵܬ݂ܵܗ̇]]</span> <span class="mention-gloss-paren+annotation-paren">(</span><span lang="aii-Latn" class="tr+Latn">ṭlāṯāh</span><span class="mention-gloss-paren+annotation-paren">)</span>
+
+
+
+
+| <span class="Syrc" lang="aii">[[ܛܠܬܗܘܢ#Assyrian&#95;Neo-Aramaic|ܛܠܵܬ݂ܗܘܿܢ]]</span> <span class="mention-gloss-paren+annotation-paren">(</span><span lang="aii-Latn" class="tr+Latn">ṭlāṯhōn</span><span class="mention-gloss-paren+annotation-paren">)</span>
+
+
+
+
+|}
+
+
+
+</div>
+""",  # noqa: E501 W291
+        )
+        expected = {
+            "forms": [
+                {
+                    "form": "no-table-tags",
+                    "tags": ["table-tags"],
+                    "source": "Conjugation",
+                },
+                {
+                    "form": "ܛܠܵܐ",
+                    "roman": "ṭlā",
+                    "source": "Conjugation",
+                    "tags": ["stem"],
+                },
+                {
+                    "form": "ܛܠܵܬ݂ܝܼ",
+                    "roman": "ṭlāṯī",
+                    "source": "Conjugation",
+                    "tags": ["first-person", "singular", "stem"],
+                },
+                {
+                    "form": "ܛܠܵܬ݂ܲܢ",
+                    "roman": "ṭlāṯan",
+                    "source": "Conjugation",
+                    "tags": ["first-person", "plural"],
+                },
+                {
+                    "form": "ܛܠܵܬ݂ܘܼܟ݂",
+                    "roman": "ṭlāṯūḵ",
+                    "source": "Conjugation",
+                    "tags": ["masculine", "second-person", "singular", "stem"],
+                },
+                {
+                    "form": "ܛܠܵܬ݂ܵܟ݂ܝ",
+                    "roman": "ṭlāṯāḵ",
+                    "source": "Conjugation",
+                    "tags": ["feminine", "second-person", "singular", "stem"],
+                },
+                {
+                    "form": "ܛܠܵܬ݂ܵܘܟ݂ܘܿܢ",
+                    "roman": "ṭlāṯāwḵōn",
+                    "source": "Conjugation",
+                    "tags": ["plural", "second-person"],
+                },
+                {
+                    "form": "ܛܠܵܬ݂ܹܗ",
+                    "roman": "ṭlāṯēh",
+                    "source": "Conjugation",
+                    "tags": ["masculine", "singular", "stem", "third-person"],
+                },
+                {
+                    "form": "ܛܠܵܬ݂ܵܗ̇",
+                    "roman": "ṭlāṯāh",
+                    "source": "Conjugation",
+                    "tags": ["feminine", "singular", "stem", "third-person"],
+                },
+                {
+                    "form": "ܛܠܵܬ݂ܗܘܿܢ",
+                    "roman": "ṭlāṯhōn",
+                    "source": "Conjugation",
+                    "tags": ["plural", "third-person"],
+                },
+            ]
+        }
+        self.assertEqual(expected, ret)


### PR DESCRIPTION
At some point, having several templates in an inflection section needed to be fixed, which I think I? did with a simple regex for curly braces and matching nesting levels.

However, in cases where you got already pre-expanded (or just raw wikitext) tables in the inflection section instead of templates, this broke down the table when encountering templates inside the table.

This should fix #973 

The issue was the introduction of new inflection-table-top and inflection-table-bottom book-end templates, similarly to how trans-top and trans-bottom are used to generate large translation sections. These generate warning messages because they create dangling HTML tags and other nasty stuff, but as long as they're pre-expanded it should be fine... Except it exposed a previous bug as detailed above.

Tests to check for this bug added under test_en_inflection_aii.py because that seems the way to do this.