### PR TITLE
Emulate wikitext links whitespace better

### DIFF
--- a/src/wiktextract/clean.py
+++ b/src/wiktextract/clean.py
@@ -1381,7 +1381,7 @@ def clean_value(
             # Wikipedia or Wikisource link
             v = after_colon.split("|")[0]
         else:
-            v = m.group(0).strip("[] ").split("|")[0]
+            v = m.group(0).strip("[]").split("|")[0]
         return clean_value(wxr, v, no_strip=True)
 
     def repl_link_bars(m: re.Match) -> str:
@@ -1398,7 +1398,7 @@ def clean_value(
             return ""
         # m.group(5) is always the last matching group because you can
         # only access the last matched group; the indexes don't 'grow'
-        return clean_value(wxr, m.group(5) or m.group(2) or "", no_strip=True)
+        return clean_value(wxr, m.group(3) or "", no_strip=True)
 
     def repl_1_sup(m: re.Match) -> str:
         return to_superscript(clean_value(wxr, m.group(1)))
@@ -1534,18 +1534,19 @@ def clean_value(
             title,
         )
         title = re.sub(
-            r"(?s)\[\[\s*:?([^]|#<>:&]+?)\s*(#[^][|<>]*?)?\]\]", repl_1, title
+            r"(?s)\[\[\s*:?([^]|#<>:&]+?)(#[^][|<>]*?)?\]\]", repl_1, title
         )
         title = re.sub(
             r"(?s)\[\[\s*(([\w\d]+)\s*:)?(\s*[^][#|<>]+?)"
-            r"\s*(#[^][|]*?)?\|?\]\]",
+            r"(#[^][|]*?)?\|?\]\]",
             repl_link,
             title,
         )
         title = re.sub(
-            r"(?s)\[\[\s*([^][|<>]+?)\s*\|"
-            r"\s*(([^][|]|\[[^]]*\])+?)"
-            r"(\s*\|\s*(([^][|]|\[[^]]*\])+?))*\s*\|*\]\]",
+            # [[  (...)  |
+            r"(?s)\[\[\s*([^][|<>]+?)\s*"
+            # (|((...OR[...])+))*|]]
+            r"(\|(([^][|]|\[[^]]*\])+?))*\|*\]\]",
             repl_link_bars,
             title,
         )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -161,6 +161,28 @@ class CleanTests(unittest.TestCase):
         v = clean_value(self.wxr, v)
         self.assertEqual(v, "Bar")
 
+    def test_cv_link18(self):
+        v = "[[faa|foo]][[bor| bar]]"
+        v = clean_value(self.wxr, v)
+        self.assertEqual(v, "foo bar")
+
+    def test_cv_link19(self):
+        v = "[[faa|foo ]][[bor|bar]]"
+        v = clean_value(self.wxr, v)
+        self.assertEqual(v, "foo bar")
+
+    def test_cv_link20(self):
+        # Wikitext behavior: remove whitespace at the start of [[ ...]]
+        v = "[[foo]][[ bar]]"
+        v = clean_value(self.wxr, v)
+        self.assertEqual(v, "foobar")
+
+    def test_cv_link21(self):
+        # ... but not after
+        v = "[[foo ]][[bar]]"
+        v = clean_value(self.wxr, v)
+        self.assertEqual(v, "foo bar")
+
     def test_cv_url1(self):
         v = "This is a [http://ylonen.org test]."
         v = clean_value(self.wxr, v)


### PR DESCRIPTION
Wikitext links can have surprising output with whitespace:

[[  ...]][[   ...]] -> `......`
[[... ]][[... ]] -> `... ... `
[[xyz| ... ]] -> `   ...   `

We can simplify some regexes at the same time.