### PR TITLE
Move code that modified `valid_tags` and `valid_topic`

### DIFF
--- a/src/wiktextract/extractor/en/form_descriptions.py
+++ b/src/wiktextract/extractor/en/form_descriptions.py
@@ -803,22 +803,10 @@ for tag in valid_tags:
     add_to_valid_tree(valid_sequences, tag, tag)
 for tag in uppercase_tags:
     hyphenated = re.sub(r"\s+", "-", tag)
-    if hyphenated in valid_tags:
-        print(
-            "DUPLICATE TAG: {} (from uppercase tag {!r})".format(
-                hyphenated, tag
-            )
-        )
-    assert hyphenated not in valid_tags
-    # Might as well, while we're here: Add hyphenated location tag.
-    valid_tags[hyphenated] = "dialect"
-    add_to_valid_tree(valid_sequences, hyphenated, hyphenated)
-for tag in uppercase_tags:
-    hyphenated = re.sub(r"\s+", "-", tag)
-    # XXX Move to above loop? Or is this here for readability?
     if "/" in tag:
         sequences_with_slashes.add(tag)
     add_to_valid_tree(valid_sequences, tag, hyphenated)
+
 # xlat_tags_map!
 add_to_valid_tree_mapping(valid_sequences, xlat_tags_map, valid_tags, False)
 for k in xlat_tags_map:
@@ -833,10 +821,9 @@ for topic in valid_topics:
 # Let each original topic value stand alone.  These are not generally on
 # valid_topics.  We add the original topics with spaces replaced by hyphens.
 for topic in topic_generalize_map.keys():
-    hyphenated = topic.replace(" ", "-")
-    valid_topics.add(hyphenated)
+    hyphenated = re.sub(r"\s+", "-", topic)
     if "/" in topic:
-        sequences_with_slashes.add(tag)
+        sequences_with_slashes.add(topic)
     add_to_valid_tree(valid_sequences, topic, hyphenated)
 # Add canonicalized/generalized topic values
 add_to_valid_tree_mapping(

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -4,6 +4,7 @@
 #
 # Copyright (c) 2020-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
+import re
 from typing import Dict, List, Union
 
 # Mappings for tags in template head line ends outside parentheses.  These are
@@ -6465,6 +6466,17 @@ for k, v in valid_tags.items():
 for tag in form_of_tags - set(valid_tags.keys()):
     print("tags.py:form_of_tags contains invalid tag {}".format(tag))
 
+for tag in uppercase_tags:
+    hyphenated = re.sub(r"\s+", "-", tag)
+    if hyphenated in valid_tags:
+        print(
+            "DUPLICATE TAG: {} (from uppercase tag {!r})".format(
+                hyphenated, tag
+            )
+        )
+    assert hyphenated not in valid_tags
+    # Might as well, while we're here: Add hyphenated location tag.
+    valid_tags[hyphenated] = "dialect"
 
 # Don't move this, notify me so that I can change some an import in
 # the kaikki.org regen code

--- a/src/wiktextract/topics.py
+++ b/src/wiktextract/topics.py
@@ -3,6 +3,8 @@
 #
 # Copyright (c) 2020-2022 Tatu Ylonen.  See file LICENSE and https://ylonen.org
 
+import re
+
 # Set of valid topic tags.  (Other tags may be canonicalized to these)
 valid_topics = set([
     "Buddhism",
@@ -1068,3 +1070,7 @@ topic_generalize_map = {
     "Abrahamic religions": "religion",
 
 }
+
+for topic in topic_generalize_map.keys():
+    hyphenated = re.sub(r"\s+", "-", topic)
+    valid_topics.add(hyphenated)


### PR DESCRIPTION
See #1427

When `form_descriptions` was moved to the new English extractor from the top level, it also had some loops that added stuff to `valid_tags` and `valid_topics` that more sensibly belonged to the top-level.

This also caused issues because if code from `form_descriptions` was imported into another extractor, it could cause side-effects in tests depending: `valid_*` could be different from what was expected.