### PR TITLE
Change process start method to "forkserver"

### DIFF
--- a/src/wiktextract/thesaurus.py
+++ b/src/wiktextract/thesaurus.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor
 from copy import deepcopy
 from dataclasses import dataclass, field
-from multiprocessing import current_process, get_context
+from multiprocessing import current_process, get_all_start_methods, get_context
 from pathlib import Path
 from traceback import format_exc
 from typing import Optional, TextIO
@@ -93,7 +93,9 @@ def extract_thesaurus_data(
     wxr.remove_unpicklable_objects()
     with ProcessPoolExecutor(
         max_workers=num_processes,
-        mp_context=get_context("spawn"),
+        mp_context=get_context(
+            "forkserver" if "forkserver" in get_all_start_methods() else "spawn"
+        ),
         initializer=init_worker,
         initargs=(deepcopy(wxr),),
     ) as executor:

--- a/src/wiktextract/wiktionary.py
+++ b/src/wiktextract/wiktionary.py
@@ -14,7 +14,7 @@ import tempfile
 import time
 from concurrent.futures import ProcessPoolExecutor
 from copy import deepcopy
-from multiprocessing import current_process, get_context
+from multiprocessing import current_process, get_all_start_methods, get_context
 from pathlib import Path
 from traceback import format_exc
 from typing import TextIO
@@ -652,7 +652,7 @@ def check_json_data(wxr: WiktextractContext, dt: dict) -> None:
             [
                 "alt",
                 "code",  # DEPRECATED for "lang_code"
-                "lang_code"
+                "lang_code",
                 "english",  # DEPRECATED in favor of "translation"
                 "translation",
                 "lang",
@@ -789,7 +789,9 @@ def reprocess_wiktionary(
     wxr.remove_unpicklable_objects()
     with ProcessPoolExecutor(
         max_workers=num_processes,
-        mp_context=get_context("spawn"),
+        mp_context=get_context(
+            "forkserver" if "forkserver" in get_all_start_methods() else "spawn"
+        ),
         initializer=init_worker,
         initargs=(deepcopy(wxr),),
     ) as executor:


### PR DESCRIPTION
"forkserver" is faster than "spawn" and is the default method since Python 3.14