### PR TITLE
[ja] add "transliteration" tag to "headword-tr" class name form

### DIFF
--- a/src/wiktextract/extractor/ja/header.py
+++ b/src/wiktextract/extractor/ja/header.py
@@ -60,7 +60,7 @@ def extract_header_nodes(
         elif (
             isinstance(node, HTMLNode)
             and node.tag == "span"
-            and "form-of" in node.attrs.get("class", "")
+            and "form-of" in node.attrs.get("class", "").split()
         ):
             for span_child in node.children:
                 if isinstance(span_child, str) and span_child.strip() != "":
@@ -132,7 +132,8 @@ def add_form_data(
             for class_name in FORM_OF_CLASS_TAGS:
                 if class_name in class_names:
                     form.tags.append(class_name)
-        if "tr Latn" in node.attrs.get("class", ""):
+        class_name = node.attrs.get("class", "")
+        if "tr Latn" in class_name or "headword-tr" in class_name:
             form.tags.append("transliteration")
         translate_raw_tags(form)
         if raw_tags == ["又は"] and len(word_entry.forms) > 0:

--- a/tests/test_ja_header.py
+++ b/tests/test_ja_header.py
@@ -83,7 +83,7 @@ class TestJaHeader(TestCase):
             data.forms,
             [
                 Form(form="料理する", tags=["canonical"]),
-                Form(form="りょうりする"),
+                Form(form="りょうりする", tags=["transliteration"]),
             ],
         )
 
@@ -137,9 +137,9 @@ class TestJaHeader(TestCase):
         self.assertEqual(
             [f.model_dump(exclude_defaults=True) for f in data.forms],
             [
-                {"form": "きんぎょく"},
-                {"form": "きんたま"},
-                {"form": "かねだま"},
+                {"form": "きんぎょく", "tags": ["transliteration"]},
+                {"form": "きんたま", "tags": ["transliteration"]},
+                {"form": "かねだま", "tags": ["transliteration"]},
             ],
         )
 


### PR DESCRIPTION
Module:ja-headword line 229 says "かな表記をtranslitとする" which translates to "The kana notation is translit".