### PR TITLE
[en] Introduce `hyphenations` field, handle `hyph` template

### DIFF
--- a/src/wiktextract/extractor/en/type_utils.py
+++ b/src/wiktextract/extractor/en/type_utils.py
@@ -89,6 +89,11 @@ class FormData(TypedDict, total=False):
     topics: list[str]
 
 
+class Hyphenation(TypedDict, total=False):
+    parts: list[str]
+    tags: list[str]
+
+
 SoundData = TypedDict(
     "SoundData",
     {
@@ -182,7 +187,8 @@ class WordData(TypedDict, total=False):
     forms: list[FormData]
     head_templates: list[TemplateData]
     holonyms: list[LinkageData]
-    hyphenation: list[str]
+    hyphenation: list[str]  # Being deprecated
+    hyphenations: list[Hyphenation]
     hypernyms: list[LinkageData]
     hyponyms: list[LinkageData]
     inflection_templates: list[TemplateData]

--- a/tests/test_en_pronunciation.py
+++ b/tests/test_en_pronunciation.py
@@ -313,3 +313,120 @@ class TestPronunciation(TestCase):
                 ]
             },
         )
+
+    def test_hyphenation_1(self):
+        self.wxr.wtp.start_page("baz")
+        self.wxr.wtp.add_page(
+            "Template:enPR", 10, "(Received Pronunciation) enPR: föö"
+        )
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* Noun:
+* {{hyphenation|en|foo|bar}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        # import pprint
+        # pprint.pp(out)
+
+        self.assertEqual(
+            out,
+            {
+                "hyphenations": [
+                    {
+                        "parts": ["foo", "bar"],
+                        "tags": [],
+                    },
+                ]
+            },
+        )
+
+    def test_hyphenation_2(self):
+        self.wxr.wtp.start_page("baz")
+        self.wxr.wtp.add_page(
+            "Template:enPR", 10, "(Received Pronunciation) enPR: föö"
+        )
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* Noun:
+* {{hyphenation|en|foo|bar||fo|obar}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        # import pprint
+        # pprint.pp(out)
+
+        self.assertEqual(
+            out,
+            {
+                "hyphenations": [
+                    {
+                        "parts": ["foo", "bar"],
+                        "tags": [],
+                    },
+                    {
+                        "parts": ["fo", "obar"],
+                        "tags": [],
+                    },
+                ]
+            },
+        )
+
+    def test_hyphenation_3(self):
+        self.wxr.wtp.start_page("baz")
+        self.wxr.wtp.add_page(
+            "Template:enPR", 10, "(Received Pronunciation) enPR: föö"
+        )
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* Noun:
+* {{hyphenation|en|foo|bar|caption=US}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        # import pprint
+        # pprint.pp(out)
+
+        self.assertEqual(
+            out,
+            {
+                "hyphenations": [
+                    {
+                        "parts": ["foo", "bar"],
+                        "tags": ["US"],
+                    },
+                ]
+            },
+        )
+
+    def test_hyphenation_4(self):
+        self.wxr.wtp.start_page("baz")
+        self.wxr.wtp.add_page(
+            "Template:enPR", 10, "(Received Pronunciation) enPR: föö"
+        )
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* Noun:
+* {{hyphenation|en|foo|bar||fo|obar||f|oobar|caption=US}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        # import pprint
+        # pprint.pp(out)
+
+        self.assertEqual(
+            out,
+            {
+                "hyphenations": [
+                    {
+                        "parts": ["foo", "bar"],
+                        "tags": ["US"],
+                    },
+                    {
+                        "parts": ["fo", "obar"],
+                        "tags": ["US"],
+                    },
+                    {
+                        "parts": ["f", "oobar"],
+                        "tags": ["US"],
+                    },
+                ]
+            },
+        )
+


### PR DESCRIPTION
Instead of having a field `hyphenation` (which should be deprecated) with a list of strings, this introduces a new Hyphenation TypeDict with a `parts: list[str]` field for the different parts of a hyphenation and `tags`.

Currently we will have these two parallel and try to remove `hyphenation` later.

`hyphenation` and `hyph` templates are also handled now in the template-handling function in pronunciation.py, in a similar way to pron and audio file templates.

However, some language-specific templates have their own modules that generate their own hyphenation text (looking at you, it-pr...) so this won't handle that.

"Why doesn't this Italian language example work?? Wait, `quieto` doesn't use `hyph` like the template documentation example said, it uses its own template..."