### PR TITLE
[en] extract "uxa" example template as "ux" template

### DIFF
--- a/src/wiktextract/extractor/en/example.py
+++ b/src/wiktextract/extractor/en/example.py
@@ -68,6 +68,7 @@ def extract_example_list_item(
             "collocation",
             "co",
             "coi",
+            "uxa",
         ]:
             examples.append(
                 extract_ux_template(


### PR DESCRIPTION
same Lua module, resolve #1119