### PR TITLE
[en] fix Lua error and `IndexError` exception in categories.py

### DIFF
--- a/src/wiktextract/wiktwords.py
+++ b/src/wiktextract/wiktwords.py
@@ -502,7 +502,7 @@ def main():
         extract_namespace(wxr, "Module", args.modules_file)
     if args.templates_file:
         extract_namespace(wxr, "Template", args.templates_file)
-    if args.categories_file:
+    if args.categories_file and args.dump_file_language_code == "en":
         logger.info("Extracting category tree")
         tree = extract_categories(wxr)
         with open(args.categories_file, "w") as f:


### PR DESCRIPTION
One of the "Module:category tree/poscatboiler/data" subpage has a string type `v.parents`.