### PR TITLE
[en] Fix bug with removing bullet punctuation in Greek heads

### DIFF
--- a/src/wiktextract/extractor/en/form_descriptions.py
+++ b/src/wiktextract/extractor/en/form_descriptions.py
@@ -1887,7 +1887,7 @@ def parse_word_head(
     base = base.replace("?", "")  # Removes uncertain articles etc
     base = re.sub(r"\s+", " ", base)
     base = re.sub(r" ([,;])", r"\1", base)
-    base = re.sub(r"(.*) •.*", r"\1", base)
+    base = re.sub(r" • ", r" ", base)
     # Many languages use • as a punctuation mark separating the base
     # from the rest of the head. στάδιος/Ancient Greek, issue #176
     base = base.strip()


### PR DESCRIPTION
Issue #1313

See https://github.com/tatuylonen/wiktextract/issues/176

When fixing the above issue, I made a mistake by removing everything after the bullet.

Replacing the bullet with other punctuation (like comma) introduces super-wonky results because there's some old code for Tatu that handles certain weird scenarios by adding an " or " into the text. There are no comments and the code is hard to read, so hopefully just removing it should work.