### PR TITLE
[el] Translate tags in `Linkage`

### DIFF
--- a/src/wiktextract/extractor/el/linkages.py
+++ b/src/wiktextract/extractor/el/linkages.py
@@ -206,10 +206,13 @@ def process_linkage_section(
             )
             return
 
-    target_field.extend(
+    linkages = [
         Linkage(word=" ".join(link_parts), raw_tags=ltags, examples=lexamples)
         for link_parts, ltags, lexamples in combined_line_data
-    )
+    ]
+    for linkage in linkages:
+        translate_raw_tags(linkage)
+    target_field.extend(linkages)
 
     # iterate over list item lines and get links
 

--- a/src/wiktextract/extractor/el/models.py
+++ b/src/wiktextract/extractor/el/models.py
@@ -105,7 +105,7 @@ class Linkage(GreekBaseModel):
     # note: str = ""
     raw_tags: list[str] = []
     tags: list[str] = []
-    # topics: list[str] = []
+    topics: list[str] = []
     # urls: list[str]
     examples: list[str] = []
 

--- a/src/wiktextract/extractor/el/section_titles.py
+++ b/src/wiktextract/extractor/el/section_titles.py
@@ -650,6 +650,7 @@ SUBSECTION_HEADINGS: dict[str, SubSectionMap] = {
     "μερική συνωνυμία": {"type": Heading.Synonyms},
     # Exact synonym
     "ταυτόσημο": {"type": Heading.Synonyms},
+    "ταυτόσημα": {"type": Heading.Synonyms},
     "εκφράσεις": {"type": Heading.Related, "tags": ["idiomatic"]},
     "σύνθετα": {"type": Heading.Related, "tags": ["compound"]},
     "μεταγραφές": {"type": Heading.Transliterations},
@@ -657,7 +658,7 @@ SUBSECTION_HEADINGS: dict[str, SubSectionMap] = {
     "παράγωγα": {"type": Heading.Derived},
     # Derived words
     "απόγονοι": {"type": Heading.Derived},
-    "υποκοριστικά": {"type": Heading.Derived, "tags": ["diminuitive"]},
+    "υποκοριστικά": {"type": Heading.Derived, "tags": ["diminutive"]},
     # Anagrams
     "αλλόγλωσσα παράγωγα": {"type": Heading.Translations},
     "μεταφράσεις": {"type": Heading.Translations},

--- a/src/wiktextract/extractor/el/tags.py
+++ b/src/wiktextract/extractor/el/tags.py
@@ -10,7 +10,7 @@ Otherwise, the implementation of tags is a translation effort: when this
 edition of Wiktionary says 'x', what tags does that refer to?
 """
 
-from wiktextract.extractor.el.models import Form, Sense, WordEntry
+from wiktextract.extractor.el.models import Form, Linkage, Sense, WordEntry
 from wiktextract.tags import uppercase_tags, valid_tags
 from wiktextract.topics import valid_topics
 
@@ -391,6 +391,7 @@ other_tags = {
     "δεικτική αντωνυμία": ["pronoun"],
     "οριστική αντωνυμία": ["pronoun", "definite"],
     "αόριστη αντωνυμία": ["pronoun", "indefinite"],
+    "επιμεριστική αντωνυμία": ["pronoun", "distributive"],
     "ακρωνύμιο": ["acronym"],
     "αρκτικόλεξο": ["initialism"],
     "υποκοριστικό": ["diminutive"],
@@ -731,7 +732,7 @@ tag_map: dict[str, list[str]] = {
 }
 
 
-Taggable = WordEntry | Form | Sense
+Taggable = WordEntry | Form | Sense | Linkage
 """An object with raw_tags, tags and topics attributes."""
 
 


### PR DESCRIPTION
Title. Also a couple of tags added.

Stems from [πηγάινω](https://el.wiktionary.org/wiki/πηγαίνω), where I could not find this section in the jsonl:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/beddcb3d-ddb2-417c-94af-522a6c8a3090" />
