### PR TITLE
[en] Fix bug with inflection section table parsing; also add some `inflection_data` data

### DIFF
--- a/src/wiktextract/extractor/en/inflectiondata.py
+++ b/src/wiktextract/extractor/en/inflectiondata.py
@@ -2611,7 +2611,11 @@ infl_map: dict[str, InflMapNode] = {
     },
     "Subjunctive mood ➤": {
         "lang": "Greek",
-        "then": "subjunctive dummy-tense",
+        "then": {
+            "inflection-template": "el-conjug-1st",
+            "then": "dummy-skip-this",
+            "else": "subjunctive dummy-tense",
+        },
         "else": "subjunctive",
     },
     "Imperative mood ➤": {

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -2627,7 +2627,7 @@ def parse_language(
                 tablecontext = None
                 m = re.search(r"{{([^}{|]+)\|?", text)
                 if m:
-                    template_name = m.group(1)
+                    template_name = m.group(1).strip()
                     tablecontext = TableContext(template_name)
 
                 parse_inflection_section(


### PR DESCRIPTION
I had added a `inflection-template` condition to the control-flow-like header-control data system in `inflection_data` a long while back that had a minor bug in that if you have an template invocation like this

```
{{template-name
|something
...}}
```

the template name I got by using a regex (for some reason, this was pretty early, I think) still had whitespace.

Fix: `.strip()`.


Also added some conditionals data to fix the subjunctive rows that are problematic in #1583