### PR TITLE
[zh] add `classifiers` field for "th-noun" template

### DIFF
--- a/src/wiktextract/extractor/zh/models.py
+++ b/src/wiktextract/extractor/zh/models.py
@@ -200,3 +200,4 @@ class WordEntry(ChineseBaseModel):
     original_title: str = ""
     anagrams: list[Linkage] = []
     hyphenations: list[Hyphenation] = []
+    classifiers: list[Classifier] = []


### PR DESCRIPTION
The "b" HTML elements in Thai noun header template is not form words but classifiers, other editions use the same template probably also has this problem.