### PR TITLE
[en] Pre-expand `Template:transclude`

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -322,6 +322,8 @@ ADDITIONAL_EXPAND_TEMPLATES: set[str] = {
     "ru-alt-ё",
     "inflection of",
     "no deprecated lang param usage",
+    "transclude",  # these produce sense entries (or other lists)
+    "tcl",
 }
 
 # Inverse linkage for those that have them


### PR DESCRIPTION
Fixes some issues, for example see ܒܝܬ ܢܗܪܝܢ/Assyrian Neo- Aramaic.

These templates (which find sense data by id from other articles) create lists (of glosses, typically) that are turned into lists too late and thus get lumped under one gloss entry.