### PR TITLE
[en] Modify regex containing xlat_head_map keys used to parse heads

### DIFF
--- a/src/wiktextract/extractor/en/form_descriptions.py
+++ b/src/wiktextract/extractor/en/form_descriptions.py
@@ -194,7 +194,7 @@ head_final_re_text = r"( -)?( ({}))+".format(
         sorted(xlat_head_map.keys(), key=len, reverse=True)
     )
 )
-head_final_re = re.compile(head_final_re_text + "$")
+head_final_re = re.compile(head_final_re_text + r"$")
 
 # Regexp used to match head tag specifiers at end of a form for certain
 # Bantu languages (particularly Swahili and similar languages).
@@ -227,7 +227,7 @@ head_split_re_text = (
     + head_final_semitic_re_text
     + "|"
     + head_final_other_re_text
-    + ")?( or |[,;]+)"
+    + ")?( or |[,;]+| *$)"
 )
 head_split_re = re.compile(head_split_re_text)
 head_split_re_parens = 0
@@ -1949,6 +1949,7 @@ def parse_word_head(
     else:
         # Do the normal split; previous only-behavior.
         splits = re.split(head_split_re, base)
+    # print("BASE: ", repr(base))
     # print("SPLITS:", splits)
     alts: list[str] = []
     # print("parse_word_head: splits:", splits,

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -185,6 +185,7 @@ xlat_head_map = {
     "n inan pl or f inan or f inan pl": "neuter inanimate plural feminine singular",  # XXX
     "f inan pl or m anim or m anim pl": "feminine inanimate plural masculine animate singular",  # XXX
     "f inan pl or m inan or m inan pl": "feminine inanimate plural masculine singular",  # XXX
+    "n anim or n inan or n anim pl or n inan pl": "neuter animate inanimate singular plural",
     "n anim pl or n inan or n inan pl": "neuter animate plural inanimate singular",  # XXX
     "n inan or n inan pl or f inan or f inan pl": "neuter inanimate singular plural feminine",
     "n inan pl or n anim or n anim pl": "neuter inanimate plural animate singular",  # XXX
@@ -387,6 +388,10 @@ xlat_head_map = {
     "mu class": "class-18",
     "m or f by sense": "masculine feminine by-personal-gender",
     "superlative dubious": "",
+    # пьянчужка/Russian
+    "m anim or f anim by sense": "masculine feminine by-personal-gender",
+    "m pl or f pl by sense": "masculine feminine plural by-personal-gender",
+    "m pers or f pers by sense": "masculine feminine personal by-personal-gender",
 }
 
 # Languages that can have head-final numeric class indicators.  They are mostly


### PR DESCRIPTION
Fixes #1597

Issue with the regex was that it assumed that there would be several taggable strings in the head separated by " or " or punctuation, but when there aren't alts or alternative tags for the only headword present, then it wouldn't trigger.

Fix: add `$` to the regex to detect heads with single blocks of a taggable text.