### PR TITLE
[ja] fix `AssertionError` exception in page "ドライバー"

### DIFF
--- a/src/wiktextract/extractor/ja/translation.py
+++ b/src/wiktextract/extractor/ja/translation.py
@@ -256,10 +256,10 @@ def extract_trans_see_template(
         index = page_title.index("#")
         target_id = page_title[index + 1 :]
         page_title = page_title[:index]
-    page = wxr.wtp.get_page(page_title)
-    if page is None:
+    page_body = wxr.wtp.get_page_body(page_title, 0)
+    if page_body is None:
         return
-    root = wxr.wtp.parse(page.body)
+    root = wxr.wtp.parse(page_body)
     target_node = find_subpage_section(wxr, root, "翻訳", target_id)
     if target_node is not None:
         extract_translation_section(


### PR DESCRIPTION
a redirect page title is used in "trans-see" template and the redirected page doesn't have translation section