### PR TITLE
[ja] Support `ja-kanji` template extraction

### DIFF
--- a/src/wiktextract/extractor/ja/kanji.py
+++ b/src/wiktextract/extractor/ja/kanji.py
@@ -1,0 +1,66 @@
+import re
+
+from wikitextprocessor.parser import TemplateNode
+
+from ...page import clean_node
+from ...wxr_context import WiktextractContext
+from .models import Sound, WordEntry
+
+JA_KANJI_TEMPLATE_PARAMS = {
+    "呉音": "go-on",
+    "漢音": "kan-on",
+    "唐音": "to-on",
+    "慣用音": "kan-yo-on",
+    "音": "on",
+    "訓": "kun",
+    "古訓": "ko-kun",
+    "名乗り": "nanori",
+}
+"""Parameters of the ja-kanji template that contain readings.
+
+On'yomi (音読み); Chinese-derived readings (katakana):
+- 呉音 (go-on): Historical reading
+- 漢音 (kan-on): Historical reading
+- 唐音 (to-on): Historical reading
+- 慣用音 (kan-yo-on): Customary reading, often corrupted or non-standard
+- 音 (on): Generic on'yomi when the specific type is unknown
+
+Kun'yomi (訓読み); native Japanese readings (hiragana):
+- 訓 (kun): Standard kun'yomi
+- 古訓 (ko-kun): Archaic kun'yomi
+- 名乗り (nanori): Readings used exclusively in personal names
+"""
+
+
+def extract_ja_kanji(
+    wxr: WiktextractContext, base_data: WordEntry, t_node: TemplateNode
+) -> None:
+    # https://ja.wiktionary.org/wiki/テンプレート:ja-kanji
+    # First collect 常用 (joyo) readings (readings in active use)
+    # it mixes on'yomi (katakana) and kun'yomi (hiragana)
+    joyo = set()
+    joyo_value = t_node.template_parameters.get("常用", "")
+    if joyo_value:
+        joyo_reading = clean_node(wxr, base_data, joyo_value)
+        for r in joyo_reading.split(","):
+            r = re.sub(r"[<;/].*$", "", r).strip()
+            if r:
+                joyo.add(r)
+
+    # Then extract all readings, tagging joyo ones accordingly
+    for param, value in t_node.template_parameters.items():
+        if not isinstance(param, str):
+            continue
+        base_param = re.sub(r"\d+$", "", param)
+        reading_type = JA_KANJI_TEMPLATE_PARAMS.get(base_param)
+        if reading_type is None:
+            continue
+        reading = clean_node(wxr, base_data, value)
+        if not reading:
+            continue
+        for r in reading.split(","):
+            r = re.sub(r"[<;/].*$", "", r).strip()
+            tags = [reading_type]
+            if r in joyo:
+                tags.append("joyo")
+            base_data.sounds.append(Sound(other=r, tags=tags))

--- a/src/wiktextract/extractor/ja/kanji.py
+++ b/src/wiktextract/extractor/ja/kanji.py
@@ -4,7 +4,7 @@ from wikitextprocessor.parser import TemplateNode
 
 from ...page import clean_node
 from ...wxr_context import WiktextractContext
-from .models import Sound, WordEntry
+from .models import Form, WordEntry
 
 JA_KANJI_TEMPLATE_PARAMS = {
     "呉音": "go-on",
@@ -63,4 +63,6 @@ def extract_ja_kanji(
             tags = [reading_type]
             if r in joyo:
                 tags.append("joyo")
-            base_data.sounds.append(Sound(other=r, tags=tags))
+            base_data.forms.append(
+                Form(form=r, tags=["transliteration", *tags])
+            )

--- a/src/wiktextract/extractor/ja/page.py
+++ b/src/wiktextract/extractor/ja/page.py
@@ -8,6 +8,7 @@ from ...page import clean_node
 from ...wxr_context import WiktextractContext
 from .conjugation import extract_conjugation_section
 from .etymology import extract_etymology_section
+from .kanji import extract_ja_kanji
 from .linkage import extract_alt_form_section, extract_linkage_section
 from .models import Sense, WordEntry
 from .pos import extract_note_section, parse_pos_section
@@ -177,6 +178,8 @@ def parse_page(
         for t_node in level2_node.find_child(NodeKind.TEMPLATE):
             if t_node.template_name.endswith("-cat"):
                 clean_node(wxr, base_data, t_node)
+            elif t_node.template_name == "ja-kanji":
+                extract_ja_kanji(wxr, base_data, t_node)
         for level3_node in level2_node.find_child(NodeKind.LEVEL3):
             parse_section(wxr, page_data, base_data, level3_node)
 

--- a/tests/test_ja_kanji.py
+++ b/tests/test_ja_kanji.py
@@ -1,0 +1,65 @@
+import unittest
+
+from wikitextprocessor import Wtp
+from wikitextprocessor.parser import NodeKind
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.ja.kanji import extract_ja_kanji
+from wiktextract.extractor.ja.models import Sound, WordEntry
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestExtractJaKanji(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="ja"),
+            WiktionaryConfig(
+                dump_file_lang_code="ja",
+                capture_language_codes=None,
+            ),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def _extract_ja_kanji(self, template: str) -> WordEntry:
+        word = "filler"
+        self.wxr.wtp.start_page(word)
+        root = self.wxr.wtp.parse(template)
+        t_node = next(root.find_child(NodeKind.TEMPLATE))
+        data = WordEntry(word=word, lang_code="ja", lang="日本語")
+        extract_ja_kanji(self.wxr, data, t_node)
+        return data
+
+    def test_extract_ja_kanji_1(self) -> None:
+        # https://ja.wiktionary.org/wiki/韻#日本語
+        data = self._extract_ja_kanji(
+            "{{ja-kanji|常用=イン|呉音=ウン|漢音=ウン|慣用音=イン<ヰン|訓=ひびき}}"
+        )
+        self.assertEqual(
+            data.sounds,
+            [
+                Sound(other="ウン", tags=["go-on"]),
+                Sound(other="ウン", tags=["kan-on"]),
+                Sound(other="イン", tags=["kan-yo-on", "joyo"]),
+                Sound(other="ひびき", tags=["kun"]),
+            ],
+        )
+
+    def test_extract_ja_kanji_2(self) -> None:
+        # https://ja.wiktionary.org/wiki/文#日本語
+        data = self._extract_ja_kanji(
+            "{{ja-kanji|常用=ブン,モン,ふみ|施策=教育:1|呉音=モン|漢音=ブン|訓=ふみ,あや,かざ-る}}"
+        )
+        self.assertEqual(
+            data.sounds,
+            [
+                Sound(other="モン", tags=["go-on", "joyo"]),
+                Sound(other="ブン", tags=["kan-on", "joyo"]),
+                Sound(other="ふみ", tags=["kun", "joyo"]),
+                Sound(other="あや", tags=["kun"]),
+                Sound(other="かざ-る", tags=["kun"]),
+            ],
+        )

--- a/tests/test_ja_kanji.py
+++ b/tests/test_ja_kanji.py
@@ -5,7 +5,7 @@ from wikitextprocessor.parser import NodeKind
 
 from wiktextract.config import WiktionaryConfig
 from wiktextract.extractor.ja.kanji import extract_ja_kanji
-from wiktextract.extractor.ja.models import Sound, WordEntry
+from wiktextract.extractor.ja.models import Form, WordEntry
 from wiktextract.wxr_context import WiktextractContext
 
 
@@ -39,12 +39,14 @@ class TestExtractJaKanji(unittest.TestCase):
             "{{ja-kanji|常用=イン|呉音=ウン|漢音=ウン|慣用音=イン<ヰン|訓=ひびき}}"
         )
         self.assertEqual(
-            data.sounds,
+            data.forms,
             [
-                Sound(other="ウン", tags=["go-on"]),
-                Sound(other="ウン", tags=["kan-on"]),
-                Sound(other="イン", tags=["kan-yo-on", "joyo"]),
-                Sound(other="ひびき", tags=["kun"]),
+                Form(form="ウン", tags=["transliteration", "go-on"]),
+                Form(form="ウン", tags=["transliteration", "kan-on"]),
+                Form(
+                    form="イン", tags=["transliteration", "kan-yo-on", "joyo"]
+                ),
+                Form(form="ひびき", tags=["transliteration", "kun"]),
             ],
         )
 
@@ -54,12 +56,12 @@ class TestExtractJaKanji(unittest.TestCase):
             "{{ja-kanji|常用=ブン,モン,ふみ|施策=教育:1|呉音=モン|漢音=ブン|訓=ふみ,あや,かざ-る}}"
         )
         self.assertEqual(
-            data.sounds,
+            data.forms,
             [
-                Sound(other="モン", tags=["go-on", "joyo"]),
-                Sound(other="ブン", tags=["kan-on", "joyo"]),
-                Sound(other="ふみ", tags=["kun", "joyo"]),
-                Sound(other="あや", tags=["kun"]),
-                Sound(other="かざ-る", tags=["kun"]),
+                Form(form="モン", tags=["transliteration", "go-on", "joyo"]),
+                Form(form="ブン", tags=["transliteration", "kan-on", "joyo"]),
+                Form(form="ふみ", tags=["transliteration", "kun", "joyo"]),
+                Form(form="あや", tags=["transliteration", "kun"]),
+                Form(form="かざ-る", tags=["transliteration", "kun"]),
             ],
         )


### PR DESCRIPTION
Closes #1587 

It doesn't parse every argument, but most of what I consider to be of value. It can always be easily tweaked in the future to be more precise but from what I could test it worked fine.

For @xxyzz , does the extraction of the template happen at the right place, or should I have put it somewhere else. I mean the changes in `src/wiktextract/extractor/ja/page.py`:

It usually happens at this level in Wiktionary:
```
=={{L|ja}}==
[[Category:{{ja}}]]
{{ja-kanji|常用=イン|呉音=ウン|漢音=ウン|慣用音=イン<ヰン|訓=ひびき}}
```
https://ja.wiktionary.org/wiki/韻#日本語

For everyone, should I have used a `Form` instead of `Sound`, since it is mostly a string and some tags? Much like transliterations are forms with the `transliteration` tag. I even had a `KanjiReading` class at some point, but it was pretty much a simpler `Form`.

