### PR TITLE
[el] Don't add forms if there is no template name

### DIFF
--- a/src/wiktextract/extractor/el/table.py
+++ b/src/wiktextract/extractor/el/table.py
@@ -105,6 +105,7 @@ def process_inflection_section(
     snode: WikiNode,
     *,
     source: FormSource = "",
+    top_template_name: str | None = None
 ) -> None:
     table_nodes: list[tuple[str | None, WikiNode]] = []
     # template_depth is used as a nonlocal variable in bold_node_handler
@@ -112,7 +113,6 @@ def process_inflection_section(
     # collect template data only for the top-level templates that are
     # visible in the wikitext, not templates inside templates.
     template_depth = 0
-    top_template_name: str | None = None
 
     def table_node_handler_fn(
         node: WikiNode,
@@ -446,7 +446,13 @@ def parse_table(
     #         form.raw_tags = new_raw_tags
     # print(f"Inside parse_table: {forms=}")
 
-    if len(forms) > 0:
+    # If there is no template name (https://el.wiktionary.org/wiki/κρόκος)
+    # we are adding junk anyway. This prevents a Form with empty form, which
+    # is treated as an (non critical) error by src/wiktextract/wiktionary.py
+    #
+    # (I think the κρόκος issue is due to not stopping parsing at headings,
+    # since the two intermingled templates are in different headings...)
+    if forms and template_name:
         data.forms.append(
             Form(
                 form=template_name,

--- a/tests/test_el_inflection.py
+++ b/tests/test_el_inflection.py
@@ -47,7 +47,9 @@ class TestElInflection(TestCase):
         self.wxr.wtp.start_subsection(pos)
         tree = self.wxr.wtp.parse(text)
         data = WordEntry(lang=lang, lang_code="el", word=word)
-        process_inflection_section(self.wxr, data, tree)  # note that source=""
+        process_inflection_section(
+            self.wxr, data, tree, top_template_name="tname-filler"
+        )
         dumped = data.model_dump(exclude_defaults=True)
         forms = dumped["forms"]
         return forms
@@ -161,7 +163,7 @@ class TestElInflection(TestCase):
 |}
 """
         expected = [
-            {"tags": ["inflection-template"]},
+            {"form": "tname-filler", "tags": ["inflection-template"]},
             {
                 "form": "πλάγιος",
                 "tags": ["masculine", "singular", "nominative"],
@@ -358,7 +360,7 @@ class TestElInflection(TestCase):
 |}
 """
         expected = [
-            {"tags": ["inflection-template"]},
+            {"form": "tname-filler", "tags": ["inflection-template"]},
             {"form": "αιδώς", "tags": ["singular", "nominative"]},
             {"form": "αιδούς", "tags": ["genitive", "singular"]},
             {"form": "αιδώ", "tags": ["accusative", "singular"]},
@@ -405,7 +407,7 @@ class TestElInflection(TestCase):
 |}
 """
         expected = [
-            {"tags": ["inflection-template"]},
+            {"form": "tname-filler", "tags": ["inflection-template"]},
             {"form": "αβγούλι", "tags": ["singular", "nominative"]},
             {"form": "αβγούλια", "tags": ["nominative", "plural"]},
             # There should be no genitive
@@ -590,7 +592,7 @@ class TestElInflection(TestCase):
 |}
 """
         expected = [
-            {"tags": ["inflection-template"]},
+            {"form": "tname-filler", "tags": ["inflection-template"]},
             {"form": "-ωνιά", "tags": ["singular", "nominative"]},
             {"form": "-ωνιές", "tags": ["nominative", "plural"]},
             {"form": "-ωνιάς", "tags": ["genitive", "singular"]},
@@ -640,7 +642,7 @@ class TestElInflection(TestCase):
 |}
 """
         expected = [
-            {"tags": ["inflection-template"]},
+            {"form": "tname-filler", "tags": ["inflection-template"]},
             {"form": "μπόι", "tags": ["singular", "nominative"]},
             {"form": "μπόγια", "tags": ["nominative", "plural"]},
             {"form": "μπογιού", "tags": ["genitive", "singular"]},
@@ -689,7 +691,7 @@ class TestElInflection(TestCase):
 | colspan="5" align="right" style="text-align:right; background:#eaf0fa; font-size:70%; line-height:100%;" | [[:Κατηγορία:Ουσιαστικά που κλίνονται όπως το 'ζωγράφος' (νέα ελληνικά)|Κατηγορία]]  όπως «[[Παράρτημα:Ουσιαστικά (νέα ελληνικά)/κοινά#ζωγράφος|ζωγράφος]]» - [[Παράρτημα:Ουσιαστικά (νέα ελληνικά)|<span title="Παράρτημα:Ουσιαστικά">Παράρτημα:Ουσιαστικά</span>]]
 |}"""
         expected = [
-            {"tags": ["inflection-template"]},
+            {"form": "tname-filler", "tags": ["inflection-template"]},
             {
                 "form": "-γράφος",
                 "tags": ["singular", "nominative"],
@@ -770,7 +772,7 @@ class TestElInflection(TestCase):
         """.strip()
 
         expected = [
-            {"tags": ["inflection-template"]},
+            {"form": "tname-filler", "tags": ["inflection-template"]},
             {
                 "form": "πίνω",
                 "tags": ["present", "first-person", "singular"],
@@ -891,7 +893,7 @@ class TestElInflection(TestCase):
         """
 
         expected = [
-            {"tags": ["inflection-template"]},
+            {"form": "tname-filler", "tags": ["inflection-template"]},
             {
                 "form": "τρώω",
                 "tags": ["first-person", "singular", "present"],
@@ -1065,7 +1067,7 @@ class TestElInflection(TestCase):
         """.strip()
 
         expected = [
-            {"tags": ["inflection-template"]},
+            {"form": "tname-filler", "tags": ["inflection-template"]},
             {
                 "form": "πίνουν",
                 "tags": ["present", "third-person", "plural"],


### PR DESCRIPTION
Alternatively, you could close this and consider fixing whatever it is that happens at [κρόκος](https://el.wiktionary.org/wiki/%CE%BA%CF%81%CF%8C%CE%BA%CE%BF%CF%82) with the pictures.

Without this you will find:

```json
{"tags":["inflection-template"],"source":"inflection"},{"form":"thumb|200px|Ο κρόκος ενός αβγού.","raw_tags":["thumb|150px|Άνθη κρόκου Crocus sativus"],"source":"inflection"}
```

in the forms.