### PR TITLE
[el] Merge θα particle in head parsing

### DIFF
--- a/src/wiktextract/extractor/el/head.py
+++ b/src/wiktextract/extractor/el/head.py
@@ -1,8 +1,7 @@
 import re
+from unicodedata import name as unicode_name
 
 from mediawiki_langcodes import code_to_name
-
-from unicodedata import name as unicode_name
 
 from wiktextract.extractor.en.form_descriptions import distw
 from wiktextract.wxr_context import WiktextractContext
@@ -24,7 +23,7 @@ def parse_head(wxr: WiktextractContext, pos_data: WordEntry, text: str) -> bool:
             if len(split_text) > 3:
                 # Just throw the prefix into the (probably) bolded text
                 split_text[2] = split_text[0] + split_text[2]
-                split_text[0] = ''
+                split_text[0] = ""
             else:
                 return False
         else:
@@ -270,6 +269,11 @@ def partition_head_forms(
     for forms, tags in blocks:
         # print(f"{forms=}, {tags=}")
         tags = list(set(tags))
+
+        # Merge particle (θα = will) with their respective verb
+        if len(forms) == 2 and forms[0] == "θα":
+            forms = [f"θα {forms[1]}"]
+
         for form in forms:
             ret.append(Form(form=form, raw_tags=tags))
 


### PR DESCRIPTION
Just a minor bug fix that I found while testing #1394 

When parsing verb headers, the particle `θα` (rough equivalent of the English `will`), was treated as a separate form. This effectively meant that for a verb like `ψάχνω`, the json would be:

```json
    {
      "form": "θα", // will
      "raw_tags": [
        "στ.μέλλ"
      ]
    },
    {
      "form": "ψάξω", // search
      "raw_tags": [
        "στ.μέλλ"
      ]
    },
 ```

instead of the expected

```json
    {
      "form": "θα ψάξω", // will search
      "raw_tags": [
        "στ.μέλλ"
      ]
    },
 ```
 
I opted to merge the θα particle because it's consistent with the verb tables, but it is probably more useful to only keep the verb without the particles. At any rate, having a stray θα makes no sense.

It is a dirty ad-hoc hack, but then again, it is quite an edge case.