### PR TITLE
[en] strip newline from template name

### DIFF
--- a/src/wiktextract/extractor/en/analyze_template.py
+++ b/src/wiktextract/extractor/en/analyze_template.py
@@ -144,7 +144,7 @@ def analyze_template(wtp: Wtp, page: Page) -> tuple[set[str], bool]:
                  (\|  |  \}\})            # | or }}""",
         unpaired_text,
     ):
-        called_template = m.group(3)
+        called_template = m.group(3).strip()
         called_template = re.sub(r"(?si)<nowiki\s*/>", "", called_template)
         if len(called_template) > 0:
             included_templates.add(called_template)


### PR DESCRIPTION
this is regards to #973

when templates are used with newlines, ex. https://en.wiktionary.org/w/index.php?title=%DC%9F%DC%98%DC%A1%DC%AC%DC%AA%DC%90&action=edit&section=5 the name is not correctly parsed out, this attempts to fix that so we end up with `"aii-infl-noun"` instead of `"aii-infl-noun\n"` as the template name