### PR TITLE
[el] Support parsing Linkage in Sense

### DIFF
--- a/src/wiktextract/extractor/el/page.py
+++ b/src/wiktextract/extractor/el/page.py
@@ -41,7 +41,11 @@ from .section_titles import (
 def parse_page(
     wxr: WiktextractContext, page_title: str, page_text: str
 ) -> list[dict[str, WordEntry]]:
-    """Parse Greek Wiktionary (el.wiktionary.org) page."""
+    """Parse Greek Wiktionary (el.wiktionary.org) page.
+
+    References:
+    * https://el.wiktionary.org/wiki/Βικιλεξικό:Δομή_λημμάτων
+    """
 
     if wxr.config.verbose:
         logger.info(f"Parsing page: {page_title}")
@@ -123,7 +127,6 @@ def parse_page(
         )
 
         prev_data: WordEntry | None = None
-
 
         if len(sublevels) == 0 and ok:
             # Someone messed up by putting a Level 1 directly after a language

--- a/tests/test_el_glosses.py
+++ b/tests/test_el_glosses.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest import TestCase
 
 from wikitextprocessor import Wtp
@@ -6,6 +7,10 @@ from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.el.models import WordEntry
 from wiktextract.extractor.el.pos import process_pos
 from wiktextract.wxr_context import WiktextractContext
+
+
+def raw_trim(raw: str) -> str:
+    return "\n".join(line.strip() for line in raw.strip().split("\n"))
 
 
 class TestElGlosses(TestCase):
@@ -22,6 +27,131 @@ class TestElGlosses(TestCase):
 
     def tearDown(self) -> None:
         self.wxr.wtp.close_db_conn()
+
+    def mktest_bl_linkage(self, raw: str, expected: dict[str, Any]) -> None:
+        """Test βλ-linkage parsing in glosses.
+
+        Reference:
+        https://el.wiktionary.org/wiki/Πρότυπο:βλ
+
+        Test suite:
+        * linkage inside synonym
+        * linkage without gloss
+        * linkage without gloss, but one quote
+        * linkage without gloss, with βλ-prefixed linkage
+        * linkage basic
+        * linkage multiple
+        * linkage useless (delete)
+
+        Notes:
+        * Is this another template or equivalent?
+        https://el.wiktionary.org/wiki/Πρότυπο:ΒΠ
+        * Same for βλέπε, δείτε etc.
+        """
+        self.wxr.wtp.start_page("start_filler")
+        data = WordEntry(lang="Greek", lang_code="el", word="word_filler")
+        # * Prefixing the header allows us to not have it everywhere in the tests.
+        # * Adding the head just silences a warning.
+        raw = "==={{ουσιαστικό|el}}===\n'''head'''\n" + raw_trim(raw)
+        root = self.wxr.wtp.parse(raw)
+        pos_node = root.children[0]
+        process_pos(self.wxr, pos_node, data, None, "", "", pos_tags=[])  # type: ignore
+        # from wiktextract.extractor.el.logger import dbg
+        # dbg(data)
+        dumped = data.model_dump(exclude_defaults=True)
+        senses = {"senses": dumped["senses"]}
+        self.assertEqual(senses, expected)
+
+    def test_bl_linkage_inside_synonym(self) -> None:
+        # https://el.wiktionary.org/wiki/αφόδευμα
+        #
+        # NOTE: the original had a {{}} instead of {{συνων}} that was expanded
+        # before reaching process_pos, so we edited manually.
+        raw = """
+            * [[ό,τι]] [[αφοδεύω|αφοδεύει]] κάποιος
+            *: {{συνων}} {{βλ|περίττωμα}}
+        """
+        expected = {
+            "senses": [
+                {
+                    "glosses": ["ό,τι αφοδεύει κάποιος"],
+                    "related": [{"word": "περίττωμα"}],
+                }
+            ],
+        }
+        self.mktest_bl_linkage(raw, expected)
+
+    def test_bl_linkage_no_gloss(self) -> None:
+        # https://el.wiktionary.org/wiki/αγριόσκυλος
+        raw = """* {{βλ|αγριόσκυλο}}"""
+        expected = {"senses": [{"related": [{"word": "αγριόσκυλο"}]}]}
+        self.mktest_bl_linkage(raw, expected)
+
+    def test_bl_linkage_no_gloss_with_bl_starting_linkage(self) -> None:
+        # Handmade: to test prefix selection.
+        raw = """* {{βλ|βλέπε}}"""
+        expected = {"senses": [{"related": [{"word": "βλέπε"}]}]}
+        self.mktest_bl_linkage(raw, expected)
+
+    def test_bl_linkage_no_gloss_one_quote(self) -> None:
+        # https://el.wiktionary.org/wiki/αιματόχροος
+        raw = """
+            * {{βλ|αιματόχρους}}
+            *: {{παράθεμα}} ''Στα πρώτα...''
+        """
+        expected = {
+            "senses": [
+                {
+                    "examples": [{"text": ":Πρότυπο:παράθεμα Στα πρώτα..."}],
+                    "related": [{"word": "αιματόχρους"}],
+                }
+            ],
+        }
+        self.mktest_bl_linkage(raw, expected)
+
+    def test_bl_linkage(self) -> None:
+        # https://el.wiktionary.org/wiki/μετροταινία
+        raw = """
+            * οποιοδήποτε είδος ταινίας...
+            *: {{βλ|και=2|μεζούρα}}
+        """
+        expected = {
+            "senses": [
+                {
+                    "glosses": ["οποιοδήποτε είδος ταινίας..."],
+                    "related": [{"word": "μεζούρα"}],
+                }
+            ]
+        }
+        self.mktest_bl_linkage(raw, expected)
+
+    def test_bl_linkage_multiple(self) -> None:
+        # https://el.wiktionary.org/wiki/ισοβαρής
+        raw = """
+            # που ενώνει σημεία με ίδια [[βαρομετρικός|βαρομετρική]] [[πίεση]]
+            #: {{βλ|όρος=1|ισοβαρής γραμμή|ισοβαρής καμπύλη}}
+            #: {{βλ|και=2|ισαλλοβαρής}}
+        """
+        expected = {
+            "senses": [
+                {
+                    "glosses": ["που ενώνει σημεία με ίδια βαρομετρική πίεση"],
+                    "related": [
+                        {"word": "ισοβαρής γραμμή"},
+                        {"word": "ισοβαρής καμπύλη"},
+                        {"word": "ισαλλοβαρής"},
+                    ],
+                },
+            ],
+        }
+        self.mktest_bl_linkage(raw, expected)
+
+    def test_bl_linkage_inline_useless(self) -> None:
+        # https://el.wiktionary.org/wiki/επί
+        # Should delete the βλ template
+        raw = """# δηλώνει [[αιτία]] {{βλ|όρος=τις εκφράσεις}}"""
+        expected = {"senses": [{"glosses": ["δηλώνει αιτία"]}]}
+        self.mktest_bl_linkage(raw, expected)
 
     def test_el_glosses1(self) -> None:
         self.wxr.wtp.start_page("brain")


### PR DESCRIPTION
Partially addresses #1087 

I would like some feedback before continuing, specially since I feel like I am reinventing the wheel, and that some of my helper functions are probably already somewhere else.

Pasting the `mktest_bl_linkage` testing helper function docstring, these should be covered now. By linkage, read only (for now) βλ-linkage.
- [x] linkage inside synonym
- [x] linkage without gloss
- [x] linkage without gloss, but one quote
- [x] linkage without gloss, with βλ-prefixed linkage
- [x] linkage basic
- [x] linkage multiple
- [x] linkage useless (delete)