### PR TITLE
[el] Narrow `POSName`

### DIFF
--- a/src/wiktextract/extractor/el/etymology.py
+++ b/src/wiktextract/extractor/el/etymology.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from wikitextprocessor import NodeKind, TemplateNode, WikiNode
 from wikitextprocessor.parser import LEVEL_KIND_FLAGS
 
@@ -11,7 +13,7 @@ from .parse_utils import (
 )
 from .pos import extract_form_of_templates
 from .pronunciation import process_pron
-from .section_titles import Heading
+from .section_titles import Heading, POSName
 
 
 def process_etym(
@@ -55,6 +57,9 @@ def process_etym(
     ):
         if heading_type == Heading.POS:
             section_num = num if num > section_num else section_num
+            # SAFETY: Since the heading_type is POS, find_sections
+            # "pos_or_section" is guaranteed to be a pos: POSName
+            pos = cast(POSName, pos)
             ret_etym_sublevels.append(
                 (
                     pos,

--- a/src/wiktextract/extractor/el/page.py
+++ b/src/wiktextract/extractor/el/page.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any
+from typing import Any, cast
 
 from mediawiki_langcodes import code_to_name, name_to_code
 
@@ -32,7 +32,7 @@ from .parse_utils import (
 )
 from .pos import process_pos
 from .pronunciation import process_pron
-from .section_titles import Heading
+from .section_titles import Heading, POSName
 
 # from .text_utils import ENDING_NUMBER_RE
 
@@ -233,7 +233,10 @@ def parse_page(
 
                 found_pos_sections.extend(pron_sublevels)
 
-            if heading_type is Heading.POS:
+            if heading_type == Heading.POS:
+                # SAFETY: Since the heading_type is POS, parse_lower_heading
+                # "pos_or_section" is guaranteed to be a pos: POSName
+                pos = cast(POSName, pos)
                 found_pos_sections.append(
                     (
                         pos,

--- a/src/wiktextract/extractor/el/parse_utils.py
+++ b/src/wiktextract/extractor/el/parse_utils.py
@@ -93,6 +93,13 @@ def find_sections(
     None,
     None,
 ]:
+    """In practice, only called when we expect heading_type to be either
+    Heading.POS or Heading.Pron.
+
+    Heading.POS guarantees that pos_or_section is a POSName.
+    Heading.Pron guarantees that pos_or_section is a SectionName, and, looking
+    at SUBSECTION_HEADINGS, either: "pronunciation" or "προφορά"
+    """
     for node in nodes:
         heading_title = clean_node(wxr, None, node.largs[0]).lower().strip()
 

--- a/src/wiktextract/extractor/el/pronunciation.py
+++ b/src/wiktextract/extractor/el/pronunciation.py
@@ -1,4 +1,5 @@
 import re
+from typing import cast
 
 from wikitextprocessor import NodeKind, TemplateNode, WikiNode
 from wikitextprocessor.parser import LEVEL_KIND_FLAGS  # , print_tree
@@ -10,7 +11,7 @@ from wiktextract.page import clean_node
 # from wiktextract.wxr_logging import logger
 from .models import Sound, WordEntry
 from .parse_utils import POSReturns, find_sections
-from .section_titles import Heading
+from .section_titles import Heading, POSName
 from .tags_utils import convert_tags
 
 TEMPLATES_TO_IGNORE: set[str] = set(
@@ -153,7 +154,9 @@ def process_pron(
         section_num = num if num > section_num else section_num
 
         if heading_type == Heading.POS:
-            section_num = num if num > section_num else section_num
+            # SAFETY: Since the heading_type is POS, find_sections
+            # "pos_or_section" is guaranteed to be a pos: POSName
+            pos = cast(POSName, pos)
             pos_returns.append(
                 (
                     pos,

--- a/src/wiktextract/extractor/el/section_titles.py
+++ b/src/wiktextract/extractor/el/section_titles.py
@@ -1,7 +1,7 @@
 # https://simple.wiktionary.org/wiki/Category:Part_of_speech_templates
 import re
 from enum import Enum, auto
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 
 class Heading(Enum):
@@ -9,7 +9,7 @@ class Heading(Enum):
     Ignored = auto()
     POS = auto()
     Etym = auto()
-    Pron = auto()
+    Pron = auto()  # Pronunciation
     Infl = auto()
     Related = auto()
     Transliterations = auto()
@@ -23,7 +23,35 @@ class Heading(Enum):
 
 
 Tags = list[str]
-POSName = str
+POSName = Literal[
+    "",  # Used as default
+    "ERROR_UNKNOWN_POS",
+    "abbrev",
+    "adj",
+    "adv",
+    "adv_phrase",
+    "affix",
+    "article",
+    "character",
+    "conj",
+    "contraction",
+    "det",
+    "infix",
+    "intj",
+    "name",
+    "noun",
+    "num",
+    "particle",
+    "phrase",
+    "prefix",
+    "prep",
+    "pron",  # pronoun
+    "romanization",
+    "root",
+    "suffix",
+    "symbol",
+    "verb",
+]
 POSMap = TypedDict(
     "POSMap",
     {


### PR DESCRIPTION
* Narrow `POSName` with a literal
* Please mypy by casting at some places. Explain the rationale.

Note that this is more that type hints. Pydantic validates `POSName`, since it appears as the type of `pos` in `WordEntry`. This effectively mean that the code will crash if something not in `POSname` is assigned to `wordentry.pos`. It also means that we are guaranteed that only strings in that list will appear on the final jsonl.