### PR TITLE
[el] Fix γρ template and sections to parse `AltForm`

### DIFF
--- a/src/wiktextract/extractor/el/etymology.py
+++ b/src/wiktextract/extractor/el/etymology.py
@@ -11,7 +11,7 @@ from .parse_utils import (
     POSReturns,
     find_sections,
 )
-from .pos import extract_form_of_templates
+from .pos import extract_alt_form_templates
 from .pronunciation import process_pron
 from .section_titles import Heading, POSName
 
@@ -36,12 +36,12 @@ def process_etym(
     # Extract form_of data
     for i, t_node in enumerate(etym_contents):
         if isinstance(t_node, TemplateNode):
-            extract_form_of_templates(wxr, base_data, t_node, etym_contents, i)
+            extract_alt_form_templates(wxr, base_data, t_node, etym_contents, i)
         if isinstance(t_node, WikiNode) and t_node.kind == NodeKind.LIST:
             for l_item in t_node.find_child_recursively(NodeKind.LIST_ITEM):
                 for j, l_node in enumerate(l_item.children):
                     if isinstance(l_node, TemplateNode):
-                        extract_form_of_templates(
+                        extract_alt_form_templates(
                             wxr, base_data, l_node, l_item.children, j
                         )
 

--- a/src/wiktextract/extractor/el/models.py
+++ b/src/wiktextract/extractor/el/models.py
@@ -112,7 +112,7 @@ class Linkage(GreekBaseModel):
     examples: list[str] = []
 
 
-class FormOf(GreekBaseModel):
+class AltForm(GreekBaseModel):
     word: str
     # extra: str
     # roman: str
@@ -125,9 +125,9 @@ class Sense(GreekBaseModel):
     tags: list[str] = []
     raw_tags: list[str] = []
     topics: list[str] = []
-    form_of: list[FormOf] = []
-    # alt_of : list[FormOf] = []
-    # compound_of: list[FormOf] = []
+    form_of: list[AltForm] = []
+    alt_of : list[AltForm] = []
+    # compound_of: list[AltForm] = []
     categories: list[str] = []  # Wikipedia category link data; not printed.
     examples: list[Example] = []
     synonyms: list[Linkage] = []
@@ -255,8 +255,8 @@ class WordEntry(GreekBaseModel):
     raw_tags: list[str] = []
     hyphenation: str = ""  # Should be a list `hyphenations`.
     head_templates: list[TemplateData] = []
-    # alt_of: list[FormOf] = []
-    form_of: list[FormOf] = []
+    alt_of: list[AltForm] = []
+    form_of: list[AltForm] = []
     antonyms: list[Linkage] = []
     # coordinate_terms: list[Linkage] = []
     derived: list[Linkage] = []

--- a/src/wiktextract/extractor/el/section_titles.py
+++ b/src/wiktextract/extractor/el/section_titles.py
@@ -12,6 +12,8 @@ class Heading(Enum):
     Pron = auto()  # Pronunciation
     Infl = auto()
     Related = auto()
+    AltOf = auto()
+    FormOf = auto()
     Transliterations = auto()
     Synonyms = auto()
     Homonyms = auto()
@@ -52,6 +54,7 @@ POSName = Literal[
     "symbol",
     "verb",
 ]
+"""Greek subset of the English PARTS_OF_SPEECH."""
 POSMap = TypedDict(
     "POSMap",
     {
@@ -665,8 +668,17 @@ SUBSECTION_HEADINGS: dict[str, SubSectionMap] = {
     "κλίση": {"type": Heading.Infl},
     "references": {"type": Heading.Ref},
     "αναφορές": {"type": Heading.Ref},
-    "άλλες γραφές": {"type": Heading.Transliterations},
-    "άλλες μορφές": {"type": Heading.Related},
+    # Lit. other spellings
+    # Ex. γορίλλας/γορίλας @ https://el.wiktionary.org/wiki/γορίλλας
+    # Ex. ερωοτοπάλεμα/ἐρωτοπάλεμα @ https://el.wiktionary.org/wiki/ερωτοπάλεμα
+    #     from "{{άλλη γραφή}}" that expands to "άλλες γραφές"
+    # cf. γρ template parsing at pos.py. Keep both in sync.
+    "άλλες γραφές": {"type": Heading.AltOf},
+    # Lit. other forms
+    # Ex. ελαιόδενδρο/ελιά @ https://el.wiktionary.org/wiki/ελαιόδενδρο
+    #     from "{{μορφές}}" that expands to "άλλες μορφές"
+    # cf. γρ template parsing at pos.py. Keep both in sync.
+    "άλλες μορφές": {"type": Heading.FormOf},
     "ανεπίσημα": {"type": Heading.Related},
     "συγγενικά": {"type": Heading.Related},
     "πολυλεκτικοί όροι": {"type": Heading.Related},


### PR DESCRIPTION
Documentation to the γρ template [here](https://el.wiktionary.org/wiki/%CE%A0%CF%81%CF%8C%CF%84%CF%85%CF%80%CE%BF:%CE%B3%CF%81)

The main point is that the `γρ` template, and the associated sections (άλλες μορφές - other forms, άλλη γραφή - other writing/spelling), can fit in both model categories: `FormOf` and `AltOf`. To discriminate:

* Section άλλες μορφές > `FormOf`
* Section άλλη γραφή > `AltOf`
* `γρ` template > `FormOf` if it contains a form keyword (μορφ, μορφή etc.) as second parameter, otherwise `AltOf`

---

Other changes:
* Renamed the class `FormOf` to `AltForm`, similar to what xxyzz does in other extractors, because pushing `FormOf` to `data.alt_of` was quite confusing.
* There are some impressing gymnastics by me in order to not change the behaviour of that lingering Esperanto testcase. The proper transliteration section should be  "μεταγραφές", but since it wouldn't surprise me to see editors use the `γρ` associated sections for that, I tried to not change it.
* A bunch of renaming for clarity
* A couple tests