### PR TITLE
[en] use "quotation" value for "Example.type"

### DIFF
--- a/src/wiktextract/extractor/en/example.py
+++ b/src/wiktextract/extractor/en/example.py
@@ -390,7 +390,7 @@ def clean_example_empty_data(data: ExampleData) -> None:
             new_raw_tags.append(raw_tag)
     data["raw_tags"] = new_raw_tags
     if len(data.get("ref", "")) > 0:
-        data["type"] = "quote"
+        data["type"] = "quotation"
     else:
         data["type"] = "example"
     for key, value in data.copy().items():

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -685,6 +685,7 @@ quotation_templates: set[str] = {
     "quote-wikipedia",
     "wikiquote",
     "Wikiquote",
+    "Q",
 }
 
 taxonomy_templates = {


### PR DESCRIPTION
also add template "Q" to `quotation_templates` set so it could have "quotation" type value

fix #1572