### PR TITLE
fix: handle multi-word translations in German extractor

### DIFF
--- a/src/wiktextract/extractor/de/translation.py
+++ b/src/wiktextract/extractor/de/translation.py
@@ -62,6 +62,10 @@ def process_u_tabelle_list_item(
                 before_colon = False
             elif node in [",", ";"] and len(tr_data.word) > 0:
                 tr_data = append_tr_data(word_entry, tr_data)
+            elif not before_colon and len(tr_data.word) > 0:
+                # Plain text between {{Ü}} templates of the same translation
+                # e.g. {{Ü|fr|temps}} de {{Ü|fr|travail}} → "temps de travail"
+                tr_data.word += " " + node
 
         if before_colon and len(tr_data.lang) == 0:
             tr_data.lang = clean_node(wxr, None, node)
@@ -71,9 +75,22 @@ def process_u_tabelle_list_item(
                 tr_data.lang_code = name_to_code(tr_data.lang_code, "de")
         elif isinstance(node, TemplateNode):
             if node.template_name.startswith("Ü"):
-                if len(tr_data.word) > 0:
+                u_lang_code = clean_node(
+                    wxr, None, node.template_parameters.get(1, "")
+                )
+                if len(tr_data.word) > 0 and u_lang_code != tr_data.lang_code:
+                    # Different language → save current, start new
                     tr_data = append_tr_data(word_entry, tr_data)
-                process_u_template(wxr, tr_data, node)
+                    process_u_template(wxr, tr_data, node)
+                elif len(tr_data.word) > 0:
+                    # Same language → append word to form multi-word translation
+                    # e.g. {{Ü|fr|temps}} de {{Ü|fr|travail}} → "temps de travail"
+                    new_word = clean_node(
+                        wxr, None, node.template_parameters.get(2, "")
+                    )
+                    tr_data.word += " " + new_word
+                else:
+                    process_u_template(wxr, tr_data, node)
             else:
                 raw_tag = clean_node(wxr, None, node).strip(": \n")
                 if raw_tag != "":

--- a/tests/test_de_translation.py
+++ b/tests/test_de_translation.py
@@ -218,6 +218,63 @@ class TestDETranslation(unittest.TestCase):
             ],
         )
 
+    def test_multi_word_translation(self):
+        """Multi-word translations like {{Ü|fr|temps}} de {{Ü|fr|travail}}
+        should produce a single entry 'temps de travail', not two separate ones."""
+        self.wxr.wtp.add_page("Vorlage:fr", 10, "[[Französisch]]")
+        self.wxr.wtp.start_page("Arbeitszeit")
+        root = self.wxr.wtp.parse("""{{Ü-Tabelle|1|G=Zeit, die man arbeitet|Ü-Liste=
+*{{fr}}: {{Ü|fr|temps}} de {{Ü|fr|travail}}
+}}""")
+        word_entry = WordEntry(
+            lang="Deutsch", lang_code="de", word="Arbeitszeit"
+        )
+        extract_translation(self.wxr, word_entry, root)
+        self.assertEqual(
+            word_entry.model_dump(exclude_defaults=True)["translations"],
+            [
+                {
+                    "lang_code": "fr",
+                    "lang": "Französisch",
+                    "word": "temps de travail",
+                    "sense": "Zeit, die man arbeitet",
+                    "sense_index": "1",
+                }
+            ],
+        )
+
+    def test_multi_word_with_comma_separator(self):
+        """Multi-word translations followed by a comma and another translation
+        should produce two separate entries."""
+        self.wxr.wtp.add_page("Vorlage:fr", 10, "[[Französisch]]")
+        self.wxr.wtp.start_page("Arbeitszeit")
+        root = self.wxr.wtp.parse("""{{Ü-Tabelle|1|G=Zeit|Ü-Liste=
+*{{fr}}: {{Ü|fr|temps}} de {{Ü|fr|travail}}, {{Ü|fr|horaire}}
+}}""")
+        word_entry = WordEntry(
+            lang="Deutsch", lang_code="de", word="Arbeitszeit"
+        )
+        extract_translation(self.wxr, word_entry, root)
+        self.assertEqual(
+            word_entry.model_dump(exclude_defaults=True)["translations"],
+            [
+                {
+                    "lang_code": "fr",
+                    "lang": "Französisch",
+                    "word": "temps de travail",
+                    "sense": "Zeit",
+                    "sense_index": "1",
+                },
+                {
+                    "lang_code": "fr",
+                    "lang": "Französisch",
+                    "word": "horaire",
+                    "sense": "Zeit",
+                    "sense_index": "1",
+                },
+            ],
+        )
+
     def test_hiragana(self):
         self.wxr.wtp.add_page("Vorlage:ja", 10, "[[Japanisch]]")
         data = parse_page(


### PR DESCRIPTION
Multi-word translations like {{Ü|fr|temps}} de {{Ü|fr|travail}} were being split into two separate entries ('temps' and 'travail') instead of being combined into 'temps de travail'.

Two changes:
- Plain text between Ü templates (e.g. 'de') is now concatenated to the current word instead of being silently dropped.
- Consecutive Ü templates with the same lang_code append their words to form a single multi-word translation, while different lang_codes still trigger a new translation entry.