### PR TITLE
[el] add form_of parsing for inflections (nouns, adjectives)

### DIFF
--- a/src/wiktextract/extractor/el/models.py
+++ b/src/wiktextract/extractor/el/models.py
@@ -120,7 +120,7 @@ class Sense(GreekBaseModel):
     glosses: list[str] = []  # ["Gloss supercategory", "Specific gloss."]
     tags: list[str] = []
     raw_tags: list[str] = []
-    # form_of: list[FormOf] = []
+    form_of: list[FormOf] = []
     # alt_of : list[FormOf] = []
     # compound_of: list[FormOf] = []
     # topics: list[str] = []

--- a/src/wiktextract/extractor/el/tags_utils.py
+++ b/src/wiktextract/extractor/el/tags_utils.py
@@ -65,6 +65,6 @@ def convert_tags(raw_tags: list[str]) -> tuple[list[str], list[str], list[str]]:
 
 def convert_tags_in_sense(sense: Sense) -> None:
     tags, raw_tags, poses = convert_tags(sense.raw_tags)
-    sense.tags = tags
+    sense.tags.extend(tags)
     sense.raw_tags = raw_tags
     sense.tags.extend(poses)

--- a/tests/test_el_form_of.py
+++ b/tests/test_el_form_of.py
@@ -52,7 +52,6 @@ class TestElGlosses(TestCase):
             self.assertIn("glosses", sense)
             sense.pop("glosses")
 
-        received = dumped["senses"]
         # print(f"{received=}")
         # print(f"{expected=}")
         self.assertEqual(received, expected)

--- a/tests/test_el_inflection.py
+++ b/tests/test_el_inflection.py
@@ -46,15 +46,11 @@ class TestElGlosses(TestCase):
         dumped = data.model_dump(exclude_defaults=True)
 
         # Check for the "glosses" key and remove it for comparison
-        for sense in dumped["senses"]:
+        received = dumped["senses"]
+        for sense in received:
             self.assertIsInstance(sense, dict)
             self.assertIn("glosses", sense)
             sense.pop("glosses")
-
-            # The order of tags may change between runs
-            # FIXME: this should not be the case?
-            if "raw_tags" in sense:
-                sense["raw_tags"].sort()
 
         received = dumped["senses"]
         # print(f"{received=}")
@@ -66,8 +62,8 @@ class TestElGlosses(TestCase):
         raw = """* {{πτώσηΑεν|κόρφος}}"""
         expected = [
             {
-                "raw_tags": ["αιτιατική", "ενικού"],
                 "form_of": [{"word": "κόρφος"}],
+                "tags": ["accusative", "singular"],
             }
         ]
         self.mktest_sense(raw, expected)
@@ -77,7 +73,7 @@ class TestElGlosses(TestCase):
         raw = """* {{πτώσειςΟΚπλ|κόρφος}}"""
         expected = [
             {
-                "raw_tags": ["κλητική", "ονομαστική", "πληθυντικού"],
+                "tags": ["nominative", "plural", "vocative"],
                 "form_of": [{"word": "κόρφος"}],
             }
         ]
@@ -88,8 +84,13 @@ class TestElGlosses(TestCase):
         raw = """* {{θηλ_του-πτώσειςΟΑΚεν|μικρός}}"""
         expected = [
             {
-                "tags": ["θηλυκό"],  # This is parsed somewhere else I guess
-                "raw_tags": ["αιτιατική", "ενικού", "κλητική", "ονομαστική"],
+                "tags": [
+                    "accusative",
+                    "feminine",
+                    "nominative",
+                    "singular",
+                    "vocative",
+                ],
                 "form_of": [{"word": "μικρός"}],
             }
         ]
@@ -103,16 +104,16 @@ class TestElGlosses(TestCase):
         """
         expected = [
             {
-                "raw_tags": ["αιτιατική", "ενικού"],
+                "tags": ["accusative", "singular"],
                 "form_of": [{"word": "θαυμάσιος"}],
             },
             {
-                "raw_tags": [
-                    "αιτιατική",
-                    "ενικού",
-                    "κλητική",
-                    "ονομαστική",
-                    "ουδέτερο",
+                "tags": [
+                    "accusative",
+                    "neuter",
+                    "nominative",
+                    "singular",
+                    "vocative",
                 ],
                 "form_of": [{"word": "θαυμάσιος"}],
             },
@@ -122,6 +123,5 @@ class TestElGlosses(TestCase):
     def test_inflection_verb(self) -> None:
         # https://el.wiktionary.org/wiki/ξεκίνησα
         raw = """* {{ρημ τύπος|α' ενικό [[οριστική]]ς αορίστου|ξεκινώ}}"""
-        expected = [{'form_of': [{'word': 'ξεκινώ'}]}]
+        expected = [{"form_of": [{"word": "ξεκινώ"}]}]
         self.mktest_sense(raw, expected)
-

--- a/tests/test_el_inflection.py
+++ b/tests/test_el_inflection.py
@@ -53,7 +53,8 @@ class TestElGlosses(TestCase):
 
             # The order of tags may change between runs
             # FIXME: this should not be the case?
-            sense["raw_tags"].sort()
+            if "raw_tags" in sense:
+                sense["raw_tags"].sort()
 
         received = dumped["senses"]
         # print(f"{received=}")
@@ -117,3 +118,10 @@ class TestElGlosses(TestCase):
             },
         ]
         self.mktest_sense(raw, expected)
+
+    def test_inflection_verb(self) -> None:
+        # https://el.wiktionary.org/wiki/ξεκίνησα
+        raw = """* {{ρημ τύπος|α' ενικό [[οριστική]]ς αορίστου|ξεκινώ}}"""
+        expected = [{'form_of': [{'word': 'ξεκινώ'}]}]
+        self.mktest_sense(raw, expected)
+

--- a/tests/test_el_inflection.py
+++ b/tests/test_el_inflection.py
@@ -1,0 +1,119 @@
+from typing import Any
+from unittest import TestCase
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.el.models import WordEntry
+from wiktextract.extractor.el.pos import process_pos
+from wiktextract.wxr_context import WiktextractContext
+
+
+def raw_trim(raw: str) -> str:
+    return "\n".join(line.strip() for line in raw.strip().split("\n"))
+
+
+class TestElGlosses(TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="el"),
+            WiktionaryConfig(
+                dump_file_lang_code="el",
+                capture_language_codes=None,
+            ),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def mktest_sense(self, raw: str, expected: list[dict[str, Any]]) -> None:
+        """Compare only senses["tags"] and senses["form_of"].
+
+        Do not compare senses["glosses"] but check that it exists. This
+        way we don't need to expand templates, and we still (roughly) check
+        that we didn't delete any glosses in the process.
+        """
+        self.wxr.wtp.start_page("start_filler")
+        data = WordEntry(lang="Greek", lang_code="el", word="word_filler")
+        # * Prefixing the header allows us to not have it everywhere in the tests.
+        # * Adding the head just silences a warning.
+        raw = "==={{ουσιαστικό|el}}===\n'''head'''\n" + raw_trim(raw)
+        root = self.wxr.wtp.parse(raw)
+        pos_node = root.children[0]
+        process_pos(self.wxr, pos_node, data, None, "", "", pos_tags=[])  # type: ignore
+        dumped = data.model_dump(exclude_defaults=True)
+
+        # Check for the "glosses" key and remove it for comparison
+        for sense in dumped["senses"]:
+            self.assertIsInstance(sense, dict)
+            self.assertIn("glosses", sense)
+            sense.pop("glosses")
+
+            # The order of tags may change between runs
+            # FIXME: this should not be the case?
+            sense["raw_tags"].sort()
+
+        received = dumped["senses"]
+        # print(f"{received=}")
+        # print(f"{expected=}")
+        self.assertEqual(received, expected)
+
+    def test_inflection_noun(self) -> None:
+        # https://el.wiktionary.org/wiki/κόρφο
+        raw = """* {{πτώσηΑεν|κόρφος}}"""
+        expected = [
+            {
+                "raw_tags": ["αιτιατική", "ενικού"],
+                "form_of": [{"word": "κόρφος"}],
+            }
+        ]
+        self.mktest_sense(raw, expected)
+
+    def test_inflection_noun_multiple(self) -> None:
+        # https://el.wiktionary.org/wiki/κόρφο
+        raw = """* {{πτώσειςΟΚπλ|κόρφος}}"""
+        expected = [
+            {
+                "raw_tags": ["κλητική", "ονομαστική", "πληθυντικού"],
+                "form_of": [{"word": "κόρφος"}],
+            }
+        ]
+        self.mktest_sense(raw, expected)
+
+    def test_inflection_adj(self) -> None:
+        # https://el.wiktionary.org/wiki/μικρή
+        raw = """* {{θηλ_του-πτώσειςΟΑΚεν|μικρός}}"""
+        expected = [
+            {
+                "tags": ["θηλυκό"],  # This is parsed somewhere else I guess
+                "raw_tags": ["αιτιατική", "ενικού", "κλητική", "ονομαστική"],
+                "form_of": [{"word": "μικρός"}],
+            }
+        ]
+        self.mktest_sense(raw, expected)
+
+    def test_inflection_adj_multiple(self) -> None:
+        # https://el.wiktionary.org/wiki/θαυμάσιο
+        raw = """
+            # {{πτώσηΑεν|θαυμάσιος}}
+            # {{ουδ του-πτώσειςΟΑΚεν|θαυμάσιος}}
+        """
+        expected = [
+            {
+                "raw_tags": ["αιτιατική", "ενικού"],
+                "form_of": [{"word": "θαυμάσιος"}],
+            },
+            {
+                "raw_tags": [
+                    "αιτιατική",
+                    "ενικού",
+                    "κλητική",
+                    "ονομαστική",
+                    "ουδέτερο",
+                ],
+                "form_of": [{"word": "θαυμάσιος"}],
+            },
+        ]
+        self.mktest_sense(raw, expected)


### PR DESCRIPTION
Closes #1122

- [x] Adds `form_of` and `raw_tags` for `[gender of] + πτώσ(η|εις)` templates. 
This should cover most nouns and adjectives.
- [x] Test it.
- [x] Support verbs.
- [x] Localize to English and populate `tags` instead of `raw_tags`

Notes:
- Glosses are unchanged based on this [structure]
(https://github.com/tatuylonen/wiktextract/issues/1122#issuecomment-2803472770).
- Glosses are not tested in order to avoid expanding templates. I did verify locally that indeed they were unaffected by the changes.
- Some `raw_tags` (cf. θηλυκό) are parsed from `raw_tags` into `tags` at some other points of the code. I didn't add any extra logic myself.
- I didn't see how to apply @xxyzz [comment](https://github.com/tatuylonen/wiktextract/issues/1122#issuecomment-2800936424). Everything is done at `parse_gloss_inflections`.

Let me know what you think.