### PR TITLE
Lang sublang

### DIFF
--- a/src/wiktextract/extractor/en/form_descriptions.py
+++ b/src/wiktextract/extractor/en/form_descriptions.py
@@ -1370,7 +1370,7 @@ def parse_head_final_tags(
         prev_form = form
         m = re.search(head_final_re, form)
         if m is not None:
-            print(f"{m=}, {m.groups()=}")
+            # print(f"{m=}, {m.groups()=}")
             tagkeys = m.group(3)
             # Only replace tags ending with numbers in languages that have
             # head-final numeric tags (e.g., Bantu classes); also, don't replace

--- a/src/wiktextract/extractor/en/translations.py
+++ b/src/wiktextract/extractor/en/translations.py
@@ -371,7 +371,8 @@ def parse_translation_item_text(
         extra_langcodes.add(lang_code)
         # Canonicalize language name (we could have gotten it via
         # alias or other_names)
-        lang = code_to_name(lang_code, "en")
+        if new_lang_name := code_to_name(lang_code, "en"):
+            lang = new_lang_name
     m = re.match(r"\*?\s*([-' \w][-'&, \w()]*)[:：]\s*", item)
     tags = []
     if m:

--- a/src/wiktextract/extractor/en/translations.py
+++ b/src/wiktextract/extractor/en/translations.py
@@ -375,6 +375,7 @@ def parse_translation_item_text(
     m = re.match(r"\*?\s*([-' \w][-'&, \w()]*)[:：]\s*", item)
     tags = []
     if m:
+        lang_sublang = ""
         sublang = m.group(1).strip()
         language_name_variations: list[str] = list()
         if lang and sublang:


### PR DESCRIPTION
Fixes #1631

    Changes to mediawiki_langcodes exposed an uninitialized
    variable.

    `mediawiki_langcodes.code_to_name()` and `.name_to_code()`
    are not necessarily symmetrical anymore. We tried to
    "canonicalize" names using a name-to-code -> code-to-name
    pipeline, but it can now return an empty string '' instead
    of None(as previously? maybe not), which exposed the bug.

    We want a `lang` name, so keep the old one if the
    code_to_name fails to return anything. Also initialize
    `lang_sublang`.