### PR TITLE
[doc] Typos and suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You can also easily pretty-print the data into a more human-readable form using:
 print(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False))
 ```
 
-Non-en editions has JSON schema files at https://tatuylonen.github.io/wiktextract/, the English edition doesn't have JSON schema but the fields are listed at https://kaikki.org/dictionary/errors/mapping/index.html and has TypedDict models in [type_utils.py](https://github.com/tatuylonen/wiktextract/blob/master/src/wiktextract/extractor/en/type_utils.py) file.
+Non-en editions have JSON schema files at https://tatuylonen.github.io/wiktextract/. The English edition doesn't have a JSON schema but the fields are listed at https://kaikki.org/dictionary/errors/mapping/index.html, and has `TypedDict` models in [type_utils.py](https://github.com/tatuylonen/wiktextract/blob/master/src/wiktextract/extractor/en/type_utils.py).
 
 Here is a pretty-printed example of an extracted word entry for the
 word `thrill` as an English verb (only one part-of-speech is shown here):


### PR DESCRIPTION
Just a couple suggestions over #1471, but more than anything, an excuse to ask if you plan on dropping python 3.10 support any time soon?

I am not sure the English version uses those `TypedDicts`, but having the `Required` type hint for `TypedDicts` (3.11>=) just makes them much more robust. I know that, at least, it will silence quite some IDE warnings for the Greek edition.