### PR TITLE
[el] Fix participle pos

### DIFF
--- a/src/wiktextract/extractor/el/page.py
+++ b/src/wiktextract/extractor/el/page.py
@@ -155,6 +155,16 @@ def parse_page(
                         source="declension",
                     )
 
+        # If we only looked at the headword (μετοχή), all the participles would
+        # be labeled as "verb"s, which is just wrong.
+        # Instead, we quickly inspect the page for a participle template, and
+        # then, if we are indeed a participle, we update the pos.
+        better_participle_pos: POSName | None = None
+        for child in page_root.find_child_recursively(NodeKind.TEMPLATE):
+            t_name = child.template_name
+            if t_name.startswith("μτχ") and t_name != "μτχεε":
+                better_participle_pos = "adj"
+
         for sublevel in sublevels:
             if len(sublevel.largs) == 0:
                 wxr.wtp.debug(
@@ -169,6 +179,14 @@ def parse_page(
             heading_type, pos, tags, num, ok = parse_lower_heading(
                 wxr, heading_title
             )
+
+            # It would have been great if we had a "participle" pos, but alas!
+            if (
+                pos == "verb"
+                and tags == ["participle"]
+                and better_participle_pos
+            ):
+                pos = better_participle_pos
 
             section_num = num if num > section_num else section_num
 

--- a/tests/test_el_pos.py
+++ b/tests/test_el_pos.py
@@ -1,0 +1,66 @@
+from unittest import TestCase
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.el.page import parse_page
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestElHeader(TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="el"),
+            WiktionaryConfig(
+                dump_file_lang_code="el",
+                capture_language_codes=None,
+            ),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def mktest_pos(self, raw, expected) -> None:
+        self.wxr.wtp.add_page("Πρότυπο:-el-", 10, "Νέα ελληνικά (el)")
+        self.wxr.wtp.add_page("Πρότυπο:μετοχή", 10, "Μετοχή")
+        self.wxr.wtp.add_page("Πρότυπο:ετυμολογία", 10, "Ετυμολογία")
+
+        word = "word_filler"
+        page_datas = parse_page(self.wxr, word, raw)
+        received = page_datas[0]["pos"]
+        self.assertEqual(expected, received)
+
+    def test_el_participle_is_adj_at_etym(self) -> None:
+        # https://el.wiktionary.org/wiki/ζαρωμένος
+        raw = """=={{-el-}}==
+
+==={{ετυμολογία}}===
+: '''{{PAGENAME}}''' < {{μτχππ|ζαρώνω}}
+
+==={{μετοχή|el}}===
+'''{{PAGENAME}}, -η, -ο'''
+* foo
+"""
+        self.mktest_pos(raw, "adj")
+
+    def test_el_participle_is_adj_at_main(self) -> None:
+        # https://el.wiktionary.org/wiki/ψηφίσας
+        raw = """=={{-el-}}==
+
+==={{μετοχή|el}}===
+'''{{PAGENAME}}, -ασα, -αν'''
+* {{μτχεα|ψηφίζω|el|χ+=ψήφισα}}: που [[ψηφίζω|ψήφισε]]
+"""
+        self.mktest_pos(raw, "adj")
+
+    def test_el_participle_is_verb_at_main(self) -> None:
+        # https://el.wiktionary.org/wiki/αναδεικνύοντας
+        raw = """=={{-el-}}==
+
+==={{μετοχή|el}}===
+'''{{PAGENAME}}'''
+* {{μτχεε|αναδεικνύω}}
+"""
+        self.mktest_pos(raw, "verb")


### PR DESCRIPTION
Not sure if this needs a Greek grammar explanation. Please tell me it does not.

Note that the English version does label ζαρωμένος as adjective. Then again, it is just under an adjective template there, which unsurprisingly helps the matter... [el](https://el.wiktionary.org/wiki/%CE%B6%CE%B1%CF%81%CF%89%CE%BC%CE%AD%CE%BD%CE%BF%CF%82#Greek) [en](https://en.wiktionary.org/wiki/%CE%B6%CE%B1%CF%81%CF%89%CE%BC%CE%AD%CE%BD%CE%BF%CF%82#Greek)

---

Also, this does not type check. It requires this overload in `wikitextprocessor` that I am too lazy to send in a PR. If you want to add it yourself, feel free:

```py
    @overload
    def find_child_recursively(
        self,
        target_kinds: Literal[NodeKind.TEMPLATE],
    ) -> Iterator["TemplateNode"]: ...
 ```