### PR TITLE
[en] In head `alts`, if encountering " -" in text, chop it off

### DIFF
--- a/src/wiktextract/extractor/en/form_descriptions.py
+++ b/src/wiktextract/extractor/en/form_descriptions.py
@@ -1820,10 +1820,6 @@ def parse_word_head(
     if "Lua execution error" in text or "Lua timeout error" in text:
         return
 
-    # In Aug 2021, some words had spurious Template:en at the end of head forms
-    # due to a Wiktionary error.
-    text = re.sub(r"\s+Template:[-a-zA-Z]+\s*$", "", text)
-
     # Fix words with "superlative:" or "comparative:" at end of head
     # e.g. grande/Spanish/Adj
     text = re.sub(r" (superlative|comparative): (.*)", r" (\1 \2)", text)
@@ -1878,6 +1874,7 @@ def parse_word_head(
     # Many languages use • as a punctuation mark separating the base
     # from the rest of the head. στάδιος/Ancient Greek, issue #176
     base = base.strip()
+    # print(f"{base=}")
 
     # Check for certain endings in head (mostly for compatibility with weird
     # heads, e.g. rata/Romanian "1st conj." at end)
@@ -1996,6 +1993,13 @@ def parse_word_head(
         if alt.startswith("compound form:"):
             mode = "compound-form"
             alt = alt[14:].strip()
+        if (dash_i := alt.find(" -")) > 0:
+            # test_en_head / test_suffixes_at_end_of_form1
+            # Some heads have suffixes that end up attached to the form
+            # like in https://en.wiktionary.org/wiki/%E6%A5%BD%E3%81%97%E3%81%84
+            # We'll assume that there is no lemma anywhere that has " -" in it
+            # in any language, and thus it is safe to just chop it off.
+            alt = alt[:dash_i]
         if mode == "compound-form":
             add_related(
                 wxr,

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -812,7 +812,7 @@ def parse_sense_linkage(
 
                     lang_code = clean_node(wxr, None, ht.get(1, ""))
                     for t_data in search_thesaurus(
-                        wxr.thesaurus_db_conn,
+                        wxr.thesaurus_db_conn,  # type: ignore
                         w,
                         lang_code,
                         pos,

--- a/tests/test_en_head.py
+++ b/tests/test_en_head.py
@@ -181,8 +181,7 @@ class HeadTests(unittest.TestCase):
         parse_word_head(
             self.wxr,
             "noun",
-            "testpage f (plurale tantum, stem testpag, inanimate) "
-            "(+ dative)",
+            "testpage f (plurale tantum, stem testpag, inanimate) (+ dative)",
             data,
             False,
             None,
@@ -672,7 +671,7 @@ class HeadTests(unittest.TestCase):
         parse_word_head(
             self.wxr,
             "noun",
-            "rear admiral (lower half) (plural rear admirals " "(lower half))",
+            "rear admiral (lower half) (plural rear admirals (lower half))",
             data,
             False,
             None,
@@ -952,6 +951,72 @@ class HeadTests(unittest.TestCase):
                     ],
                     "senses": [{"raw_tags": ["han"], "tags": ["no-gloss"]}],
                     "word": "敎",
+                }
+            ],
+        )
+
+    def test_suffixes_at_end_of_form1(self):
+        # Issue #1484
+        data = {}
+        self.wxr.wtp.start_page("foo")
+        self.wxr.wtp.start_section("Japanese")
+        self.wxr.wtp.start_subsection("Adjective")
+        self.wxr.wtp.add_page(
+            "Template:ja-adj",
+            10,
+            """
+<p><span class="headword-line"><strong class="Jpan headword" lang="ja"><ruby>楽<rp>(</rp><rt><a href="/wiki/%E3%81%9F%E3%81%AE%E3%81%97%E3%81%84#Japanese" title="たのしい">たの</a></rt><rp>)</rp></ruby>しい</strong> <a href="/wiki/Wiktionary:Japanese_transliteration" title="Wiktionary:Japanese transliteration">•</a> (<span lang="ja-Latn" class="headword-tr tr Latn" dir="ltr"><a href="/wiki/tanoshii#Japanese" title="tanoshii">tanoshii</a></span></span>)&nbsp;<i><abbr title="-i (type I) inflection">-i</abbr></i> (<i>adverbial</i> <b class="Jpan" lang="ja"><a href="/wiki/%E6%A5%BD%E3%81%97%E3%81%8F#Japanese" title="楽しく"><ruby>楽<rp>(</rp><rt>たの</rt><rp>)</rp></ruby>しく</a></b> <span class="mention-gloss-paren annotation-paren">(</span><span class="tr">tanoshiku</span><span class="mention-gloss-paren annotation-paren">)</span>)
+</p>""",
+        )
+        data = parse_page(
+            self.wxr,
+            "楽しい",
+            """
+==Japanese==
+
+===Adjective===
+{{ja-adj}}
+
+# pleasant
+""",
+        )
+        self.assertEqual(
+            data,
+            [
+                {
+                    "forms": [
+                        {
+                            "form": "楽しい",
+                            "ruby": [("楽", "たの")],
+                            "tags": ["canonical"],
+                        },
+                        {"form": "tanoshii", "tags": ["romanization"]},
+                        {
+                            "form": "楽しく",
+                            "roman": "tanoshiku",
+                            "ruby": [("楽", "たの")],
+                            "tags": ["adverbial"],
+                        },
+                    ],
+                    "head_templates": [
+                        {
+                            "args": {},
+                            "expansion": "楽(たの)しい • (tanoshii) -i (adverbial 楽(たの)しく (tanoshiku))",
+                            "name": "ja-adj",
+                        }
+                    ],
+                    "lang": "Japanese",
+                    "lang_code": "ja",
+                    "pos": "adj",
+                    "senses": [
+                        {
+                            "glosses": ["pleasant"],
+                            "raw_glosses": [
+                                "pleasant"
+                            ],
+                        }
+                    ],
+                    "word": "楽しい",
                 }
             ],
         )


### PR DESCRIPTION
See #1484 

This should fix an issue where some head forms have suffixes after the text that are added to forms: "children -ren" as a made-up example.

If text has " -" in it, just chop it off at the end. I can't think of any case where you'd have something like "foo -b" in the dictionary... Ok, I hope "rm -rf" isn't added or something like that. If so, add a further test to check whether the article title has it, no big deal.