### PR TITLE
[en] Remove unnecessary pre-expand directive

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -322,10 +322,6 @@ ADDITIONAL_EXPAND_TEMPLATES: set[str] = {
     "ru-alt-ё",
     "inflection of",
     "no deprecated lang param usage",
-    # These separated top and bottom templates for inflection tables were
-    # introduced at the end of 2024...
-    "inflection-table-top",
-    "inflection-table-bottom",
 }
 
 # Inverse linkage for those that have them


### PR DESCRIPTION
Turns out this was unnecessary, I just missed it
because I didn't test whether it was necessary.

These two templates are already put under pre-expand due to automatic heuristics.