### PR TITLE
Fix two `SetuptoolsDeprecationWarning`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "wiktextract"
 version = "1.99.7"
 description = "Wiktionary dump file parser and multilingual data extractor"
 readme = "README.md"
-license = {text = "MIT License"}
+license = "MIT"
 authors = [
     {name = "Tatu Ylonen", email = "ylo@clausal.com"},
 ]
@@ -15,7 +15,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
- `project.license` as a TOML table is deprecated
- License classifiers are deprecated