### PR TITLE
Parse multiple "head final" tags; handle words with semicolons ("tl;dr")

### DIFF
--- a/src/wiktextract/extractor/en/form_descriptions.py
+++ b/src/wiktextract/extractor/en/form_descriptions.py
@@ -218,7 +218,7 @@ head_final_other_re_text = r" ({})".format(
 head_final_other_re = re.compile(head_final_other_re_text + "$")
 
 # Regexp for splitting heads.  See parse_word_head().
-head_split_re_text = (
+head_split_re_text_part_1 = (
     "("
     + head_final_re_text
     + "|"
@@ -227,9 +227,15 @@ head_split_re_text = (
     + head_final_semitic_re_text
     + "|"
     + head_final_other_re_text
-    + ")?( or |[,;]+| *$)"
 )
+
+head_split_re_text = head_split_re_text_part_1 + ")?( or |[,;]+| *$)"
+
+head_split_re_text_no_semicolon = head_split_re_text_part_1 + ")?( or |,+| *$)"
+
 head_split_re = re.compile(head_split_re_text)
+head_split_no_semicolon_re = re.compile(head_split_re_text_no_semicolon)
+
 head_split_re_parens = 0
 for m in re.finditer(r"(^|[^\\])[(]+", head_split_re_text):
     head_split_re_parens += m.group(0).count("(")
@@ -1359,38 +1365,50 @@ def parse_head_final_tags(
                 tags.extend(head_final_other_map[tagkeys].split(" "))
 
     # Handle normal head-final tags
-    m = re.search(head_final_re, form)
-    if m is not None:
-        tagkeys = m.group(3)
-        # Only replace tags ending with numbers in languages that have
-        # head-final numeric tags (e.g., Bantu classes); also, don't replace
-        # tags if the main title ends with them (then presume they are part
-        # of the word)
-        # print("head_final_tags form={!r} tagkeys={!r} lang={}"
-        #       .format(form, tagkeys, lang))
-        tagkeys_contains_digit = re.search(r"\d", tagkeys)
-        if (
-            (not tagkeys_contains_digit or lang in head_final_numeric_langs)
-            and not wxr.wtp.title.endswith(" " + tagkeys)  # type:ignore[union-attr]
-            and
-            # XXX the above test does not capture when the whole word is a
-            # xlat_head_map key, so I added the below test to complement
-            # it; does this break anything?
-            not wxr.wtp.title == tagkeys
-        ):  # defunct/English,
-            # "more defunct" -> "more" ["archaic"]
-            if not tagkeys_contains_digit or lang in head_final_numeric_langs:
-                form = form[: m.start()]
-                v = xlat_head_map[tagkeys]
-                if v.startswith("?"):
-                    v = v[1:]
-                    wxr.wtp.debug(
-                        "suspicious suffix {!r} in language {}: {}".format(
-                            tagkeys, lang, origform
-                        ),
-                        sortid="form_descriptions/1077",
-                    )
-                tags.extend(v.split())
+    # Loop this until nothing is found
+    while True:
+        prev_form = form
+        m = re.search(head_final_re, form)
+        if m is not None:
+            print(f"{m=}, {m.groups()=}")
+            tagkeys = m.group(3)
+            # Only replace tags ending with numbers in languages that have
+            # head-final numeric tags (e.g., Bantu classes); also, don't replace
+            # tags if the main title ends with them (then presume they are part
+            # of the word)
+            # print("head_final_tags form={!r} tagkeys={!r} lang={}"
+            #       .format(form, tagkeys, lang))
+            tagkeys_contains_digit = re.search(r"\d", tagkeys)
+            if (
+                (not tagkeys_contains_digit or lang in head_final_numeric_langs)
+                and not wxr.wtp.title.endswith(" " + tagkeys)  # type:ignore[union-attr]
+                and
+                # XXX the above test does not capture when the whole word is a
+                # xlat_head_map key, so I added the below test to complement
+                # it; does this break anything?
+                not wxr.wtp.title == tagkeys
+            ):  # defunct/English,
+                # "more defunct" -> "more" ["archaic"]
+                if (
+                    not tagkeys_contains_digit
+                    or lang in head_final_numeric_langs
+                ):
+                    # m.start(3) gets the start of what is in m.group(3), handy
+                    form = form[: m.start(3)].strip()
+                    v = xlat_head_map[tagkeys]
+                    if v.startswith("?"):
+                        v = v[1:]
+                        wxr.wtp.debug(
+                            "suspicious suffix {!r} in language {}: {}".format(
+                                tagkeys, lang, origform
+                            ),
+                            sortid="form_descriptions/1077",
+                        )
+                    tags.extend(v.split())
+        else:
+            break
+        if prev_form == form:
+            break
 
     # Generate warnings about words ending in " or" after processing
     if (
@@ -1931,11 +1949,26 @@ def parse_word_head(
     if m:
         base = base[: m.start()] + base[m.end() :]
 
+    semicolon_present = False
     # Split the head into alternatives.  This is a complicated task, as
     # we do not want so split on "or" or "," when immediately followed by more
     # head-final tags, but otherwise do want to split by them.
     # 20230907 added "or" to this to handle 'true or false', titles with 'or'
-    if wxr.wtp.title and ("," in wxr.wtp.title or " or " in wxr.wtp.title):
+    if wxr.wtp.title and (
+        "," in wxr.wtp.title or ";" in wxr.wtp.title or " or " in wxr.wtp.title
+    ):
+        # If the title has ";", we don't want to split on that and can remove
+        # the ; from the splitting regex pretty easily because it's uncommon.
+        # However, commas are so common that not splitting on them is just
+        # not feasible, and we have to just deal with that if there are
+        # alternative forms or variations with stray commas that shouldn't
+        # be split.
+        if ";" in wxr.wtp.title:
+            semicolon_present = True
+            base = base.replace(";", "<SEMICOLON>")
+            default_splitter = head_split_no_semicolon_re
+        else:
+            default_splitter = head_split_re
         # A kludge to handle article titles/phrases with commas.
         # Preprocess splits to first capture the title, then handle
         # all the others as usual.
@@ -1945,7 +1978,7 @@ def parse_word_head(
             if psplit == wxr.wtp.title:
                 splits.append(psplit)
             else:
-                splits.extend(re.split(head_split_re, psplit))
+                splits.extend(re.split(default_splitter, psplit))
     else:
         # Do the normal split; previous only-behavior.
         splits = re.split(head_split_re, base)
@@ -2038,7 +2071,7 @@ def parse_word_head(
             )
             tags = list(tags)  # Make sure we don't modify anything cached
             tags.append("canonical")
-            if alt_i == 0 and "," in wxr.wtp.title:  # type:ignore[operator]
+            if alt_i == 0 and "," in wxr.wtp.title or ";" in wxr.wtp.title:  # type:ignore[operator]
                 # Kludge to handle article titles/phrases with commas.
                 # basepart's regex strips commas, which leads to a
                 # canonical form that is the title phrase without a comma.
@@ -2047,6 +2080,16 @@ def parse_word_head(
                 # canonicals.append((tags, baseparts)) and not (tags, [alt])
                 baseparts = [alt]
             canonicals.append((tags, baseparts))
+
+    # If more of this kind of replace-and-return-original kind of stuff is
+    # needed, make semicolon_present into a flag enum, something like `modified`
+    if semicolon_present:
+        new_cans = []
+        for tags, baseparts in canonicals:
+            new_cans.append(
+                (tags, [s.replace("<SEMICOLON>", ";") for s in baseparts])
+            )
+        canonicals = new_cans
     for tags, baseparts in canonicals:
         add_related(
             wxr,

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -392,6 +392,22 @@ xlat_head_map = {
     "m anim or f anim by sense": "masculine feminine by-personal-gender",
     "m pl or f pl by sense": "masculine feminine plural by-personal-gender",
     "m pers or f pers by sense": "masculine feminine personal by-personal-gender",
+    "gender m": "masculine",  # nene/Abau
+    "gender f": "feminine",  # just for completion's sake
+    "gender mf": "masculine feminine",
+    "class I": "class-i",
+    "class II": "class-ii",
+    "class III": "class-iii",
+    "class IV": "class-iv",
+    "class V": "class-v",
+    "class VI": "class-vi",
+    "class VII": "class-vii",
+    "class VIII": "class-viii",
+    "class IX": "class-ix",
+    "class X": "class-x",
+    "class XI": "class-xi",
+    "class XII": "class-xii",
+    "class XIII": "class-xiii",
 }
 
 # Languages that can have head-final numeric class indicators.  They are mostly
@@ -4584,6 +4600,16 @@ xlat_tags_map: dict[str, str | list[str]] = {
     "class I": "class-i",
     "class II": "class-ii",
     "class III": "class-iii",
+    "class IV": "class-iv",
+    "class V": "class-v",
+    "class VI": "class-vi",
+    "class VII": "class-vii",
+    "class VIII": "class-viii",
+    "class IX": "class-ix",
+    "class X": "class-x",
+    "class XI": "class-xi",
+    "class XII": "class-xii",
+    "class XIII": "class-xiii",
     "class N": "class-n",
     "class a-i": "class-a-i",
     "to multiple people": "addressee-plural",
@@ -5315,6 +5341,16 @@ valid_tags = {
     "class-i": "class",  # Choctaw
     "class-ii": "class",
     "class-iii": "class",
+    "class-iv": "class",
+    "class-v": "class",
+    "class-vi": "class",
+    "class-vii": "class",
+    "class-viii": "class",
+    "class-ix": "class",
+    "class-x": "class",
+    "class-xi": "class",
+    "class-xii": "class",
+    "class-xiii": "class",
     "class-n": "class",  # Chickasaw
     "class-a-i": "class",  # Akkadian
     "classifier": "detail",

--- a/tests/test_en_head.py
+++ b/tests/test_en_head.py
@@ -1132,3 +1132,12 @@ class HeadTests(unittest.TestCase):
         self.assertEqual(self.wxr.wtp.debugs, [])
         self.assertEqual(data, {"tags": ["feminine", "masculine", "neuter"]})
         self.wxr.wtp.title = "testpage"
+
+    def test_head_with_several_final_tags(self):
+        data = {}
+        parse_word_head(
+            self.wxr, "noun", "testpage class III gender m ", data, False, None
+        )
+        self.assertEqual(self.wxr.wtp.warnings, [])
+        self.assertEqual(self.wxr.wtp.debugs, [])
+        self.assertEqual(data, {"tags": ["class-iii", "masculine"]})

--- a/tests/test_en_head.py
+++ b/tests/test_en_head.py
@@ -1120,3 +1120,15 @@ class HeadTests(unittest.TestCase):
                 }
             ],
         )
+
+
+    def test_head_title_with_semicolon(self):
+        data = {}
+        self.wxr.wtp.title = "test; page"
+        parse_word_head(
+            self.wxr, "noun", "test; page f, m, n", data, False, None
+        )
+        self.assertEqual(self.wxr.wtp.warnings, [])
+        self.assertEqual(self.wxr.wtp.debugs, [])
+        self.assertEqual(data, {"tags": ["feminine", "masculine", "neuter"]})
+        self.wxr.wtp.title = "testpage"

--- a/tests/test_ja_example.py
+++ b/tests/test_ja_example.py
@@ -76,7 +76,7 @@ class TestJaExample(TestCase):
             sense.examples[0],
             Example(
                 text="尤も僕は気の毒にも度大島を泣かせては、泣虫泣虫とからかひしものなり。",
-                bold_text_offsets=[(19, 21), (21, 23)],
+                bold_text_offsets=[(19, 21), (21, 23), (21, 24)],
                 ref="（芥川龍之介『学校友だち』）〔1925年〕",
                 ruby=[("尤", "もっと"), ("度", "たびたび")],
             ),
@@ -95,7 +95,7 @@ class TestJaExample(TestCase):
             sense.examples[0],
             Example(
                 text="春夏と並んで、候鳥の「民間伝承の歌」に似たものは、秋の鳴き虫の誹諧である。",
-                bold_text_offsets=[(27, 30)],
+                bold_text_offsets=[(27, 31)],
                 ref="（折口信夫『俳諧歌の研究』）〔1934年〕 昭和9年5月、『続俳句講座』第3巻「特殊研究篇」初出、『折口信夫全集』13巻213ページ所収",
             ),
         )

--- a/tests/test_ja_example.py
+++ b/tests/test_ja_example.py
@@ -76,7 +76,7 @@ class TestJaExample(TestCase):
             sense.examples[0],
             Example(
                 text="尤も僕は気の毒にも度大島を泣かせては、泣虫泣虫とからかひしものなり。",
-                bold_text_offsets=[(19, 21), (21, 23), (21, 24)],
+                bold_text_offsets=[(19, 21), (21, 23)],
                 ref="（芥川龍之介『学校友だち』）〔1925年〕",
                 ruby=[("尤", "もっと"), ("度", "たびたび")],
             ),
@@ -95,7 +95,7 @@ class TestJaExample(TestCase):
             sense.examples[0],
             Example(
                 text="春夏と並んで、候鳥の「民間伝承の歌」に似たものは、秋の鳴き虫の誹諧である。",
-                bold_text_offsets=[(27, 31)],
+                bold_text_offsets=[(27, 30)],
                 ref="（折口信夫『俳諧歌の研究』）〔1934年〕 昭和9年5月、『続俳句講座』第3巻「特殊研究篇」初出、『折口信夫全集』13巻213ページ所収",
             ),
         )


### PR DESCRIPTION
This PR is a mess, I should really just reset all these commits and recommit them.

Fixes #1589 
1. Accidentally found an issue where if you have a head like "nene class III m", it would get parsed as "nene class III" with a `masculine` tag. This has been addressed by putting the relevant code into a loop that checks when things stop changing and then breaking.
2. Handle semicolons in words, like "tl;dr" or "too long; didn't read". How? Basically if the title has a semicolon, we'll pretty much ignore all semicolons in the head... Semicolons are rare enough that we might get away with it.