### PR TITLE
[en] Ignore "also/..." templates like "also" is ignored

### DIFF
--- a/src/wiktextract/extractor/en/form_descriptions.py
+++ b/src/wiktextract/extractor/en/form_descriptions.py
@@ -1550,8 +1550,8 @@ def add_related(
     assert isinstance(ruby_data, (list, tuple)) or ruby_data is None
     if ruby_data is None:
         ruby_data = []
-    # print("add_related: tags_lst={} related={}".format(tags_lst, related))
     related = " ".join(related_list)
+    # print("add_related: tags_lst={} related={}".format(tags_lst, related))
     if related == "[please provide]":
         return None
     if related in IGNORED_RELATED:

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -4244,7 +4244,7 @@ def parse_top_template(
             return ""
         if name in ("reconstruction",):
             return ""
-        if name.lower() == "also":
+        if name.lower() == "also" or name.lower().startswith("also/"):
             # XXX shows related words that might really have been the intended
             # word, capture them
             return ""


### PR DESCRIPTION
Just to get rid of some unnecessary debug messages, `also` was previously ignored but not its subpages.