### PR TITLE
[el] Some stupid code-duplication to recheck for glosses

### DIFF
--- a/src/wiktextract/extractor/el/pos.py
+++ b/src/wiktextract/extractor/el/pos.py
@@ -124,6 +124,18 @@ def process_pos(
             glosses_lists.append(line[0])
 
     if glosses_index is None:
+        # if nothing found, accept ":" nodes
+        for i, line in enumerate(node_lines):
+            if (
+                len(line) == 1
+                and isinstance(line[0], WikiNode)
+                and line[0].kind == NodeKind.LIST
+            ):
+                if glosses_index is None:
+                    glosses_index = i
+                glosses_lists.append(line[0])
+
+    if glosses_index is None:
         # Could not find any glosses.
         # logger.info(f"  ////  {wxr.wtp.title}\n  MISSING GLOSSES")
         wxr.wtp.warning("Missing glosses", sortid="pos/20250121")


### PR DESCRIPTION
Fixes #1185

Some word entries just use a pseudo-gloss with ":" and a "see x"-template, with nothing else. If we find something that at first doesn't seem to have any glosses, check it again and accept `:` lists.