### PR TITLE
[en] Handle Template:vi-readings for Vietnamese Han characters

### DIFF
--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -761,7 +761,7 @@ uppercase_tags = set(
         "Banatiski Gurbet",
         "Banawá",
         "Bangkok",
-        "Bangladesh", # bhai/English 20241113
+        "Bangladesh",  # bhai/English 20241113
         "Banten",
         "Banyamasan",
         "Barbados",
@@ -1175,7 +1175,7 @@ uppercase_tags = set(
         "Hijazi",  # Variant of Arabic
         "Hijazi Arabic",  # Variant of Arabic
         "Hinduism",
-        "Hinglish", # babu/English 20241113
+        "Hinglish",  # babu/English 20241113
         "Hokkien",  # Chinese dialect/language
         "Honduras",
         "Hong Kong",
@@ -4780,7 +4780,7 @@ xlat_tags_map: Dict[str, Union[str, List[str]]] = {
     "Dialectal or colloquial": "colloquial",
     "Rare except in very formal contexts": "rare formal",
     "alternative in würde normally preferred": "",
-    "sometimes derogatory": "sometimes derogatory", 
+    "sometimes derogatory": "sometimes derogatory",
 }
 
 # This mapping is applied to full descriptions before splitting by comma.
@@ -6401,6 +6401,11 @@ valid_tags = {
     "masculine-plural": "gender",
     "collocation": "misc",
     "comeronym": "misc",
+
+    # https://en.wiktionary.org/wiki/Template:vi-readings
+    "han-viet-reading": "misc",
+    "nom-reading": "misc",
+
 }
 
 for k, v in valid_tags.items():

--- a/tests/test_en_head.py
+++ b/tests/test_en_head.py
@@ -913,3 +913,45 @@ class HeadTests(unittest.TestCase):
                 ],
             },
         )
+
+    def test_vie_reading_template1(self):
+        # Issue #1272
+        data = {}
+        self.maxDiff = 10000
+        self.wxr.wtp.start_page("敎")
+        self.wxr.wtp.start_section("Vietnamese")
+        self.wxr.wtp.start_subsection("Han character")
+        data = parse_page(
+            self.wxr,
+            "敎",
+            """==Vietnamese==
+
+===Han character===
+{{vi-readings|rs=攴07
+|hanviet=giao-test, giáo-test
+|nom=dáo, dạy, giáo
+}}
+""",
+        )
+        # import json
+
+        # print(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False))
+        self.assertEqual(
+            data,
+            [
+                {
+                    "lang": "Vietnamese",
+                    "lang_code": "vi",
+                    "pos": "character",
+                    "related": [
+                        {"tags": ["han-viet-reading"], "word": "giao"},
+                        {"tags": ["han-viet-reading"], "word": "giáo"},
+                        {"tags": ["nom-reading"], "word": "dáo"},
+                        {"tags": ["nom-reading"], "word": "dạy"},
+                        {"tags": ["nom-reading"], "word": "giáo"},
+                    ],
+                    "senses": [{"raw_tags": ["han"], "tags": ["no-gloss"]}],
+                    "word": "敎",
+                }
+            ],
+        )


### PR DESCRIPTION
Fixes #1272 

It was hard to figure out where to put this information. `forms` is wrong, readings are not an inflected form of a character, `form_of` and `alt_of` both don't seem to use `tags` fields, so what was left was using `related` which takes generic `LinkageData` stuff, including tags.

Created two new tags `han-viet-reading` and `nom-reading`.

References are ignored, as are `phienthiet` arguments in the template. I couldn't figure out where to put them.