### PR TITLE
[el] Extract `form_of` when there are more than one template in contents

### DIFF
--- a/src/wiktextract/extractor/el/pos.py
+++ b/src/wiktextract/extractor/el/pos.py
@@ -511,7 +511,7 @@ def bold_node_fn(
 
 
 def extract_form_of_templates(
-    wxr: WiktextractContext, parent_sense: Sense, contents: list[str | WikiNode]
+    wxr: WiktextractContext, parent_sense: Sense, t_node: TemplateNode
 ) -> None:
     """Parse form_of for nouns, adjectives and verbs.
 
@@ -525,12 +525,6 @@ def extract_form_of_templates(
     https://el.wiktionary.org/wiki/Κατηγορία:Πρότυπα_για_κλιτικούς_τύπους
     https://el.wiktionary.org/wiki/Πρότυπο:ρημ_τύπος
     """
-    # Be sure that we only contain a single template node!
-    t_nodes = [elt for elt in contents if isinstance(elt, TemplateNode)]
-    if len(t_nodes) != 1:
-        return
-
-    t_node = t_nodes[0]
     t_name = t_node.template_name
 
     # Generic
@@ -658,7 +652,9 @@ def parse_gloss(
     if len(contents) == 0:
         return False
 
-    extract_form_of_templates(wxr, parent_sense, contents)
+    for t_node in contents:
+        if isinstance(t_node, TemplateNode):
+            extract_form_of_templates(wxr, parent_sense, t_node)
 
     template_tags: list[str] = []
     synonyms: list[Linkage] = []

--- a/tests/test_el_glosses.py
+++ b/tests/test_el_glosses.py
@@ -37,6 +37,7 @@ class TestElGlosses(TestCase):
         Test suite:
         * linkage in a not (":" or "*")-ending LIST_ITEM
         * linkage in a list with a single ":"
+        * linkage together with another template
         * linkage inside synonym
         * linkage without gloss
         * linkage without gloss, but one quote
@@ -91,6 +92,21 @@ class TestElGlosses(TestCase):
             "senses": [
                 {"related": [{"word": "αναμαλλιάζω"}], "tags": ["no-gloss"]}
             ]
+        }
+        self.mktest_bl_linkage(raw, expected)
+
+    def test_bl_linkage_with_another_template(self) -> None:
+        # https://el.wiktionary.org/wiki/επωτίδες
+        raw = """* {{πτώσειςΟΑΚπλ|επωτίδα}} {{βλ|όρος=το αρχαίο|ἐπωτίδες}}"""
+        expected = {
+            "senses": [
+                {
+                    "glosses": [":Πρότυπο:πτώσειςΟΑΚπλ"],
+                    "tags": ["accusative", "nominative", "plural", "vocative"],
+                    "form_of": [{"word": "επωτίδα"}],
+                    "related": [{"word": "ἐπωτίδες"}],
+                }
+            ],
         }
         self.mktest_bl_linkage(raw, expected)
 


### PR DESCRIPTION
The test should be self explanatory.

Note that the `πτώσεις` template transpiles to the glosses. This is fine and coherent with the tests in `test_el_form_of.py`. The glosses just happen to be hidden there. Compare the results from a word in that test suite with the newly added `επωτίδες`:

```JSONL
{"word":"κόρφο","lang_code":"el","lang":"Greek","pos":"noun","senses":[{"glosses":["αιτιατική ενικού του κόρφος"],"tags":["accusative","singular"],"form_of":[{"word":"κόρφος"}]}]}
{"word":"επωτίδες","lang_code":"el","lang":"Greek","pos":"noun","senses":[{"glosses":["ονομαστική, αιτιατική και κλητική πληθυντικού του επωτίδα"],"tags":["accusative","nominative","plural","vocative"],"form_of":[{"word":"επωτίδα"}],"related":[{"word":"ἐπωτίδες"}]}]}
```