### PR TITLE
[en] Add "Nouns" and "Proper Nouns" linkage section titles

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -3653,7 +3653,6 @@ def parse_language(
             return None
 
         for node in treenode.children:
-            # print(node)
             if not isinstance(node, WikiNode):
                 # print("  X{}".format(repr(node)[:40]))
                 continue
@@ -3765,6 +3764,7 @@ def parse_language(
                         for pdata in pos_datas:
                             data_extend(pdata, "tags", dt["tags"])
                 elif t_no_number in LINKAGE_TITLES:
+                    # print(f"LINKAGE_TITLES NODE {node=}")
                     rel = LINKAGE_TITLES[t_no_number]
                     data = select_data()
                     parse_linkage(data, rel, node)

--- a/src/wiktextract/extractor/en/section_titles.py
+++ b/src/wiktextract/extractor/en/section_titles.py
@@ -120,7 +120,7 @@ POS_TITLES: dict[str, POSSubtitleData] = {
         "pos": "noun",
         "debug": "part-of-speech Noun form is proscribed",
     },
-    "nouns": {"pos": "noun", "debug": "usually in singular"},
+    # "nouns": {"pos": "noun", "debug": "usually in singular"},
     "noum": {"pos": "noun", "debug": "misspelled subtitle"},
     "number": {"pos": "num", "tags": ["number"]},
     "numeral": {"pos": "num"},
@@ -235,6 +235,8 @@ LINKAGE_TITLES: dict[str, str] = {
     "proverbs": "proverbs",
     "abbreviations": "abbreviations",
     "derived terms": "derived",
+    "nouns": "derived",
+    "proper nouns": "derived",
 }
 
 COMPOUNDS_TITLE = "compounds"


### PR DESCRIPTION
See: mouth, heath, town

If we have a section like

```
====Derived terms====
* {{lookfrom|en|town}}

=====Nouns=====
...

=====Proper nouns=====
...
```

fix_subtitle_hierarchy will demote "Derived Terms" to level 6 (due to moving all Pronunciation sections between 3 and 4) and so `Nouns` and `Proper Nouns` are at the same level and don't get parsed at all.

Fix: make section titles "nouns" and "proper nouns" into linkage section names. This seems to be the case in the database currently, "Nouns" and "Proper nouns" are not used as POS sections.