### PR TITLE
[en] Transform footnotes with `xlat_descs_map`

### DIFF
--- a/src/wiktextract/extractor/en/form_descriptions.py
+++ b/src/wiktextract/extractor/en/form_descriptions.py
@@ -874,7 +874,7 @@ def distw(titleparts: Sequence[str], word: str) -> float:
 
 
 def map_with(
-    ht: Union[dict[str, Union[str, list[str]]], dict[str, str]],
+    ht: dict[str, str | list[str]] | dict[str, str],
     lst: Sequence[str],
 ) -> list[str]:
     """Takes alternatives from ``lst``, maps them using ``ht`` to zero or

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -4819,6 +4819,7 @@ xlat_descs_map = {
     "m": "masculine",
     "f": "feminine",
     "classic": "",
+    "Sparsely attested near 1500.“[ can, v.1.]”, in OED Online 8pxPaid subscription required\u2060, Oxford: Oxford University Press, December 2024": "archaic rare",
 }
 
 # Words that are interpreted as tags at the beginning of a linkage
@@ -5368,7 +5369,7 @@ valid_tags = {
     "contemporary": "misc",
     "contingent": "mood",  # Verb form, উঘাল/Assamese
     "continuative": "aspect",  # Verb aspect (actions still happening; e.g., Japanese)
-    "contracted": "misc",  # Is this the same as contraction? -> not exactly, see ἐρωτάω/Greek 
+    "contracted": "misc",  # Is this the same as contraction? -> not exactly, see ἐρωτάω/Greek
     "contracted-dem-form": "misc",
     "contraction": "mod",
     "contrastive": "mood",  # Apparently connective verb form in Korean
@@ -6431,7 +6432,6 @@ valid_tags = {
     "since-position": "misc",
     "together-with-position": "misc",
     "up-to-position": "misc",
-
     # "zh-dial" template
     "Written-vernacular-Chinese": "script",
     "Northeastern-Mandarin": "script",


### PR DESCRIPTION
Fixes issue #1314, 'canneth' form missing tags

Turns out that `xlat_descs_map` is used differently from what I thought: it is used to transform text straight into tag text, which is then usually parsed with decode_tags down the line. It works because the raw tag, even things like `with-dummy-subject` get decoded directly.

Should rename it. I don't even know what `xlat` means.

Anyhow, the fix here is that certain footnotes are just so messy we can't do much about them, so add them to this map and transform the text into tags with `map_with`.

This makes parsing footnotes slower, but that's such a small share of overall time spent that it shouldn't really matter.

I'm starting to understand why enterprise code names things verbosely.