### PR TITLE
[tools] add missing fields data of reused models

### DIFF
--- a/tools/generate_schema.py
+++ b/tools/generate_schema.py
@@ -8,7 +8,7 @@ def iter_schemas():
     extractor_folder = files("wiktextract") / "extractor"
     for extractor_folder in filter(
         lambda p: p.is_dir()
-        and p.stem != "template"
+        and p.stem not in ["template", "sv"]
         and (p / "models.py").is_file(),
         (files("wiktextract") / "extractor").iterdir(),
     ):


### PR DESCRIPTION
Fields of models used in multiple places are only listed at the first used place. For example, fields of `Example` are only displayed in `etymology_examples` but not `senses.examples`. Same for `Linkage`.

and hide incomplete sv edition schema