### PR TITLE
[en] Add "attestations" field to senses (Template:defdate)

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -81,6 +81,7 @@ from .section_titles import (
 )
 from .translations import parse_translation_item_text
 from .type_utils import (
+    AttestationData,
     DescendantData,
     ExampleData,
     FormData,
@@ -1931,6 +1932,23 @@ def parse_language(
                         return info_exp
                     return ""
             if name in ("defdate",):
+                date = clean_node(wxr, None, ht.get(1, ()))
+                refs = []
+                named_refs = []
+                for k, v in ht.items():
+                    if isinstance(k, str) and "ref" in k:
+                        ref_v = clean_node(wxr, None, v)
+                        if "n" in k:
+                            named_refs.append(ref_v)
+                        else:
+                            refs.append(ref_v)
+                data_append(
+                    sense_base,
+                    "attestations",
+                    AttestationData(
+                        date=date, refs=refs, refns=named_refs
+                    ),
+                )
                 return ""
             if name == "senseid":
                 langid = clean_node(wxr, None, ht.get(1, ()))

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1935,8 +1935,10 @@ def parse_language(
                 date = clean_node(wxr, None, ht.get(1, ()))
                 refs = []
                 named_refs = []
-                for k, v in ht.items():
-                    if isinstance(k, str) and "ref" in k:
+                for k, v in sorted(
+                    (k, v) for k, v in ht.items() if isinstance(k, str)
+                ):
+                    if "ref" in k:
                         ref_v = clean_node(wxr, None, v)
                         if "n" in k:
                             named_refs.append(ref_v)
@@ -1945,9 +1947,7 @@ def parse_language(
                 data_append(
                     sense_base,
                     "attestations",
-                    AttestationData(
-                        date=date, refs=refs, refns=named_refs
-                    ),
+                    AttestationData(date=date, refs=refs, refns=named_refs),
                 )
                 return ""
             if name == "senseid":

--- a/src/wiktextract/extractor/en/type_utils.py
+++ b/src/wiktextract/extractor/en/type_utils.py
@@ -143,6 +143,11 @@ class EtymologyExample(TypedDict, total=False):
     type: str
 
 
+class AttestationData(TypedDict, total=False):
+    date: str
+    refs: list[str]
+    refns: list[str]
+
 class SenseData(TypedDict, total=False):
     alt_of: list[AltOf]
     antonyms: list[LinkageData]
@@ -169,6 +174,7 @@ class SenseData(TypedDict, total=False):
     topics: list[str]
     wikidata: list[str]
     wikipedia: list[str]
+    attestations: list[AttestationData]
 
 
 class WordData(TypedDict, total=False):

--- a/src/wiktextract/extractor/en/type_utils.py
+++ b/src/wiktextract/extractor/en/type_utils.py
@@ -143,10 +143,15 @@ class EtymologyExample(TypedDict, total=False):
     type: str
 
 
+class ReferenceData(TypedDict, total=False):
+    text: str
+    refn: str
+
+
 class AttestationData(TypedDict, total=False):
     date: str
-    refs: list[str]
-    refns: list[str]
+    references: list[ReferenceData]
+
 
 class SenseData(TypedDict, total=False):
     alt_of: list[AltOf]

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -4781,6 +4781,8 @@ xlat_tags_map: Dict[str, Union[str, List[str]]] = {
     "Rare except in very formal contexts": "rare formal",
     "alternative in würde normally preferred": "",
     "sometimes derogatory": "sometimes derogatory",
+    # gratis/Swedish
+    "not inflected": "indeclinable",
 }
 
 # This mapping is applied to full descriptions before splitting by comma.

--- a/tests/test_en_page.py
+++ b/tests/test_en_page.py
@@ -917,6 +917,7 @@ foo
 
 # sense 1 {{defdate|19th century|ref=Reference Foo|refn=FOO}}
 # sense 2 {{defdate|20th century|ref=Reference Bar|refn=BAR}}
+# sense 3 {{defdate|21th century|ref=Reference Baz|refn=BAZ|ref2=Reference Baz 2|ref2n=BAZ2}}
 """,
         )
         # XXX should also capture examples
@@ -933,11 +934,11 @@ foo
                             "attestations": [
                                 {
                                     "date": "19th century",
-                                    "refns": [
-                                        "FOO",
-                                    ],
-                                    "refs": [
-                                        "Reference Foo",
+                                    "references": [
+                                        {
+                                            "refn": "FOO",
+                                            "text": "Reference Foo",
+                                        },
                                     ],
                                 },
                             ],
@@ -947,11 +948,29 @@ foo
                             "attestations": [
                                 {
                                     "date": "20th century",
-                                    "refns": [
-                                        "BAR",
+                                    "references": [
+                                        {
+                                            "refn": "BAR",
+                                            "text": "Reference Bar",
+                                        },
                                     ],
-                                    "refs": [
-                                        "Reference Bar",
+                                },
+                            ],
+                        },
+                        {
+                            "glosses": ["sense 3"],
+                            "attestations": [
+                                {
+                                    "date": "21th century",
+                                    "references": [
+                                        {
+                                            "refn": "BAZ",
+                                            "text": "Reference Baz",
+                                        },
+                                        {
+                                            "refn": "BAZ2",
+                                            "text": "Reference Baz 2",
+                                        },
                                     ],
                                 },
                             ],

--- a/tests/test_en_page.py
+++ b/tests/test_en_page.py
@@ -27,7 +27,7 @@ class EnPageTests(unittest.TestCase):
                 capture_compounds=True,
                 capture_redirects=True,
                 capture_examples=True,
-            )
+            ),
         )
 
     def tearDown(self) -> None:
@@ -902,6 +902,62 @@ alcance
                         },
                     ],
                     "word": "alcance",
+                }
+            ],
+        )
+
+    def test_defdate(self):
+        lst = parse_page(
+            self.wxr,
+            "foo",
+            """
+==Swedish==
+===Noun===
+foo
+
+# sense 1 {{defdate|19th century|ref=Reference Foo|refn=FOO}}
+# sense 2 {{defdate|20th century|ref=Reference Bar|refn=BAR}}
+""",
+        )
+        # XXX should also capture examples
+        self.assertEqual(
+            lst,
+            [
+                {
+                    "lang": "Swedish",
+                    "lang_code": "sv",
+                    "pos": "noun",
+                    "senses": [
+                        {
+                            "glosses": ["sense 1"],
+                            "attestations": [
+                                {
+                                    "date": "19th century",
+                                    "refns": [
+                                        "FOO",
+                                    ],
+                                    "refs": [
+                                        "Reference Foo",
+                                    ],
+                                },
+                            ],
+                        },
+                        {
+                            "glosses": ["sense 2"],
+                            "attestations": [
+                                {
+                                    "date": "20th century",
+                                    "refns": [
+                                        "BAR",
+                                    ],
+                                    "refs": [
+                                        "Reference Bar",
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                    "word": "foo",
                 }
             ],
         )


### PR DESCRIPTION
Issue #1278

Done within the gloss/sense template handler function.

`Template:defdate` is used to show the earliest (or just early) attested dates in text where a word, or a word sense, has been found. It's main parameter (#1) is a string data like "early 19th century", and it can have up to three `refX=` and `refXn=` arguments. The ref (based on how it's in etymology templates) is probably a `Template:ref` style reference that is then output by the Wiktionary expander with a `<references/>` tag later in the article, while the `refn` arguments refer to these without repeating the `ref` part. I think, based on a quick look, that we don't do special reference handling with `ref` template data, but the same data can be found within the word data so users should be able to access it.

For example in the article `gratis` for Swedish, there's a `ref` in the etymology section which is later refered to by `refn` arguments in later `defdate` templates. Both pieces are available and the `refn` should be unambiguous.