### PR TITLE
[ru] extract comparative forms data in "прил ru*" templates

### DIFF
--- a/src/wiktextract/extractor/ru/inflection.py
+++ b/src/wiktextract/extractor/ru/inflection.py
@@ -190,3 +190,25 @@ def add_form_data(
     if len(form.form) > 0 and form.form != "—":
         translate_raw_tags(form)
         word_entry.forms.append(form)
+
+
+def extract_прил_ru_comparative_forms(
+    wxr: WiktextractContext, word_entry: WordEntry, expanded_node: WikiNode
+) -> None:
+    after_comparative = False
+    for node in expanded_node.children:
+        if isinstance(node, str):
+            node_str = clean_node(wxr, None, node)
+            if node_str.endswith("Сравнительная степень —"):
+                after_comparative = True
+        elif (
+            after_comparative
+            and isinstance(node, WikiNode)
+            and node.kind == NodeKind.ITALIC
+        ):
+            for link_node in node.find_child(NodeKind.LINK):
+                form = clean_node(wxr, None, link_node)
+                if form != "":
+                    word_entry.forms.append(
+                        Form(form=form, tags=["comparative"])
+                    )

--- a/src/wiktextract/extractor/ru/page.py
+++ b/src/wiktextract/extractor/ru/page.py
@@ -15,7 +15,11 @@ from ...wxr_context import WiktextractContext
 from ...wxr_logging import logger
 from .etymology import extract_etymology
 from .gloss import extract_gloss, process_meaning_template
-from .inflection import parse_html_forms_table, parse_wikitext_forms_table
+from .inflection import (
+    extract_прил_ru_comparative_forms,
+    parse_html_forms_table,
+    parse_wikitext_forms_table,
+)
 from .linkage import (
     extract_alt_form_section,
     extract_linkage_section,
@@ -141,11 +145,6 @@ def get_pos(
 def extract_morphological_section(
     wxr: WiktextractContext, page_data: list[WordEntry], level_node: WikiNode
 ) -> None:
-    param_tag_map = {
-        "степень": "comparative",  # Шаблон:inflection/ru/adj
-        "соотв": "perfective",  # Шаблон:Гл-блок
-    }
-
     pos_data = get_pos(wxr, level_node)
     if pos_data is not None:
         page_data[-1].pos = pos_data["pos"]
@@ -180,6 +179,11 @@ def extract_morphological_section(
                 wxr, None, child_node.template_parameters.get("слоги", "")
             )
 
+        if child_node.template_name.startswith("прил ru"):
+            extract_прил_ru_comparative_forms(
+                wxr, page_data[-1], expanded_template
+            )
+
         for node in expanded_template.children:
             node_text = clean_node(wxr, page_data[-1], node)
             for text in node_text.split(","):
@@ -190,16 +194,6 @@ def extract_morphological_section(
                         page_data[-1].tags.append(tr_tag)
                     elif isinstance(tr_tag, list):
                         page_data[-1].tags.extend(tr_tag)
-
-        for param, tag in param_tag_map.items():
-            if param in child_node.template_parameters:
-                forms_text = clean_node(
-                    wxr, None, child_node.template_parameters[param]
-                )
-                for form in forms_text.split(","):
-                    form = form.strip()
-                    if form != "":
-                        page_data[-1].forms.append(Form(form=form, tags=[tag]))
 
 
 def parse_section(

--- a/tests/test_ru_gloss.py
+++ b/tests/test_ru_gloss.py
@@ -203,7 +203,6 @@ class TestRUGloss(unittest.TestCase):
                         "Глаголы в видовых парах",
                         "Глаголы, спряжение 1a",
                     ],
-                    "forms": [{"form": "прыгнуть", "tags": ["perfective"]}],
                     "lang": "Русский",
                     "lang_code": "ru",
                     "word": "прыгать",


### PR DESCRIPTION
use expanded nodes, template args are unreliable, fix #1212