### PR TITLE
[en] Fix templates `cot` and `alti` being interpreted as examples

### DIFF
--- a/src/wiktextract/extractor/en/example.py
+++ b/src/wiktextract/extractor/en/example.py
@@ -65,17 +65,20 @@ def extract_example_list_item(
             "th-usex",
             "th-x",
             "th-xi",
+            "uxa",
             "collocation",
             "co",
             "coi",
-            "uxa",
         ]:
+            copy_of_parent_data = deepcopy(parent_data)
+            if template_node.template_name in ("collocation", "co", "coi"):
+                copy_of_parent_data["tags"].append("collocation")
             examples.append(
                 extract_ux_template(
                     wxr,
                     template_node,
                     sense_data,
-                    deepcopy(parent_data),
+                    copy_of_parent_data,
                 )
             )
 

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -733,6 +733,18 @@ template_linkages_to_ignore_in_examples: set[str] = {
     "col",
     "inline alt forms",
     "alti",
+    "comeronyms",
+    "holonyms",
+    "holo",
+    "hypernyms",
+    "hyper",
+    "meronyms,"
+    "mero",
+    "troponyms",
+    "perfectives",
+    "pf",
+    "imperfectives",
+    "impf",
 }
 
 # Maps template name used in a word sense to a linkage field that it adds.
@@ -747,6 +759,28 @@ sense_linkage_templates: dict[str, str] = {
     "inline alt forms": "related",
     "coordinate terms": "coordinate_terms",
     "cot": "coordinate_terms",
+    "comeronyms": "related",
+    "holonyms": "holonyms",
+    "holo": "holonyms",
+    "hypernyms": "hypernyms",
+    "hyper": "hypernyms",
+    "meronyms": "meronyms",
+    "mero": "meronyms",
+    "troponyms": "troponyms",
+    "perfectives": "related",
+    "pf": "related",
+    "imperfectives": "related",
+    "impf": "related",
+}
+
+sense_linkage_templates_tags: dict[str, list[str]] = {
+    "alti": ["alternative"],
+    "inline alt forms": ["alternative"],
+    "comeronyms": ["comeronym"],
+    "perfectives": ["perfective"],
+    "pf": ["perfective"],
+    "imperfectives": ["imperfective"],
+    "impf": ["imperfective"],
 }
 
 
@@ -775,6 +809,7 @@ def parse_sense_linkage(
     assert isinstance(name, str)
     assert isinstance(ht, dict)
     field = sense_linkage_templates[name]
+    field_tags = sense_linkage_templates_tags.get(name, [])
     for i in range(2, 20):
         w = ht.get(i) or ""
         w = clean_node(wxr, data, w)
@@ -837,6 +872,8 @@ def parse_sense_linkage(
             alt = m.group(1)
 
         dt = {"word": w}
+        if field_tags:
+            data_extend(dt, "tags", field_tags)
         if tags:
             data_extend(dt, "tags", tags)
         if topics:

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -728,8 +728,11 @@ template_linkages: set[str] = {
     "der",
     "derived terms",
     "coordinate terms",
+    "cot",
     "rel",
     "col",
+    "inline alt forms",
+    "alti",
 }
 
 # Maps template name used in a word sense to a linkage field that it adds.
@@ -740,6 +743,10 @@ sense_linkage_templates: dict[str, str] = {
     "hyponyms": "hyponyms",
     "ant": "antonyms",
     "antonyms": "antonyms",
+    "alti": "related",
+    "inline alt forms": "related",
+    "coordinate terms": "coordinate_terms",
+    "cot": "coordinate_terms",
 }
 
 

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -718,7 +718,7 @@ taxonomy_templates = {
 # Template names, this was exctracted from template_linkage_mappings,
 # because the code using template_linkage_mappings was actually not used
 # (but not removed).
-template_linkages: set[str] = {
+template_linkages_to_ignore_in_examples: set[str] = {
     "syn",
     "synonyms",
     "ant",
@@ -3876,7 +3876,7 @@ def parse_language(
                         usex_type = "quotation"
                     elif name in taxonomy_templates:
                         taxons.update(ht.get(1, "").split())
-                    for prefix in template_linkages:
+                    for prefix in template_linkages_to_ignore_in_examples:
                         if re.search(
                             r"(^|[-/\s]){}($|\b|[0-9])".format(prefix), name
                         ):

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -745,12 +745,16 @@ template_linkages_to_ignore_in_examples: set[str] = {
     "pf",
     "imperfectives",
     "impf",
+    "syndiff",
+    "synsee",
 }
 
 # Maps template name used in a word sense to a linkage field that it adds.
 sense_linkage_templates: dict[str, str] = {
     "syn": "synonyms",
     "synonyms": "synonyms",
+    "synsee": "synonyms",
+    "syndiff": "synonyms",
     "hyp": "hyponyms",
     "hyponyms": "hyponyms",
     "ant": "antonyms",

--- a/src/wiktextract/extractor/en/type_utils.py
+++ b/src/wiktextract/extractor/en/type_utils.py
@@ -156,7 +156,7 @@ class SenseData(TypedDict, total=False):
     meronyms: list[LinkageData]
     qualifier: str
     raw_glosses: list[str]
-    related: list[LinkageData]
+    related: list[LinkageData]  # also used for "alternative forms"
     senseid: list[str]
     synonyms: list[LinkageData]
     tags: list[str]

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -6399,6 +6399,7 @@ valid_tags = {
     "no-predicative-form": "misc",  # diamanten/German
     "feminine-plural": "gender",  # Galician with different gender dep. on num.
     "masculine-plural": "gender",
+    "collocation": "misc",
 }
 
 for k, v in valid_tags.items():

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -6400,6 +6400,7 @@ valid_tags = {
     "feminine-plural": "gender",  # Galician with different gender dep. on num.
     "masculine-plural": "gender",
     "collocation": "misc",
+    "comeronym": "misc",
 }
 
 for k, v in valid_tags.items():


### PR DESCRIPTION
This took me far too long to figure out the correct way to do it. Fixes #1263 