### PR TITLE
[en] remove "aii-infl-prep/1c" from "inflection_templates"

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -290,7 +290,7 @@ FLOATING_TABLE_TEMPLATES: set[str] = {
 # so that the template are left in place with their identifying
 # name intact for later filtering.
 
-DO_NOT_PRE_EXPAND_TEMPLATES: set[str] = {"aii-infl-prep/1c"}
+DO_NOT_PRE_EXPAND_TEMPLATES: set[str] = set()
 DO_NOT_PRE_EXPAND_TEMPLATES.update(FLOATING_TABLE_TEMPLATES)
 
 # Additional templates to be expanded in the pre-expand phase
@@ -2328,7 +2328,7 @@ def parse_language(
                 r"declension|inflection|mut|mutation)($|-)",
                 name,
             )
-            if m is not None or name == "ar-prep-auto":
+            if m:
                 args_ht = clean_template_args(wxr, ht)
                 dt = {"name": name, "args": args_ht}
                 data_append(pos_data, "inflection_templates", dt)


### PR DESCRIPTION
GH issue https://github.com/tatuylonen/wiktextract/issues/973
Related PR https://github.com/tatuylonen/wiktextract/pull/1030

There's a lot aii templates which are afflicted by this issue and imo it's better if it works for all or none - otherwise it creates some confusion
