### PR TITLE
[en] Improve hyphenation code for arbitrary hyphenation in text

### DIFF
--- a/src/wiktextract/extractor/en/pronunciation.py
+++ b/src/wiktextract/extractor/en/pronunciation.py
@@ -783,14 +783,26 @@ def parse_pronunciation(
                         # have_pronunciations = True
 
             # This regex-based hyphenation detection left as backup
-            m = re.search(r"\b(Syllabification|Hyphenation): ([^\s,]*)", text)
+            m = re.search(r"\b(Syllabification|Hyphenation): *([^\n.]*)", text)
             if m:
                 data_append(data, "hyphenation", m.group(2))
-                data_append(
-                    data,
-                    "hyphenations",
-                    Hyphenation(parts=m.group(2).split(sep="-")),
-                )
+                commaseparated = m.group(2).split(",")
+                if len(commaseparated) > 1:
+                    for h in commaseparated:
+                        # That second characters looks like a dash but it's
+                        # actually unicode decimal code 8231, hyphenation dash
+                        # Add more delimiters here if needed.
+                        parts = re.split(r"-|‧", h.strip())
+                        data_append(
+                            data, "hyphenations", Hyphenation(parts=parts)
+                        )
+                    ...
+                else:
+                    data_append(
+                        data,
+                        "hyphenations",
+                        Hyphenation(parts=m.group(2).split(sep="-")),
+                    )
             # have_pronunciations = True
 
             # See if it contains a word prefix restricting which forms the

--- a/tests/test_en_pronunciation.py
+++ b/tests/test_en_pronunciation.py
@@ -430,3 +430,28 @@ class TestPronunciation(TestCase):
             },
         )
 
+    def test_hyphenation_regex(self):
+        self.wxr.wtp.start_page("quieto")
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* Hyphenation: quiè‧to, qui‧è‧to, quié‧to, qui‧é‧to
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        # import pprint
+        # pprint.pp(out)
+
+        self.assertEqual(
+            out,
+            {
+                # Remove `hyphenation` field if deprecated succesfully
+                  "hyphenation": [
+                    "quiè‧to, qui‧è‧to, quié‧to, qui‧é‧to"
+                  ],
+                "hyphenations": [
+                    {"parts": ["quiè", "to"]},
+                    {"parts": ["qui", "è", "to"]},
+                    {"parts": ["quié", "to"]},
+                    {"parts": ["qui", "é", "to"]},
+                ],
+            },
+        )


### PR DESCRIPTION
Fixes #1246 

Should take care of most arbitrary hyphenation sections found in stuff like templates generated by modules, etc. Basically, it's the backup for when `hyph` is not used and we end up with just raw text hyphenation data.