### PR TITLE
[en] Ignore Template:table auto-filling tables in linkages

### DIFF
--- a/src/wiktextract/extractor/en/linkages.py
+++ b/src/wiktextract/extractor/en/linkages.py
@@ -420,6 +420,9 @@ def parse_linkage(
         if is_panel_template(wxr, name):
             have_panel_template = True
             return ""
+        # Ignore auto-filled templates like Template:table:Solar System/en
+        if name.startswith("table:"):
+            return ""
         return None
 
     # Main body of parse_linkage()


### PR DESCRIPTION
See #1478 

I also tried to add middle-dot "·" as a word separator for linkages, but that doesn't work because it is used in MORSE CODE strings as the dit... Which means we can't parse stuff like `Template:list:planets of the Solar System/en` properly. Even using spaces around the middle dot reads as Morse code "e".