### PR TITLE
Enable use of `note` and `wiki_notice` error messages

### DIFF
--- a/src/wiktextract/config.py
+++ b/src/wiktextract/config.py
@@ -28,6 +28,8 @@ POSSubtitleData = TypedDict(
         "tags": list[str],
         "error": str,  # not used
         "warning": str,  # not used
+        "note": str,  # not used
+        "wiki_notices": str,  # not used
     },
     total=False,
 )
@@ -65,6 +67,8 @@ class WiktionaryConfig:
         "extract_ns_names",
         "allowed_html_tags",
         "parser_function_aliases",
+        "notes",
+        "wiki_notices",
     )
 
     def __init__(
@@ -120,6 +124,8 @@ class WiktionaryConfig:
         self.errors: list[ErrorMessageData] = []
         self.warnings: list[ErrorMessageData] = []
         self.debugs: list[ErrorMessageData] = []
+        self.notes: list[ErrorMessageData] = []
+        self.wiki_notices: list[ErrorMessageData] = []
         self.redirects: SoundFileRedirects = {}
         self.data_folder = files("wiktextract") / "data" / dump_file_lang_code
         self.extract_thesaurus_pages = False
@@ -149,6 +155,10 @@ class WiktionaryConfig:
             self.errors.extend(ret.get("errors", []))
         if "warnings" in ret and len(self.warnings) < 100_000:
             self.warnings.extend(ret.get("warnings", []))
+        if "notes" in ret and len(self.notes) < 100_000:
+            self.notes.extend(ret.get("warnings", []))
+        if "wiki_notices" in ret and len(self.wiki_notices) < 100_000:
+            self.wiki_notices.extend(ret.get("warnings", []))
         if "debugs" in ret and len(self.debugs) < 3_000_000:
             self.debugs.extend(ret.get("debugs", []))
 

--- a/src/wiktextract/extractor/el/page.py
+++ b/src/wiktextract/extractor/el/page.py
@@ -107,7 +107,7 @@ def parse_page(
                 previous_empty_language_name is None
                 or previous_empty_language_code is None
             ):
-                wxr.wtp.warning(
+                wxr.wtp.wiki_notice(
                     f"Can't parse language header: '{lang_name}'; "
                     "skipping section",
                     sortid="page/111",
@@ -181,7 +181,7 @@ def parse_page(
             section_num = num if num > section_num else section_num
 
             if not ok:
-                wxr.wtp.warning(
+                wxr.wtp.wiki_notice(
                     f"Sub-language heading '{heading_title}' couldn't be "
                     f"be parsed as a heading; "
                     f"{type=}, {heading_name=}, {tags=}.",

--- a/src/wiktextract/extractor/el/parse_utils.py
+++ b/src/wiktextract/extractor/el/parse_utils.py
@@ -97,7 +97,7 @@ def find_sections(
         )
 
         if num > 0:
-            wxr.wtp.warning(
+            wxr.wtp.wiki_notice(
                 f"Sub-sub-section is numbered: {heading_name}, {num=}",
                 sortid="page/find_pos_sections_1",
             )

--- a/src/wiktextract/extractor/el/pos.py
+++ b/src/wiktextract/extractor/el/pos.py
@@ -148,7 +148,7 @@ def process_pos(
     if glosses_index is None:
         # Could not find any glosses.
         # logger.info(f"  ////  {wxr.wtp.title}\n  MISSING GLOSSES")
-        wxr.wtp.warning("Missing glosses", sortid="pos/20250121")
+        wxr.wtp.wiki_notice("Missing glosses", sortid="pos/20250121")
         data.tags.append("no-gloss")
 
     template_data: list[TemplateData] = []
@@ -306,7 +306,7 @@ def process_pos(
         # for these (or copying the previous one).
 
         if prev_data is None:
-            wxr.wtp.warning(
+            wxr.wtp.wiki_notice(
                 f"Part of speech missing head: {wxr.wtp.title}",
                 sortid="pos/460/20250104",
             )
@@ -631,7 +631,7 @@ def extract_form_of_templates_basic(
     if extract_argument not in t_args:
         # mtxpp template has no args, consume the next links for the
         # form_of field
-        wxr.wtp.warning(
+        wxr.wtp.wiki_notice(
             f"Form-of template does not have lemma data: {t_name}, {t_args=}",
             sortid="pos/570/20250517",
         )
@@ -651,7 +651,7 @@ def extract_form_of_templates_basic(
         form_of = FormOf(word=lemma)
         parent_sense.form_of.append(form_of)
     else:
-        wxr.wtp.warning(
+        wxr.wtp.wiki_notice(
             "Lemma extract from form-of template was empty or whitespace:"
             f"{t_name}, {t_args=}, {lemma=}",
             sortid="pos/609/20250925",
@@ -728,7 +728,7 @@ def extract_form_of_templates_ptosi(
     t_args = t_node.template_parameters
 
     if 1 not in t_args:
-        wxr.wtp.warning(
+        wxr.wtp.wiki_notice(
             f"Form-of template does not have lemma data: {t_name}, {t_args=}",
             sortid="pos/620/20250416",
         )

--- a/src/wiktextract/extractor/el/table.py
+++ b/src/wiktextract/extractor/el/table.py
@@ -560,7 +560,7 @@ def is_header(
     if first_cells_are_bold:
         return True, False
 
-    wxr.wtp.warning(
+    wxr.wtp.wiki_notice(
         f"Can't be sure if bolded text entry '{text}' is a header or not",
         sortid="table/20250210a",
     )

--- a/src/wiktextract/extractor/el/translations.py
+++ b/src/wiktextract/extractor/el/translations.py
@@ -47,7 +47,7 @@ def process_translations(
                 lang_name = "LANG_NAME_ERROR"
             text = ht.get(2, "")
             if not text:
-                wxr.wtp.warning(
+                wxr.wtp.wiki_notice(
                     f"Translation template has no translation," f"{ht=}",
                     sortid="translations/64",
                 )

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -2019,7 +2019,7 @@ def parse_language(
                 # currently we're separating out example entries (..#:)
                 # well enough that there seems to very little contamination.
                 if is_gloss:
-                    wxr.wtp.warning(
+                    wxr.wtp.wiki_notice(
                         "Example template is used for gloss text",
                         sortid="extractor.en.page.sense_template_fn/1415",
                     )
@@ -3617,7 +3617,7 @@ def parse_language(
                             sortid="page/2755",
                         )
                     if "warning" in dt:
-                        wxr.wtp.warning(
+                        wxr.wtp.wiki_notice(
                             "{} in section {}".format(dt["warning"], t),
                             sortid="page/2759",
                         )
@@ -3625,6 +3625,16 @@ def parse_language(
                         wxr.wtp.error(
                             "{} in section {}".format(dt["error"], t),
                             sortid="page/2763",
+                        )
+                    if "note" in dt:
+                        wxr.wtp.note(
+                            "{} in section {}".format(dt["note"], t),
+                            sortid="page/20251017a",
+                        )
+                    if "wiki_notice" in dt:
+                        wxr.wtp.wiki_notice(
+                            "{} in section {}".format(dt["wiki_notice"], t),
+                            sortid="page/20251017b",
                         )
                     # Parse word senses for the part-of-speech
                     parse_part_of_speech(node, pos)

--- a/src/wiktextract/extractor/simple/pos.py
+++ b/src/wiktextract/extractor/simple/pos.py
@@ -364,7 +364,7 @@ def process_pos(
             if forms := parse_pos_table(wxr, child, data):
                 template_forms.extend(forms)
             else:
-                wxr.wtp.warning(
+                wxr.wtp.wiki_notice(
                     f"POS template '{child.template_name}' did "
                     "not have any forms.",
                     sortid="simple/pos/129",

--- a/src/wiktextract/wiktwords.py
+++ b/src/wiktextract/wiktwords.py
@@ -531,6 +531,8 @@ def main():
                     "errors": wxr.config.errors,
                     "warnings": wxr.config.warnings,
                     "debugs": wxr.config.debugs,
+                    "notes": wxr.config.notes,
+                    "wiki_notices": wxr.config.wiki_notices,
                 },
                 f,
                 sort_keys=True,


### PR DESCRIPTION
Also change some `Wtp.warning()` calls into
`Wtp.wiki_notice()` calls; most of these were added by me and make more sense as complains about the
wiki source.