### PR TITLE
[zh] fix `KeyError` exception

### DIFF
--- a/src/wiktextract/data/overrides/zh.json
+++ b/src/wiktextract/data/overrides/zh.json
@@ -730,5 +730,9 @@
   "Template:中文别名": {
     "redirect_to": "Template:Zh-altname",
     "namespace_id": 10
+  },
+  "Template:語法": {
+    "redirect_to": "Template:语法",
+    "namespace_id": 10
   }
 }

--- a/src/wiktextract/extractor/zh/example.py
+++ b/src/wiktextract/extractor/zh/example.py
@@ -83,7 +83,7 @@ def extract_example_list_item(
                     wxr,
                     word_entry,
                     child,
-                    LINKAGE_TEMPLATES[template_name],
+                    LINKAGE_TEMPLATES[template_name.lower()],
                     " ".join(sense_data.glosses),
                 )
             elif template_name.lower() in ["inline alt forms", "alti"]:


### PR DESCRIPTION
and add "語法" template redirect page, zh edition must has some mechanism to automatically redirect Chinese character templates regardless of Traditional or Simplified character form