### PR TITLE
Add some mutation headers

### DIFF
--- a/src/wiktextract/extractor/en/inflectiondata.py
+++ b/src/wiktextract/extractor/en/inflectiondata.py
@@ -3223,6 +3223,8 @@ infl_map: dict[str, InflMapNode] = {
     },
     "Lenition": "lenition",
     "Eclipsis": "eclipsis",
+    "lenition": "lenition",
+    "eclipsis": "eclipsis",
     "+ object concord": "object-concord",
     "lative": "lative",
     "post./nom.": "postpositional",  # XXX what is nom. ?


### PR DESCRIPTION
Closes #1630

From local testing (ignore the +, this is the diff against an empty dict):

Before

```
+ {'forms': [{'form': 'no-table-tags',
+             'source': 'Mutation',
+             'tags': ['table-tags']},
+            {'form': 'buneolas',
+             'source': 'Mutation',
+             'tags': ['error-unrecognized-form']},
+            {'form': 'bhuneolas',
+             'source': 'Mutation',
+             'tags': ['error-unrecognized-form']},
+            {'form': 'mbuneolas',
+             'source': 'Mutation',
+             'tags': ['error-unrecognized-form']}]}
```

After

```
+ {'forms': [{'form': 'no-table-tags',
+             'source': 'Mutation',
+             'tags': ['table-tags']},
+            {'form': 'buneolas',
+             'source': 'Mutation',
+             'tags': ['error-unrecognized-form']},
+            {'form': 'bhuneolas', 'source': 'Mutation', 'tags': ['lenition']},
+            {'form': 'mbuneolas', 'source': 'Mutation', 'tags': ['eclipsis']}]}
```

The radical doesn't appear because it is used by another template and I didn't want to touch that. Nor does that matter I think, since it's the headword anyway.

