### PR TITLE
[el] Support alternative template name of `γρ` bis

### DIFF
--- a/src/wiktextract/extractor/el/pos.py
+++ b/src/wiktextract/extractor/el/pos.py
@@ -598,7 +598,10 @@ def extract_form_of_templates(
     # * Only handle cases where the second argument refers to a form:
     #   μορφ / μορφή / λόγια μορφή του, etc.
     #   and ignore those mistakenly used as synonym templates
-    if t_name in ("γρ", "γραφή του") and 2 in t_node.template_parameters:
+    if (
+        t_name in ("γρ", "γραφή του", "alter")
+        and 2 in t_node.template_parameters
+    ):
         second_arg = t_node.template_parameters[2]
         second_arg_str = clean_node(wxr, None, second_arg)
         if "μορφ" in second_arg_str:

--- a/tests/test_el_form_of.py
+++ b/tests/test_el_form_of.py
@@ -236,8 +236,14 @@ class TestElGlosses(TestCase):
         raw = "* {{γρ|τάδε}}"
         self.mktest_sense(raw, [{}])
 
-    def test_gr_linkage_alternative_template_name(self) -> None:
+    def test_gr_linkage_alternative_template_name1(self) -> None:
         # https://el.wiktionary.org/wiki/προμηνώ
         raw = "* {{γραφή του|προμηνύω|μορφ}}"
         expected = [{"form_of": [{"word": "προμηνύω"}]}]
+        self.mktest_sense(raw, expected)
+
+    def test_gr_linkage_alternative_template_name2(self) -> None:
+        # https://el.wiktionary.org/wiki/queen-sized
+        raw = "* {{alter|queen-size|μορφή|en}}"
+        expected = [{"form_of": [{"word": "queen-size"}]}]
         self.mktest_sense(raw, expected)


### PR DESCRIPTION
Adds also `alter`. cf. https://github.com/tatuylonen/wiktextract/pull/1433#discussion_r2446722635