### PR TITLE
[el] Support `form_of` for participles

### DIFF
--- a/src/wiktextract/extractor/el/pos.py
+++ b/src/wiktextract/extractor/el/pos.py
@@ -519,11 +519,13 @@ def extract_form_of_templates(
     * κλ             | generic                | form_of
     * πτώση/πτώσεις  | nouns, adjectives etc. | form_of and tags
     * ρημ τύπος      | verbs                  | form_of
+    * μτχ            | verbs                  | form_of
 
     * References:
     https://el.wiktionary.org/wiki/Πρότυπο:κλ
     https://el.wiktionary.org/wiki/Κατηγορία:Πρότυπα_για_κλιτικούς_τύπους
     https://el.wiktionary.org/wiki/Πρότυπο:ρημ_τύπος
+    https://el.wiktionary.org/wiki/Κατηγορία:Πρότυπα_για_μετοχές
     """
     t_name = t_node.template_name
 
@@ -557,6 +559,18 @@ def extract_form_of_templates(
             )
             return
         lemma = clean_node(wxr, None, t_args[2])
+        form_of = FormOf(word=lemma)
+        parent_sense.form_of.append(form_of)
+    if t_name.startswith("μτχ"):
+        t_args = t_node.template_parameters
+        if 1 not in t_args:
+            wxr.wtp.warning(
+                "Form-of template does not have lemma data: "
+                f"{t_name}, {t_args=}",
+                sortid="pos/570/20250517",
+            )
+            return
+        lemma = clean_node(wxr, None, t_args[1])
         form_of = FormOf(word=lemma)
         parent_sense.form_of.append(form_of)
 

--- a/tests/test_el_form_of.py
+++ b/tests/test_el_form_of.py
@@ -153,6 +153,18 @@ class TestElGlosses(TestCase):
         expected = [{"form_of": [{"word": "συμβουλεύω"}]}]
         self.mktest_sense(raw, expected)
 
+    def test_form_of_verb_participle1(self) -> None:
+        # https://el.wiktionary.org/wiki/καταρτισμένος
+        raw = """* {{μτχππ|καταρτίζω}}"""
+        expected = [{"form_of": [{"word": "καταρτίζω"}]}]
+        self.mktest_sense(raw, expected)
+
+    def test_form_of_verb_participle2(self) -> None:
+        # https://el.wiktionary.org/wiki/διαδεχθείς
+        raw = """* {{μτχα|διαδέχομαι|παθ=1|χ+=διαδέχθηκα|00=-}}"""
+        expected = [{"form_of": [{"word": "διαδέχομαι"}]}]
+        self.mktest_sense(raw, expected)
+
     def test_form_of_generic_template_noun(self) -> None:
         # https://el.wiktionary.org/wiki/εδάφη
         raw = "* {{κλ||έδαφος|π=οακ|α=π}}"


### PR DESCRIPTION
Support `form_of` for the [participle](https://el.wiktionary.org/wiki/Κατηγορία:Πρότυπα_για_μετοχές) (μετοχή) template family.