### PR TITLE
[en] Include missing ancient Greek dialects

### DIFF
--- a/src/wiktextract/extractor/en/inflection.py
+++ b/src/wiktextract/extractor/en/inflection.py
@@ -244,8 +244,30 @@ title_elements_map = {
     "plural": "plural",
     "archaic": "archaic",
     "dated": "dated",
-    "Attic": "Attic",  # e.g. καλός/Greek/Adj
-    "Epic": "Epic",  # e.g. καλός/Greek/Adj
+    "iterative": "iterative",
+    "poetic": "poetic",
+    "Attic": "Attic",
+    "Epic": "Epic",
+    "Aeolic": "Aeolic",
+    "Arcadocypriot": "Arcadocypriot",
+    "Old Attic": "Old-Attic",
+    "Boeotian": "Boeotian",
+    "Byzantine": "Byzantine",
+    "Choral Doric": "Choral-Doric",
+    "Doric": "Doric",
+    "Elean": "Elean",
+    "Epirote": "Epirote",
+    "Ionic": "Ionic",
+    "Koine": "Koine",
+    "Cretan": "Cretan",
+    "Corinthian": "Corinthian",
+    "Laconian": "Laconian",
+    "Later poetic": "Later-poetic",
+    "Lesbian": "Lesbian",
+    "Locrian": "Locrian",
+    "Lyric": "Lyric",
+    "Thessalian": "Thessalian",
+    "Tragic": "Tragic",
 }
 for k, v in title_elements_map.items():
     if any(t not in valid_tags for t in v.split()):

--- a/src/wiktextract/extractor/en/inflection.py
+++ b/src/wiktextract/extractor/en/inflection.py
@@ -262,12 +262,12 @@ title_elements_map = {
     "Cretan": "Cretan",
     "Corinthian": "Corinthian",
     "Laconian": "Laconian",
-    "Later poetic": "Later-poetic",
+    "Later poetic": "Later-poetic-Ancient-Greek",
     "Lesbian": "Lesbian",
     "Locrian": "Locrian",
-    "Lyric": "Lyric",
+    "Lyric": "Lyric-Ancient-Greek",
     "Thessalian": "Thessalian",
-    "Tragic": "Tragic",
+    "Tragic": "Tragic-Ancient-Greek",
 }
 for k, v in title_elements_map.items():
     if any(t not in valid_tags for t in v.split()):

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -657,7 +657,7 @@ uppercase_tags = set(
         "Achterhooks",
         "Adana",
         "Adyghe",
-        "Aeolic",
+        "Aeolic",  # Ancient Greek
         "Affectation",
         "Afi-Amanda",
         "Africa",
@@ -718,6 +718,7 @@ uppercase_tags = set(
         "Arango",
         "Arawak",
         "Arbëresh",
+        "Arcadocypriot",  # Ancient Greek
         "Ardennes",
         "Argentina",
         "Arkhangelsk",
@@ -844,7 +845,7 @@ uppercase_tags = set(
         "Burdur",
         "Burgenland",
         "Bygdeå",
-        "Byzantine",
+        "Byzantine",  # Ancient Greek
         "Bzyb",
         "Béarn",
         "cabo Verde",
@@ -900,6 +901,7 @@ uppercase_tags = set(
         "Chinese Character classification",
         "Cholula",
         "Chongqing",
+        "Choral Doric",  # Ancient Greek
         "Christian",
         "Chugoku",
         "Chūgoku",
@@ -936,6 +938,7 @@ uppercase_tags = set(
         "Contentin",
         "Continent",
         "Copenhagen",
+        "Corinthian",  # Ancient Greek
         "Cork",
         "Cornish",
         "Cornwall",
@@ -1026,12 +1029,14 @@ uppercase_tags = set(
         "El Salvador",
         "Elazığ",
         "Elberfelder Bibel",
+        "Elean",  # Ancient Greek
         "England",
         "English Midlands",
         "English",
         "Eonavian",
         "Epic",
         "Epigraphic Gandhari",
+        "Epirote",  # Ancient Greek
         "Erhua",  # Northern Chinese dialectal feature
         "Erzgebirgisch",
         "Esham",
@@ -1374,6 +1379,7 @@ uppercase_tags = set(
         "Late Old Frisian",
         "Late West Saxon",
         "Late",
+        "Later poetic",  # Ancient Greek
         "Latin America",
         "Latinate",
         "Latinism",
@@ -1388,6 +1394,7 @@ uppercase_tags = set(
         "Leizhou Min",  # Chinese dialect/language
         "Lemosin",  # Dialect of Occitan
         "Lengadocian",  # Dialect of Occitan
+        "Lesbian",  # Ancient Greek
         "Lesotho",
         "Levantine Arabic",  # Variant of Arabic language
         "Lewis",
@@ -1409,6 +1416,7 @@ uppercase_tags = set(
         "Litvish",
         "Liverpudlian",
         "Llanos",
+        "Locrian",  # Ancient Greek
         "Logudorese",  # Variant of Sardinian
         "Lojban",
         "Loli",
@@ -1432,6 +1440,7 @@ uppercase_tags = set(
         "Lycopolitan",
         "Lyon",
         "Lyons",
+        "Lyric",  # Ancient Greek
         "Lviv",
         "Lövånger",
         "Ḷḷena",
@@ -1686,6 +1695,7 @@ uppercase_tags = set(
         "Nyungkal",
         "Nürnbergisch",
         "Occitania",
+        "Old Attic",  # Ancient Greek
         "Old Bohairic",
         "Old Chamorro",
         "Old Chinese",  # Historical variant of Chinese
@@ -2081,6 +2091,7 @@ uppercase_tags = set(
         "Thailand",
         "Thanh Chương",
         "The Hague",
+        "Thessalian",  # Ancient Greek
         "Thung Luang village",
         "Thung Luang",
         "Thurgau",
@@ -2100,6 +2111,7 @@ uppercase_tags = set(
         "Tosk",
         "Toulouse",
         "Traditional",
+        "Tragic",  # Ancient Greek
         "Trakai-Vilnius",
         "Translingual",
         "Transoxianan",
@@ -2499,7 +2511,7 @@ uppercase_tags = set(
         "Liping",
         "Ürümqi",
         "Bijie",
-        "Cretan",
+        "Cretan",  # Ancient Greek
         "Crimean Latin",
         "Imperial Aramaic",
         "Jewish Literary Aramaic",
@@ -2519,7 +2531,7 @@ uppercase_tags = set(
         "Bikol Daet",
         "Bikol Partido",
         "Bima" "Sumbawa",
-        "Boeotian",
+        "Boeotian",  # Ancient Greek
         "Bokmal",
         "Book Pahlavi",  # Book Pahlavi, pseudoscience/English/translations/
         "Bádiu",
@@ -2574,7 +2586,7 @@ uppercase_tags = set(
         "Krama",
         "Kyushu",
         "Kölnisch",
-        "Laconian",
+        "Laconian",  # Ancient Greek
         "Late Ottoman Turkish",
         "Levantine, North",
         "Levantine, South",

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -1379,7 +1379,7 @@ uppercase_tags = set(
         "Late Old Frisian",
         "Late West Saxon",
         "Late",
-        "Later poetic",  # Ancient Greek
+        "Later poetic Ancient Greek",  # Ancient Greek
         "Latin America",
         "Latinate",
         "Latinism",
@@ -1440,7 +1440,7 @@ uppercase_tags = set(
         "Lycopolitan",
         "Lyon",
         "Lyons",
-        "Lyric",  # Ancient Greek
+        "Lyric Ancient Greek",  # Ancient Greek
         "Lviv",
         "Lövånger",
         "Ḷḷena",
@@ -2111,7 +2111,7 @@ uppercase_tags = set(
         "Tosk",
         "Toulouse",
         "Traditional",
-        "Tragic",  # Ancient Greek
+        "Tragic Ancient Greek",  # Ancient Greek
         "Trakai-Vilnius",
         "Translingual",
         "Transoxianan",


### PR DESCRIPTION
I noticed that in the ancient Greek entries, the only dialects that were being included in the table tags were `Attic` and `Epic`, for example the [JSON](https://kaikki.org/dictionary/Ancient%20Greek/meaning/%CE%B2/%CE%B2%CE%B1/%CE%B2%CE%B1%CE%B8%CF%8D%CF%82.html) for [βαθύς](https://en.wiktionary.org/wiki/%CE%B2%CE%B1%CE%B8%CF%8D%CF%82#Ancient_Greek) includes:

```json
    {
      "form": "Attic declension-3",
      "source": "declension",
      "tags": [
        "table-tags"
      ]
    },
```

```json
    {
      "form": "Epic declension-3",
      "source": "declension",
      "tags": [
        "table-tags"
      ]
    },
```

but does not include `"form": "Byzantine declension-3",`.

I'm not completely sure that this is how the code works, so there may be mistakes in the pull request. What I've done is add all of the other dialects to the two places in the code where the strings `"Attic"` and `"Epic"` appear.

The tests seem to pass, but there is a lot of `DEBUG` output. However, this same output appears when I run the tests on the `master` branch at `HEAD`.

Below, I've listed the dialects and the Wiktionary page where they appear:

Dialect | Wiktionary Page
------- | ----------------
Aeolic | https://en.wiktionary.org/wiki/ἐγώ
Arcadocypriot | https://en.wiktionary.org/wiki/ϝέχω
Old Attic | https://en.wiktionary.org/wiki/ἀκούω
Boeotian | https://en.wiktionary.org/wiki/ἐγώ
Byzantine | https://en.wiktionary.org/wiki/Βενέτζια
Choral Doric | https://en.wiktionary.org/wiki/Καλλίας
Doric | https://en.wiktionary.org/wiki/ἐγώ
Elean | https://en.wiktionary.org/wiki/λατρείω
Epirote | https://en.wiktionary.org/wiki/λυρτός
Ionic | https://en.wiktionary.org/wiki/ἐγώ
Koine | https://en.wiktionary.org/wiki/ἄγγελος
Cretan | https://en.wiktionary.org/wiki/Αἰολεύς
Corinthian | https://en.wiktionary.org/wiki/Ϙόρινθος
Laconian | https://en.wiktionary.org/wiki/μηχανή
Later poetic | https://en.wiktionary.org/wiki/ἰσχύω
Lesbian | https://en.wiktionary.org/wiki/μάρτυρ
Locrian | https://en.wiktionary.org/wiki/πάθημα
Lyric | https://en.wiktionary.org/wiki/χρύσεος
Thessalian | https://en.wiktionary.org/wiki/ἐγώ
Tragic | https://en.wiktionary.org/wiki/ἔρχομαι

In addition, the following two non-dialect tags appear:

Tag | Wiktionary Page
--- | ----------------
iterative | https://en.wiktionary.org/wiki/ἐπιλαμβάνω
poetic | https://en.wiktionary.org/wiki/σχίζω

---

Related to https://github.com/tatuylonen/wiktextract/issues/1313