### PR TITLE
[el] `form_of` templates: handle bad templates and also extract from etymology

### DIFF
--- a/src/wiktextract/extractor/el/models.py
+++ b/src/wiktextract/extractor/el/models.py
@@ -241,7 +241,7 @@ class WordEntry(GreekBaseModel):
     hyphenation: str = ""  # Should be a list `hyphenations`.
     head_templates: list[TemplateData] = []
     # alt_of: list[FormOf] = []
-    # form_of: list[FormOf] = []
+    form_of: list[FormOf] = []
     antonyms: list[Linkage] = []
     # coordinate_terms: list[Linkage] = []
     derived: list[Linkage] = []

--- a/src/wiktextract/extractor/el/page.py
+++ b/src/wiktextract/extractor/el/page.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 from mediawiki_langcodes import code_to_name, name_to_code
 
@@ -40,7 +41,7 @@ from .section_titles import (
 
 def parse_page(
     wxr: WiktextractContext, page_title: str, page_text: str
-) -> list[dict[str, WordEntry]]:
+) -> list[dict[str, Any]]:
     """Parse Greek Wiktionary (el.wiktionary.org) page.
 
     References:

--- a/src/wiktextract/extractor/el/pos.py
+++ b/src/wiktextract/extractor/el/pos.py
@@ -514,7 +514,7 @@ def bold_node_fn(
 
 def extract_form_of_templates(
     wxr: WiktextractContext,
-    parent_sense: Sense,
+    parent_sense: Sense | WordEntry,
     t_node: TemplateNode,
     siblings: list[str | WikiNode],
     siblings_index: int,

--- a/tests/test_el_etymology.py
+++ b/tests/test_el_etymology.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.el.models import WordEntry
+from wiktextract.extractor.el.page import parse_page
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestElEtymology(TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="el"),
+            WiktionaryConfig(
+                dump_file_lang_code="el",
+                capture_language_codes=None,
+            ),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def test_form_of_etymologies(self) -> None:
+        page_datas = parse_page(
+            self.wxr,
+            "κατακουκουλωμένος",
+            """==Νέα ελληνικά (el)==
+===Ετυμολογία===
+: '''{{PAGENAME}}''' < {{μτχππ}} [[φοο]] < [[κατα-]] + [[κουκουλώνω]]
+
+===Μετοχή===
+'''{{PAGENAME}}, -η, -ο'''
+* (εμφατικό) εντελώς κουκουλωμένος""",
+        )
+        print(f"{page_datas=}")
+        self.assertEqual(len(page_datas), 1)
+        page_data = page_datas[0]
+        self.assertEqual(page_data["form_of"], [{"word": "φοο"}])
+        self.assertEqual(
+            page_data["etymology_text"],
+            # Broken templates left as is. Fix this if you make proper
+            # mock templates or something for these tests
+            "κατακουκουλωμένος < :Πρότυπο:μτχππ φοο < κατα- + κουκουλώνω",
+        )

--- a/tests/test_el_form_of.py
+++ b/tests/test_el_form_of.py
@@ -165,6 +165,35 @@ class TestElGlosses(TestCase):
         expected = [{"form_of": [{"word": "διαδέχομαι"}]}]
         self.mktest_sense(raw, expected)
 
+    def test_form_of_empty_args1(self) -> None:
+        # This should return nothing: no argument, no text after
+        # NOTE for this test the name of the template is for debugging
+        raw = """* {{μτχ3a}}"""
+        expected: list[dict] = [{}]
+        self.mktest_sense(raw, expected)
+
+    def test_form_of_empty_args2(self) -> None:
+        # This should return nothing: no argument, no text after
+        # NOTE for this test the name of the template is for debugging
+        raw = """* {{μτχ3b}} [[test]]"""
+        expected = [{"form_of": [{"word": "test"}]}]
+        self.mktest_sense(raw, expected)
+
+    def test_form_of_empty_args3(self) -> None:
+        # This should return nothing: no argument, no text after
+        # NOTE for this test the name of the template is for debugging
+        raw = """* {{μτχ3b}} [[test]] [[foo]]"""
+        expected = [{"form_of": [{"word": "test foo"}]}]
+        self.mktest_sense(raw, expected)
+
+    def test_form_of_empty_args4(self) -> None:
+        # This should return nothing: no argument, no text after
+        # NOTE for this test the name of the template is for debugging
+        raw = """* {{μτχ3b}} [[test]] [[foo]], [[bar]]"""
+        expected = [{"form_of": [{"word": "test foo"}]}]
+        self.mktest_sense(raw, expected)
+
+
     def test_form_of_generic_template_noun(self) -> None:
         # https://el.wiktionary.org/wiki/εδάφη
         raw = "* {{κλ||έδαφος|π=οακ|α=π}}"


### PR DESCRIPTION
Should fix most of the stuff in #1372 