### PR TITLE
[en] Revert changes to `add_def`, remove ref-elements in `after`

### DIFF
--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -4784,6 +4784,7 @@ xlat_tags_map: Dict[str, Union[str, List[str]]] = {
     "sometimes derogatory": "sometimes derogatory",
     # gratis/Swedish
     "not inflected": "indeclinable",
+    "Sparsely attested near 1500": "archaic rare",
 }
 
 # This mapping is applied to full descriptions before splitting by comma.
@@ -4819,7 +4820,6 @@ xlat_descs_map = {
     "m": "masculine",
     "f": "feminine",
     "classic": "",
-    "Sparsely attested near 1500.“[ can, v.1.]”, in OED Online 8pxPaid subscription required\u2060, Oxford: Oxford University Press, December 2024": "archaic rare",
 }
 
 # Words that are interpreted as tags at the beginning of a linkage


### PR DESCRIPTION
Reverts PR #1323

Even though there's nothing "wrong" with the actual code changes, except a minor resource cost because we do more things, if it's not actually needed I decided to revert it.

The actual "fix" to this seems to be that when parsing the output of tables, we do some bespoke local recursive delving of the parse tree for some reason (probably makes sense), so `clean_node()` is not actually used here to get the `after` text of the table containing footnotes.

Solution: when recursing, skip `ref`-elements.

The broken ref-less version of the taggable string text that was problematic was move from `xlat_descs_map` to normal tags.