### PR TITLE
[en] Georgian ka-decl-noun kludge extended to comma-separated alts

### DIFF
--- a/src/wiktextract/extractor/en/inflection.py
+++ b/src/wiktextract/extractor/en/inflection.py
@@ -1842,8 +1842,8 @@ def parse_simple_table(
         # for both the Georgian original and the romanization.
         elif (
             tablecontext.template_name == "ka-decl-noun"
-            and len(alts) == 1
-            and " (" in alts[0]
+            and len(alts) >= 1
+            and any(" (" in alt_ for alt_ in alts)
         ):
             nalts = ka_decl_noun_template_cell(alts)
         else:

--- a/src/wiktextract/extractor/en/inflection_kludges.py
+++ b/src/wiktextract/extractor/en/inflection_kludges.py
@@ -2,25 +2,26 @@ import re
 
 
 def ka_decl_noun_template_cell(alts: list[str]) -> list[tuple[str, str, str]]:
-    orig, roman = re.split(r" \(", alts[0], maxsplit=1)
-    orig = orig.strip()
-    roman = roman.strip().removesuffix(")")
-    if "(" not in orig:
-        nalts = [(orig, roman, "")]
-    else:
-        nalts = []
-        nalts.append(
-            (
-                re.sub(r"\(.*?\)", "", orig),
-                re.sub(r"\(.*?\)", "", roman),
-                "",
+    nalts = []
+    for alt in alts:
+        orig, roman = re.split(r" \(", alt, maxsplit=1)
+        orig = orig.strip()
+        roman = roman.strip().removesuffix(")")
+        if "(" not in orig:
+            nalts.append((orig, roman, ""))
+        else:
+            nalts.append(
+                (
+                    re.sub(r"\(.*?\)", "", orig),
+                    re.sub(r"\(.*?\)", "", roman),
+                    "",
+                )
             )
-        )
-        nalts.append(
-            (
-                re.sub(r"\(|\)", "", orig),
-                re.sub(r"\(|\)", "", roman),
-                "",
+            nalts.append(
+                (
+                    re.sub(r"\(|\)", "", orig),
+                    re.sub(r"\(|\)", "", roman),
+                    "",
+                )
             )
-        )
     return nalts


### PR DESCRIPTION
See #1286#issuecomment-3280297085

The previous kludge assumed this table would only have one entry per cell of Georgian+romanization, with alternative forms shown with suffixes in parentheses (suffix and no suffix), but turns out these can be comma-separated alts.

The comma separated alts are already separated earlier in the text, so we only need to loop over them (and also check the length of `alts` with `>= 1` instead of `== 1`...).