### PR TITLE
[el] Support `ρημ τύπος` template when prefixed by "junk"

### DIFF
--- a/src/wiktextract/extractor/el/pos.py
+++ b/src/wiktextract/extractor/el/pos.py
@@ -525,19 +525,12 @@ def extract_form_of_templates(
     https://el.wiktionary.org/wiki/Κατηγορία:Πρότυπα_για_κλιτικούς_τύπους
     https://el.wiktionary.org/wiki/Πρότυπο:ρημ_τύπος
     """
-
-    # For the moment...
-    # Be sure that we only contain a single non-string node!
-    compact_contents = [
-        elt for elt in contents if isinstance(elt, WikiNode) or elt.strip()
-    ]
-    if len(compact_contents) != 1:
+    # Be sure that we only contain a single template node!
+    t_nodes = [elt for elt in contents if isinstance(elt, TemplateNode)]
+    if len(t_nodes) != 1:
         return
 
-    t_node = compact_contents[0]
-    if not isinstance(t_node, TemplateNode):
-        return
-
+    t_node = t_nodes[0]
     t_name = t_node.template_name
 
     # Generic
@@ -572,6 +565,12 @@ def extract_form_of_templates(
         lemma = clean_node(wxr, None, t_args[2])
         form_of = FormOf(word=lemma)
         parent_sense.form_of.append(form_of)
+        # Discard useless information by keeping only the single template node.
+        # Cf. https://el.wiktionary.org/wiki/συμβουλέψω
+        # This will discard the following parts that offer no value:
+        # * (''να, ας, αν, ίσως κλπ'')
+        # * '''θα συμβουλέψω''':
+        contents[:] = t_nodes
 
 
 def extract_form_of_templates_ptosi(

--- a/src/wiktextract/extractor/el/pos.py
+++ b/src/wiktextract/extractor/el/pos.py
@@ -565,12 +565,6 @@ def extract_form_of_templates(
         lemma = clean_node(wxr, None, t_args[2])
         form_of = FormOf(word=lemma)
         parent_sense.form_of.append(form_of)
-        # Discard useless information by keeping only the single template node.
-        # Cf. https://el.wiktionary.org/wiki/συμβουλέψω
-        # This will discard the following parts that offer no value:
-        # * (''να, ας, αν, ίσως κλπ'')
-        # * '''θα συμβουλέψω''':
-        contents[:] = t_nodes
 
 
 def extract_form_of_templates_ptosi(

--- a/tests/test_el_form_of.py
+++ b/tests/test_el_form_of.py
@@ -139,7 +139,12 @@ class TestElGlosses(TestCase):
     def test_form_of_verb_template1_with_noise1(self) -> None:
         # https://el.wiktionary.org/wiki/συμβουλέψω
         raw = """# (''να, ας, αν, ίσως κλπ'') {{ρημ τύπος|α' ενικό [[Παράρτημα:Ρηματικοί τύποι (ελληνικά)#Υποτακτική|υποτακτικής]] αορίστου|συμβουλεύω}}"""
-        expected = [{"form_of": [{"word": "συμβουλεύω"}]}]
+        expected = [
+            {
+                "raw_tags": ["να", "ας", "αν", "ίσως κλπ"],
+                "form_of": [{"word": "συμβουλεύω"}],
+            }
+        ]
         self.mktest_sense(raw, expected)
 
     def test_form_of_verb_template1_with_noise2(self) -> None:

--- a/tests/test_el_form_of.py
+++ b/tests/test_el_form_of.py
@@ -130,10 +130,22 @@ class TestElGlosses(TestCase):
         ]
         self.mktest_sense(raw, expected)
 
-    def test_inflection_verb(self) -> None:
+    def test_form_of_verb_template1(self) -> None:
         # https://el.wiktionary.org/wiki/ξεκίνησα
         raw = """* {{ρημ τύπος|α' ενικό [[οριστική]]ς αορίστου|ξεκινώ}}"""
         expected = [{"form_of": [{"word": "ξεκινώ"}]}]
+        self.mktest_sense(raw, expected)
+
+    def test_form_of_verb_template1_with_noise1(self) -> None:
+        # https://el.wiktionary.org/wiki/συμβουλέψω
+        raw = """# (''να, ας, αν, ίσως κλπ'') {{ρημ τύπος|α' ενικό [[Παράρτημα:Ρηματικοί τύποι (ελληνικά)#Υποτακτική|υποτακτικής]] αορίστου|συμβουλεύω}}"""
+        expected = [{"form_of": [{"word": "συμβουλεύω"}]}]
+        self.mktest_sense(raw, expected)
+
+    def test_form_of_verb_template1_with_noise2(self) -> None:
+        # https://el.wiktionary.org/wiki/συμβουλέψω
+        raw = """# '''θα συμβουλέψω''': {{ρημ τύπος|α' ενικό οριστικής στιγμιαίου μέλλοντα|συμβουλεύω}}"""
+        expected = [{"form_of": [{"word": "συμβουλεύω"}]}]
         self.mktest_sense(raw, expected)
 
     def test_form_of_generic_template_noun(self) -> None:


### PR DESCRIPTION
This requires a bit of grammar explanation. I'll try to be succint.

I will probably butcher some terms, so bear with me.

Every Greek verb (take `λέω`, to say) uses the perfective form (`πω`) for both simple future and subjunctive. The only way to distinguish both is by looking at the previous particle. `θα πω` (= I will say) / `να πω` (not really translatable, but when found alone, it is something like ~let me say). Not much unlike in English `I will say` / `I would say` requires you to look at the previous particle and not only the verb inflection.

Now, for some reason, the wiktionary editors decided to repeat this "rule" at every entry, even though it is not something that depends on the verb, identically to what happens in English.

You can find, for example [here](https://el.wiktionary.org/wiki/συμβουλέψω)

```
==={{μορφή ρήματος|el}}===
'''{{PAGENAME}}'''
# (''να, ας, αν, ίσως κλπ'') {{ρημ τύπος|α' ενικό [[Παράρτημα:Ρηματικοί τύποι (ελληνικά)#Υποτακτική|υποτακτικής]] αορίστου|συμβουλεύω}}
# '''θα συμβουλέψω''': {{ρημ τύπος|α' ενικό οριστικής στιγμιαίου μέλλοντα|συμβουλεύω}}
```

And this happens a lot...

This was discarded by our previous logic since it contained two non trivial nodes. So we now just proceed if we find a single template node instead. This is fine.

The part that is maybe more debatable is this line

```py
        contents[:] = t_nodes
```

Now this is done to remove the (''να, ας, αν, ίσως κλπ'') so that it does not get parsed as raw tags. That is, so that we don't end up with this junk:

```
"raw_tags": ["να", "ας", "αν", "ίσως κλπ"],
```

at the end. 

I argue that removing this is completely fine too, since the verb information is already in the template (even though we don't parse it yet). That is, we could perfectly extract the future/subjuntive tags by just looking at

```
# {{ρημ τύπος|α' ενικό [[Παράρτημα:Ρηματικοί τύποι (ελληνικά)#Υποτακτική|υποτακτικής]] αορίστου|συμβουλεύω}}
# {{ρημ τύπος|α' ενικό οριστικής στιγμιαίου μέλλοντα|συμβουλεύω}}
```

υποτακτική > subjuntive
στιγμιαίου μέλλοντα > (genitive of) simple future