### PR TITLE
[el] Fix wrong form expansion in hyphenated words

### DIFF
--- a/src/wiktextract/extractor/el/table.py
+++ b/src/wiktextract/extractor/el/table.py
@@ -105,7 +105,7 @@ def process_inflection_section(
     snode: WikiNode,
     *,
     source: FormSource = "",
-    top_template_name: str | None = None
+    top_template_name: str | None = None,
 ) -> None:
     table_nodes: list[tuple[str | None, WikiNode]] = []
     # template_depth is used as a nonlocal variable in bold_node_handler
@@ -546,8 +546,9 @@ def postprocess_table_forms(forms: list[Form], word: str) -> list[Form]:
             separated_forms.append(form)
             continue
 
-        # Ignore suffix/prefixes (-ισμός)
-        if form.form.startswith(sep) or form.form.endswith(sep):
+        # Ignore separator if the original word contained it
+        # Ex. "-ισμός", "η-τάξη" etc.
+        if sep in word:
             separated_forms.append(form)
             continue
 

--- a/tests/test_el_form.py
+++ b/tests/test_el_form.py
@@ -25,10 +25,10 @@ class TestElInflection(TestCase):
         self.wxr.wtp.close_db_conn()
 
     def mktest_postprocess_table_forms(
-        self, raw: str, expected: list[str]
+        self, raw: str, expected: list[str], word: str = "filler"
     ) -> None:
         forms = [Form(form=entry.strip()) for entry in raw.splitlines()]
-        new_forms = postprocess_table_forms(forms, word="filler")
+        new_forms = postprocess_table_forms(forms, word)
         new_forms_lemmas = [form.form for form in new_forms]
         self.assertEqual(new_forms_lemmas, expected)
 
@@ -69,9 +69,17 @@ class TestElInflection(TestCase):
 
     def test_postprocess_forms_suffix(self) -> None:
         # https://el.wiktionary.org/wiki/-ισμός
+        word = "-ισμός"
         raw = "ο -ισμός"
         expected = ["-ισμός"]
-        self.mktest_postprocess_table_forms(raw, expected)
+        self.mktest_postprocess_table_forms(raw, expected, word)
+
+    def test_postprocess_forms_hyphenated_word(self) -> None:
+        # https://el.wiktionary.org/wiki/η-τάξη
+        word = "η-τάξη"
+        raw = "η η-τάξη"
+        expected = ["η-τάξη"]
+        self.mktest_postprocess_table_forms(raw, expected, word)
 
     def test_postprocess_forms_trailing_numbers(self) -> None:
         # https://el.wiktionary.org/wiki/Καπιτόπουλος

--- a/tests/test_el_inflection.py
+++ b/tests/test_el_inflection.py
@@ -58,8 +58,8 @@ class TestElInflection(TestCase):
         received = self.xinfl("filler", "verb", raw.strip())
         self.assertEqual(received, expected)
 
-    def mktest_form_no_raw_tags(self, raw, expected) -> None:
-        received = self.xinfl("filler", "verb", raw.strip())
+    def mktest_form_no_raw_tags(self, raw, expected, word="filler") -> None:
+        received = self.xinfl(word, "verb", raw.strip())
 
         def normalize_forms(lst) -> None:
             for form in lst:
@@ -558,6 +558,7 @@ class TestElInflection(TestCase):
 
     def test_el_suffix_inflection1(self) -> None:
         # https://el.wiktionary.org/wiki/-ωνιά
+        word = "-ωνιά"
         raw = """
 {| style="clear%3Aright%3B+float%3Aright%3B+margin-left%3A0.5em%3B+margin-bottom%3A0.5em%3Bbackground%3A%23ffffff%3B+color%3A%23000000%3B+border%3A1px+solid%23a1bdea%3B+text-align%3Aright%3B" rules="none" border="1" cellpadding="3" cellspacing="0"
 |-
@@ -605,10 +606,11 @@ class TestElInflection(TestCase):
             {"form": "-ωνιά", "tags": ["singular", "vocative"]},
             {"form": "-ωνιές", "tags": ["vocative", "plural"]},
         ]
-        self.mktest_form_no_raw_tags(raw, expected)
+        self.mktest_form_no_raw_tags(raw, expected, word)
 
     def test_el_suffix_inflection2(self) -> None:
         # https://el.wiktionary.org/wiki/-γράφος
+        word = "-γράφος"
         raw = """{|
 |-
 ! style="background:#a1bdea; border-right:1px solid #c1d3f1; text-align:center; font-size:90%;" align="center"| &darr;&nbsp;''πτώσεις''
@@ -684,7 +686,7 @@ class TestElInflection(TestCase):
                 "raw_tags": ["κλητική", "πληθυντικός"],
             },
         ]
-        self.mktest_form_no_raw_tags(raw, expected)
+        self.mktest_form_no_raw_tags(raw, expected, word)
 
     def test_noun_inflection_standard(self) -> None:
         raw = """


### PR DESCRIPTION
Kristian warned me about it, but since these are so rare I couldn't get my hands on any concrete example.

We now just ignore separator expansion if the original word contained it (mainly for hyphens, I don't think there are words with /)