### PR TITLE
Use pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ REPO ?= tatuylonen/wiktextract
 SHA ?= HEAD
 
 test:
-	python -m unittest discover -b -s tests
+	python -m pytest tests
 test_coverage:
 	python -m coverage erase
-	python -m coverage run -m unittest discover -b -s tests
+	python -m coverage run -m pytest tests
 coverage_report:
 	python -m coverage combine
 	python -m coverage html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "coverage[toml]",
     "mypy",
     "ruff",
+    "pytest",
 ]
 
 [project.scripts]


### PR DESCRIPTION
I've run the default tests via unittest, and the output is quite messy (even though the tests run successfully).

I suggest switching to using pytest to run the tests, which doesn't necessitate any code change apart from the make file and pyproject.toml. There are several advantages, but the main one is that the Standard output/error are captured by pytest.
