### PR TITLE
[el] Support `form_of` for `γρ` template

### DIFF
--- a/src/wiktextract/extractor/el/pos.py
+++ b/src/wiktextract/extractor/el/pos.py
@@ -555,9 +555,9 @@ def extract_form_of_templates(
     # * Only handle cases where the second argument refers to a form:
     #   μορφ / μορφή / λόγια μορφή του, etc.
     #   and ignore those mistakenly used as synonym templates
-    if t_name == "γρ":
+    if t_name == "γρ" and 2 in t_node.template_parameters:
         second_arg = t_node.template_parameters[2]
-        second_arg_str = clean_node(wxr, None, second_arg).strip()
+        second_arg_str = clean_node(wxr, None, second_arg)
         if "μορφ" in second_arg_str:
             return basic_extract(extract_argument=1)
 

--- a/src/wiktextract/extractor/el/pos.py
+++ b/src/wiktextract/extractor/el/pos.py
@@ -514,7 +514,7 @@ def bold_node_fn(
 
 def extract_form_of_templates(
     wxr: WiktextractContext,
-    parent_sense: Sense,
+    parent_sense: Sense | WordEntry,
     t_node: TemplateNode,
     siblings: list[str | WikiNode],
     siblings_index: int,
@@ -576,7 +576,7 @@ def extract_form_of_templates(
 
 def extract_form_of_templates_basic(
     wxr: WiktextractContext,
-    parent_sense: Sense,
+    parent_sense: Sense | WordEntry,
     siblings: list[str | WikiNode],
     sibling_index: int,
     t_name: str,
@@ -615,7 +615,9 @@ def extract_form_of_templates_basic(
 
 
 def extract_form_of_templates_ptosi(
-    wxr: WiktextractContext, parent_sense: Sense, t_node: TemplateNode
+    wxr: WiktextractContext,
+    parent_sense: Sense | WordEntry,
+    t_node: TemplateNode,
 ) -> None:
     """Parse form_of for nouns and adjectives.
 

--- a/tests/test_el_form_of.py
+++ b/tests/test_el_form_of.py
@@ -232,3 +232,9 @@ class TestElGlosses(TestCase):
         raw = "* {{γρ|well-rounded||en}}"
         expected = [{}]
         self.mktest_sense(raw, expected)
+
+    def test_gr_linkage_one_arg(self) -> None:
+        # Seen via ripgrep
+        raw = "* {{γρ|τάδε}}"
+        expected = [{}]
+        self.mktest_sense(raw, expected)

--- a/tests/test_el_form_of.py
+++ b/tests/test_el_form_of.py
@@ -207,3 +207,28 @@ class TestElGlosses(TestCase):
         raw = "* {{κλ||πλανεύω|π=1ε|ε=ορ|χ=αορ|φ=π|φ+=πλανεύομαι}}"
         expected = [{"form_of": [{"word": "πλανεύω"}]}]
         self.mktest_sense(raw, expected)
+
+    def test_form_of_gr_base(self) -> None:
+        # https://el.wiktionary.org/wiki/εσένανε
+        raw = "* {{γρ|εσένα|μορφή}}"
+        expected = [{"form_of": [{"word": "εσένα"}]}]
+        self.mktest_sense(raw, expected)
+
+    def test_form_of_gr_second_arg_wrong(self) -> None:
+        # https://el.wiktionary.org/wiki/πιάνο_τοίχου
+        # Should ignore expansion depending on the second argument
+        raw = "* {{γρ|όρθιο πιάνο|συνων}}"
+        expected = [{}]
+        self.mktest_sense(raw, expected)
+
+    def test_gr_linkage_second_arg_variant(self) -> None:
+        # https://el.wiktionary.org/wiki/μαλακή_υπερώα
+        raw = "* {{γρ|μαλθακή υπερώα|μορφ}}· ο μαλακός [[ιστός]]..."
+        expected = [{"form_of": [{"word": "μαλθακή υπερώα"}]}]
+        self.mktest_sense(raw, expected)
+
+    def test_gr_linkage_second_arg_empty(self) -> None:
+        # Seen via ripgrep
+        raw = "* {{γρ|well-rounded||en}}"
+        expected = [{}]
+        self.mktest_sense(raw, expected)


### PR DESCRIPTION
Add `form_of` for this template: [γρ](https://el.wiktionary.org/wiki/Module:%CE%AC%CE%BB%CE%BB%CE%B7%CE%BC%CE%BF%CF%81%CF%86%CE%AE)

The code would have been simpler if I didn't observe some users doing questionable things with the template. In their defense, the template documentation could have been clearer. It mixes alternatives writings with forms of, their example is completely wrong, it works when it should not, etc.

Nevertheless, in my experience this makes sense, and follows the same logic as the other `form_of` templates.

There is some noise due to my formatter. I hope that's not a problem.