### PR TITLE
[en] Also ignore `Template:list:` templates in linkages

### DIFF
--- a/src/wiktextract/extractor/en/linkages.py
+++ b/src/wiktextract/extractor/en/linkages.py
@@ -421,7 +421,7 @@ def parse_linkage(
             have_panel_template = True
             return ""
         # Ignore auto-filled templates like Template:table:Solar System/en
-        if name.startswith("table:"):
+        if name.startswith(("table:", "list:")):
             return ""
         return None
 


### PR DESCRIPTION
After sleeping on, these are just generic lists of vaguely interrelated things.