### PR TITLE
Aii extra space

### DIFF
--- a/src/wiktextract/extractor/en/form_descriptions.py
+++ b/src/wiktextract/extractor/en/form_descriptions.py
@@ -1809,11 +1809,14 @@ def parse_word_head(
     if len(links) > 0:
         # if we have link data (that is, links with stuff like commas and
         # spaces, replace word_re with a modified local scope pattern
+        # print(f"links {list((c, ord(c)) for link in links for c in link)=}")
         word_re = re.compile(
-            r"|".join(
+            r"\b" +  # In case we have forms that are longer and contain links
+                # or words as a substring...
+            r"\b|\b".join(
                 sorted((re.escape(s) for s in links), key=lambda x: -len(x))
             )
-            + r"|"
+            + r"\b|"
             + word_pattern
         )
     else:
@@ -2019,7 +2022,7 @@ def parse_word_head(
         # print("EXPANDED_ALTS:", expanded_alts)
         tagsets: Optional[list[tuple[str, ...]]]
         for alt in expanded_alts:
-            baseparts = list(m.group(0) for m in re.finditer(word_re, alt))
+            baseparts = list(m.group(0) for m in word_re.finditer(alt))
             if alt_i > 0:
                 tagsets, topics = decode_tags(" ".join(baseparts))
                 if not any("error-unknown-tag" in x for x in tagsets):

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1518,7 +1518,7 @@ def parse_language(
             else:
                 pos_data["info_templates"].extend(info_template_data)
 
-        if not word.isalnum():
+        if not word.isalnum() and not (word[0] != "-" and word[1:].isalnum()):
             # if the word contains non-letter or -number characters, it might
             # have something that messes with split-at-semi-comma; we collect
             # links so that we can skip splitting them.
@@ -3218,7 +3218,10 @@ def parse_language(
                 ):
                     # These are expanded in the default way
                     return None
-                if name in ("trans-top", "trans-top-see",):
+                if name in (
+                    "trans-top",
+                    "trans-top-see",
+                ):
                     # XXX capture id from trans-top?  Capture sense here
                     # instead of trying to parse it from expanded content?
                     if ht.get(1):

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1518,23 +1518,28 @@ def parse_language(
             else:
                 pos_data["info_templates"].extend(info_template_data)
 
-        if not word.isalnum() and not (word[0] != "-" and word[1:].isalnum()):
-            # if the word contains non-letter or -number characters, it might
-            # have something that messes with split-at-semi-comma; we collect
-            # links so that we can skip splitting them.
-            exp = wxr.wtp.parse(
-                wxr.wtp.node_to_wikitext(header_nodes), expand_all=True
-            )
-            link_nodes, _ = recursively_extract(
-                exp.children,
-                lambda x: isinstance(x, WikiNode) and x.kind == NodeKind.LINK,
-            )
-            for ln in link_nodes:
-                ltext = clean_node(wxr, None, ln.largs[-1])  # type: ignore[union-attr]
-                if not ltext.isalnum():
-                    links.append(ltext)
-            if word not in links:
-                links.append(word)
+        if not word.isalnum():
+            # `-` is kosher, add more of these if needed.
+            if word.replace("-", "").isalnum():
+                pass
+            else:
+                # if the word contains non-letter or -number characters, it
+                # might have something that messes with split-at-semi-comma; we
+                # collect links so that we can skip splitting them.
+                exp = wxr.wtp.parse(
+                    wxr.wtp.node_to_wikitext(header_nodes), expand_all=True
+                )
+                link_nodes, _ = recursively_extract(
+                    exp.children,
+                    lambda x: isinstance(x, WikiNode)
+                    and x.kind == NodeKind.LINK,
+                )
+                for ln in link_nodes:
+                    ltext = clean_node(wxr, None, ln.largs[-1])  # type: ignore[union-attr]
+                    if not ltext.isalnum():
+                        links.append(ltext)
+                if word not in links:
+                    links.append(word)
         if lang_code == "ja":
             exp = wxr.wtp.parse(
                 wxr.wtp.node_to_wikitext(header_nodes), expand_all=True

--- a/tests/test_en_head.py
+++ b/tests/test_en_head.py
@@ -719,6 +719,48 @@ class HeadTests(unittest.TestCase):
             },
         )
 
+    def test_head_combining_diacritics1(self):
+        # See https://en.wiktionary.org/wiki/-%DC%98#Assyrian_Neo-Aramaic
+        # Issue Wiktextract #1034
+        # WITHOUT DASH
+        data = {}
+        # Article title is missing combining diacritic
+        self.wxr.wtp.start_page("ܘ")
+        self.wxr.wtp.start_section("Assyrian Neo-Aramaic")
+        self.wxr.wtp.start_subsection("Suffix")
+        # Combining diacritic in head
+        parse_word_head(self.wxr, "suffix", "ܘܿ", data, False, None)
+        # print(json.dumps(data, indent=2, sort_keys=True))
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"form": "ܘܿ", "tags": ["canonical"]},
+                ],
+            },
+        )
+
+    def test_head_combining_diacritics2(self):
+        # See https://en.wiktionary.org/wiki/-%DC%98#Assyrian_Neo-Aramaic
+        # Issue Wiktextract #1034
+        # WITH DASH
+        data = {}
+        # Article title is missing combining diacritic
+        self.wxr.wtp.start_page("-ܘ")
+        self.wxr.wtp.start_section("Assyrian Neo-Aramaic")
+        self.wxr.wtp.start_subsection("Suffix")
+        # Combining diacritic in head
+        parse_word_head(self.wxr, "suffix", "-ܘܿ", data, False, None)
+        # print(json.dumps(data, indent=2, sort_keys=True))
+        self.assertEqual(
+            data,
+            {
+                "forms": [
+                    {"form": "-ܘܿ", "tags": ["canonical"]},
+                ],
+            },
+        )
+
     def test_head_templates_regex(self):
         # GitHub issue 405
         from wiktextract.extractor.en.page import HEAD_TAG_RE
@@ -839,4 +881,3 @@ class HeadTests(unittest.TestCase):
                 ],
             },
         )
-


### PR DESCRIPTION
Aii, aii, aii. At first I thought the issues was regex (and it can be, but not specifically here).

Fixes #1034

This is because of a kludge I had where I added problematic article titles to a list `links` containing words taken from links in the head, which would then be added to the default regex as "words".

The issue here was that the dash at the start of the articles (because they're suffixes) caused the article title to be added to `links`, but the articles did not have the *combining diacritic* that the form *did* have. So the regex had a "word" that overrode the actual good behavior, and it would split the form into two: the first characters from the article title and then a combining diacritic (+ rest if any).

This cannot be fixed in regex with `\b` (word-boundary virtual character that doesn't exist but can be used to find where a `\w` and `\W` meet) because **combining diacritics do not count as `\w` word characters in `re`**.

I did add "\b" to the regex anyhow, it shouldn't break things that weren't already broken, but the fix here really is a stupid kludge to check if the article has any non-alphanumeric characters after we've removed all the dashes. This takes care of situations where we have "-blaa", because the original function of the kludge to remove words/phrases with non-alnum was due to how they might break when we split on things like commas and semicolons, not dashes.