### PR TITLE
Add a script to compare json schemas

### DIFF
--- a/tools/compare_schemas.py
+++ b/tools/compare_schemas.py
@@ -1,0 +1,228 @@
+"""Generate a simple html page to visualize which attributes are in which
+language.
+
+Internally, it just compares the json schemas made from Pydantic (so no English
+edition!).
+"""
+
+import json
+from pathlib import Path
+from typing import Any, TypedDict
+
+from generate_schema import iter_schemas
+
+Attrs = list[str]
+
+
+class Summary(TypedDict):
+    language: str
+    attributes: Attrs
+
+
+def summarize_schema(schema: Any) -> Summary:
+    lang = schema.get("title") or schema.get("$id") or "unknown"
+    lang = lang.split()[0]  # remove Wiktionary part
+    attributes = set()
+    seen = set()
+
+    def walk(node, prefix=""):
+        if not isinstance(node, dict):
+            return
+
+        node_id = id(node)
+        if node_id in seen:
+            return
+        seen.add(node_id)
+
+        # Normal properties
+        if "properties" in node:
+            for prop, sub in node["properties"].items():
+                path = f"{prefix}.{prop}" if prefix else prop
+                attributes.add(path)
+                walk(sub, path)
+
+        # Array items
+        if node.get("type") == "array":
+            items = node.get("items")
+            if isinstance(items, dict):
+                walk(items, prefix)
+
+        # Definitions
+        if "$defs" in node:
+            for defname, defschema in node["$defs"].items():
+                path = f"$defs.{defname}"
+                attributes.add(path)
+                walk(defschema, path)
+
+        # Combinator keywords: oneOf, anyOf, allOf
+        for key in ("oneOf", "anyOf", "allOf"):
+            if key in node:
+                for sub in node[key]:
+                    walk(sub, prefix)
+
+        # Handle internal $ref
+        if "$ref" in node:
+            ref = node["$ref"]
+            if ref.startswith("#/"):
+                target = schema
+                for part in ref[2:].split("/"):
+                    target = target.get(part, {})
+                walk(target, prefix)
+
+    walk(schema)
+    return {"language": lang, "attributes": sorted(attributes)}
+
+
+def read_all_summaries() -> dict[str, Attrs]:
+    summaries = {}
+
+    for _, model_schema in iter_schemas():
+        # Seems dumb, but we need this to replicate reading the schemas from
+        # the _site folder, due to key sorting...
+        schema = json.loads(
+            json.dumps(
+                model_schema,
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+        summary = summarize_schema(schema)
+        lang = summary["language"]
+        summaries[lang] = summary["attributes"]
+
+    return summaries
+
+
+def add_summary_to_tree(global_tree: dict, lang: str, attrs: Attrs) -> None:
+    """Convert the flat attrs to dictionary tree.
+
+    Each node gets a _langs set that accumulates languages reaching it.
+    """
+    for path in attrs:
+        node = global_tree
+        for p in path.split("."):
+            node = node.setdefault(p, {})
+            node.setdefault("_langs", set()).add(lang)
+
+
+def basic_css() -> str:
+    return """
+<style>
+.all  { color: green; }
+.one  { color: red; }
+.some { color: black; }
+
+/* Yoinked @
+https://gist.githubusercontent.com/dylancwood/7368914/raw/48a6e93ab59a1017ee6a8512a2bf5be343aa307c/tree.css
+*/
+
+ul.tree,
+ul.tree ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+ul.tree ul {
+    margin-left: 20px; /* Changed this to be bigger */
+}
+
+ul.tree li {
+    margin: 0;
+    padding: 0 7px;
+    line-height: 20px;
+    color: #369;
+    font-weight: bold;
+    border-left: 1px solid rgb(100, 100, 100);
+}
+
+ul.tree li:last-child {
+    border-left: none;
+}
+
+ul.tree li:before {
+    position: relative;
+    top: -0.3em;
+    height: 1em;
+    width: 12px;
+    color: white;
+    border-bottom: 1px solid rgb(100, 100, 100);
+    content: "";
+    display: inline-block;
+    left: -7px;
+}
+
+ul.tree li:last-child:before {
+    border-left: 1px solid rgb(100, 100, 100);
+}
+
+</style>
+"""
+
+
+def html_tree(tree: dict, all_langs: list[str]) -> str:
+    """Return HTML for the tree; languages visible on hover. No CSS."""
+    from html import escape
+
+    n_langs = len(all_langs)
+    all_langs_set = set(all_langs)
+
+    def go(node: dict) -> str:
+        parts = ['<ul class="tree">']
+
+        for key, child in sorted(node.items()):
+            if key == "_langs":
+                continue
+
+            langs = child.get("_langs", set())
+            assert langs, "langs should not be empty"
+            missing = all_langs_set - langs
+            present = langs
+            missing_in = ", ".join(sorted(missing))
+            present_in = ", ".join(sorted(present))
+            tooltip = f"Present in: {present_in}\nMissing in: {missing_in}"
+
+            count = len(langs)
+            if count == n_langs:
+                count_class = "all"
+            elif count == 1:
+                count_class = "one"
+                first_lang = list(langs)[0]
+                count = f"1, {first_lang}"
+            else:
+                count_class = "some"
+
+            key = escape(key)
+            label = f'<span class="{count_class}">{key} ({count})</span>'
+
+            parts.append(f'<li title="{tooltip}">{label}')
+            parts.append(go(child))
+            parts.append("</li>")
+
+        parts.append("</ul>")
+        return "".join(parts)
+
+    return go(tree)
+
+
+def main() -> None:
+    summaries = read_all_summaries()
+
+    langs = sorted(summaries.keys())
+
+    global_tree = {}
+    for lang, attrs in summaries.items():
+        add_summary_to_tree(global_tree, lang, attrs)
+
+    output_path = Path("_summary")
+    output_path.mkdir(exist_ok=True)
+    summary_path = output_path / "summary.html"
+    with summary_path.open("w") as f:
+        page = basic_css() + html_tree(global_tree, langs)
+        f.write(page)
+
+    print(f"Wrote summary @ {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_schema.py
+++ b/tools/generate_schema.py
@@ -1,19 +1,11 @@
 import importlib
 import json
-from pathlib import Path
 from importlib.resources import files
+from pathlib import Path
 
 
-def main() -> None:
-    """
-    Run this script at the project root folder to generate JSON schema files of
-    each extractor that has pydantic model `WordEntry` defined in the
-    `models.py` file.
-    """
-
+def iter_schemas():
     extractor_folder = files("wiktextract") / "extractor"
-    output_path = Path("_site")
-    output_path.mkdir(exist_ok=True)
     for extractor_folder in filter(
         lambda p: p.is_dir()
         and p.stem != "template"
@@ -31,6 +23,18 @@ def main() -> None:
             model_schema["description"] = model_schema["description"].replace(
                 "\n", " "
             )
+        yield lang_code, model_schema
+
+
+def main() -> None:
+    """
+    Run this script at the project root folder to generate JSON schema files of
+    each extractor that has pydantic model `WordEntry` defined in the
+    `models.py` file.
+    """
+    output_path = Path("_site")
+    output_path.mkdir(exist_ok=True)
+    for lang_code, model_schema in iter_schemas():
         with (output_path / f"{lang_code}.json").open(
             "w", encoding="utf-8"
         ) as f:


### PR DESCRIPTION
It looks like this:

<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/52a3433c-5500-4254-a1d6-60d8cd19e04b" />
<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/76ca5239-d344-44bc-b0ac-9feea89d4421" />

It shows the languages on hover.

I refactored `generate_schema` so that I could use the iteration logic instead of reading `_site` (which I was doing before). It should work the same.

The output folder you may change it to whatever, in case you decide to add it (or not) to the website with the schemas.

Also there are some fields only present in the Simple extractor. Those you probably want to get rid of since they are not used anywhere else.

