### PR TITLE
[tr] capture more example reference formats (trailing author, kt/mt, quoted plain)

### DIFF
--- a/src/wiktextract/extractor/tr/example.py
+++ b/src/wiktextract/extractor/tr/example.py
@@ -1,3 +1,5 @@
+import re
+
 from wikitextprocessor import NodeKind, TemplateNode, WikiNode
 
 from ...page import clean_node
@@ -16,18 +18,26 @@ def extract_example_list_item(
     list_item: WikiNode,
     example: Example,
 ) -> None:
-    seen_italic = False
+    seen_text = False
     trailing_text_parts: list[str] = []
+    plain_string_parts: list[str] = []
+    has_text_node = False
     for node in list_item.children:
         if isinstance(node, TemplateNode):
             if node.template_name in ["ux", "uxi"]:
                 extract_ux_template(wxr, word_entry.lang_code, node, example)
+                has_text_node = True
             elif node.template_name == "örnek":
                 extract_örnek_template(wxr, word_entry.lang_code, node, example)
+                has_text_node = True
+            elif node.template_name in ("kt", "mt"):
+                extract_kt_template(wxr, node, example)
+                has_text_node = True
             elif node.template_name in GLOSS_LIST_LINKAGE_TEMPLATES:
                 extract_gloss_list_linkage_template(wxr, word_entry, node)
             elif node.template_name.startswith("AT:"):
                 extract_at_template(wxr, example, node)
+                has_text_node = True
         elif isinstance(node, WikiNode):
             match node.kind:
                 case NodeKind.LIST:
@@ -56,13 +66,21 @@ def extract_example_list_item(
                                 example,
                                 "bold_translation_offsets",
                             )
-                        seen_italic = True
-        elif isinstance(node, str) and seen_italic:
-            trailing_text_parts.append(node)
-            
-    if example.ref == "" and trailing_text_parts:
+                        seen_text = True
+                        has_text_node = True
+        elif isinstance(node, str):
+            if seen_text:
+                trailing_text_parts.append(node)
+            else:
+                plain_string_parts.append(node)
+
+    if not has_text_node and plain_string_parts:
+        extract_quoted_plain_example(
+            "".join(plain_string_parts), example
+        )
+    elif example.ref == "" and trailing_text_parts:
         trailing = "".join(trailing_text_parts).strip()
-        trailing = trailing.lstrip("-–—").strip()
+        trailing = trailing.lstrip("-–—").strip("()").strip()
         if trailing != "":
             example.ref = trailing
 
@@ -204,3 +222,67 @@ def extract_at_template(
                 break
 
     example.ref = clean_node(wxr, None, t_node).splitlines()[0]
+
+
+KT_REF_FIELDS = (
+    "yazar",
+    "başlık",
+    "dergi",
+    "sayı",
+    "yıl",
+    "tarih",
+    "sayfa",
+    "yayıncı",
+)
+
+
+def extract_kt_template(
+    wxr: WiktextractContext,
+    t_node: TemplateNode,
+    example: Example,
+) -> None:
+    # https://tr.wiktionary.org/wiki/Şablon:kt (book) and Şablon:mt (magazine).
+    # tanıklık = example sentence; remaining fields = ref.
+    text_arg = t_node.template_parameters.get("tanıklık", "")
+    text = clean_node(wxr, None, text_arg)
+    if text != "":
+        example.text = text
+        calculate_bold_offsets(
+            wxr,
+            wxr.wtp.parse(wxr.wtp.node_to_wikitext(text_arg)),
+            text,
+            example,
+            "bold_text_offsets",
+        )
+    ref_parts: list[str] = []
+    for field in KT_REF_FIELDS:
+        value = clean_node(wxr, None, t_node.template_parameters.get(field, ""))
+        if value != "":
+            ref_parts.append(value)
+    if ref_parts and example.ref == "":
+        example.ref = ", ".join(ref_parts)
+
+
+QUOTED_EXAMPLE_RE = re.compile(
+    r'^\s*[\"“"]\s*(?P<text>.+?)\s*[\"”"]\s*'
+    r'(?:[-–—]\s*)?(?P<ref>.+?)?\s*$',
+    re.DOTALL,
+)
+
+
+def extract_quoted_plain_example(raw: str, example: Example) -> None:
+    # Plain `"..." - Author` lines that use no italic/template markup.
+    raw = raw.strip()
+    if raw == "":
+        return
+    m = QUOTED_EXAMPLE_RE.match(raw)
+    if m is None:
+        return
+    text = (m.group("text") or "").strip()
+    if text == "":
+        return
+    example.text = text
+    if example.ref == "":
+        ref = (m.group("ref") or "").strip().lstrip("-–—").strip("()").strip()
+        if ref != "":
+            example.ref = ref

--- a/src/wiktextract/extractor/tr/example.py
+++ b/src/wiktextract/extractor/tr/example.py
@@ -56,7 +56,7 @@ def extract_example_list_item(
                                 example,
                                 "bold_translation_offsets",
                             )
-                            seen_italic = True
+                        seen_italic = True
         elif isinstance(node, str) and seen_italic:
             trailing_text_parts.append(node)
             

--- a/src/wiktextract/extractor/tr/example.py
+++ b/src/wiktextract/extractor/tr/example.py
@@ -16,6 +16,8 @@ def extract_example_list_item(
     list_item: WikiNode,
     example: Example,
 ) -> None:
+    seen_italic = False
+    trailing_text_parts: list[str] = []
     for node in list_item.children:
         if isinstance(node, TemplateNode):
             if node.template_name in ["ux", "uxi"]:
@@ -54,7 +56,15 @@ def extract_example_list_item(
                                 example,
                                 "bold_translation_offsets",
                             )
-
+                            seen_italic = True
+        elif isinstance(node, str) and seen_italic:
+            trailing_text_parts.append(node)
+            
+    if example.ref == "" and trailing_text_parts:
+        trailing = "".join(trailing_text_parts).strip()
+        trailing = trailing.lstrip("-–—").strip()
+        if trailing != "":
+            example.ref = trailing
 
 def extract_ux_template(
     wxr: WiktextractContext,

--- a/tests/test_tr_gloss.py
+++ b/tests/test_tr_gloss.py
@@ -157,6 +157,30 @@ class TestTrGloss(TestCase):
                 }
             ],
         )
+    def test_example_trailing_author_ref(self):
+        page_data = parse_page(
+            self.wxr,
+            "azamet",
+            """==Türkçe==
+===Ad===
+{{tr-ad}}
+# [[gurur]]
+::''Arkadaşlarımdan ayrılıp onun yanına geçmek azametime dokundu.'' - R. N. Güntekin""",
+        )
+        self.assertEqual(
+            page_data[0]["senses"],
+            [
+                {
+                    "glosses": ["gurur"],
+                    "examples": [
+                        {
+                            "text": "Arkadaşlarımdan ayrılıp onun yanına geçmek azametime dokundu.",
+                            "ref": "R. N. Güntekin",
+                        }
+                    ],
+                }
+            ],
+        )
 
     def test_form_of_çekim_template_lists(self):
         self.wxr.wtp.add_page(

--- a/tests/test_tr_gloss.py
+++ b/tests/test_tr_gloss.py
@@ -207,6 +207,83 @@ class TestTrGloss(TestCase):
             ],
         )
 
+    def test_kt_template_book_citation(self):
+        page_data = parse_page(
+            self.wxr,
+            "mayıs",
+            """==Türkçe==
+===Ad===
+{{tr-ad}}
+# [[ay]]
+#*'''2006:''' {{kt|başlık=Acı Lokma|yazar=Fahri ERDİNÇ|yayıncı=Yordam Kitap|yıl=2006|sayfa=31|tanıklık=Kalk, ocağın batmasın. '''Mayısın''' üstüne oturmuşsun.|dil=tr}}""",
+        )
+        self.assertEqual(
+            page_data[0]["senses"],
+            [
+                {
+                    "glosses": ["ay"],
+                    "examples": [
+                        {
+                            "text": "Kalk, ocağın batmasın. Mayısın üstüne oturmuşsun.",
+                            "bold_text_offsets": [(23, 30)],
+                            "ref": "Fahri ERDİNÇ, Acı Lokma, 2006, 31, Yordam Kitap",
+                        }
+                    ],
+                }
+            ],
+        )
+
+    def test_mt_template_magazine_citation(self):
+        page_data = parse_page(
+            self.wxr,
+            "leylek",
+            """==Türkçe==
+===Ad===
+{{tr-ad}}
+# [[kuş]]
+#*'''2025:''' {{mt|dergi=Kitap-lık|sayı=239|yıl=2025|başlık=İki|yazar=Yasemin IŞIK|sayfa=112|tanıklık=Adem abi ve Yaren '''leyleğin''' yılda bir kez kavuştuğu bu anda, annem de ellerini göğsüne kavuşturmuş, başını sallayarak ekrana bakıyor.|dil=tr}}""",
+        )
+        self.assertEqual(
+            page_data[0]["senses"],
+            [
+                {
+                    "glosses": ["kuş"],
+                    "examples": [
+                        {
+                            "text": "Adem abi ve Yaren leyleğin yılda bir kez kavuştuğu bu anda, annem de ellerini göğsüne kavuşturmuş, başını sallayarak ekrana bakıyor.",
+                            "bold_text_offsets": [(18, 26)],
+                            "ref": "Yasemin IŞIK, İki, Kitap-lık, 239, 2025, 112",
+                        }
+                    ],
+                }
+            ],
+        )
+
+    def test_quoted_plain_example_with_author(self):
+        page_data = parse_page(
+            self.wxr,
+            "göz",
+            """==Türkçe==
+===Ad===
+{{tr-ad}}
+# [[organ]]
+#* "Asıl felaket bu pınara sırt çevirmek, bu pınarın gözlerine taş tıkamak değil de ne olurdu?" - Tarık Buğra""",
+        )
+        self.assertEqual(
+            page_data[0]["senses"],
+            [
+                {
+                    "glosses": ["organ"],
+                    "examples": [
+                        {
+                            "text": "Asıl felaket bu pınara sırt çevirmek, bu pınarın gözlerine taş tıkamak değil de ne olurdu?",
+                            "ref": "Tarık Buğra",
+                        }
+                    ],
+                }
+            ],
+        )
+
     def test_form_of_çekim_template_lists(self):
         self.wxr.wtp.add_page(
             "Şablon:karşılaştırma",

--- a/tests/test_tr_gloss.py
+++ b/tests/test_tr_gloss.py
@@ -182,6 +182,31 @@ class TestTrGloss(TestCase):
             ],
         )
 
+    def test_example_trailing_author_ref_hash_colon(self):
+        page_data = parse_page(
+            self.wxr,
+            "dok",
+            """==Türkçe==
+===Ad===
+{{tr-ad}}
+# [[tersane]]
+#:''Çekiç sesleri geliyor doklardan. Güzelim bahar rüzgârında ter kokuları. İstanbul'u dinliyorum, gözlerim kapalı.'' - O. V. Kanık""",
+        )
+        self.assertEqual(
+            page_data[0]["senses"],
+            [
+                {
+                    "glosses": ["tersane"],
+                    "examples": [
+                        {
+                            "text": "Çekiç sesleri geliyor doklardan. Güzelim bahar rüzgârında ter kokuları. İstanbul'u dinliyorum, gözlerim kapalı.",
+                            "ref": "O. V. Kanık",
+                        }
+                    ],
+                }
+            ],
+        )
+
     def test_form_of_çekim_template_lists(self):
         self.wxr.wtp.add_page(
             "Şablon:karşılaştırma",


### PR DESCRIPTION
## Summary

Turkish Wiktionary writes sourced quotations in several formats besides the `{{ux}}` / `{{örnek}}` templates that `extract_example_list_item` already handles. This PR captures three more shapes that were silently dropped:

1. **Italic + " - Author" trailing text** (TDK style). Common in older entries.

   ```
   ::''Arkadaşlarımdan ayrılıp onun yanına geçmek azametime dokundu.'' - R. N. Güntekin
   ```
   Strips a leading `-`, `–`, or `—` and assigns the result to `example.ref`.

2. **`{{kt}}` (book) and `{{mt}}` (magazine) citation templates.** Very common in modern entries (~900 `{{kt}}` and ~120 `{{mt}}` hits in a 50 MB sample of the `trwiktionary-20260401` dump). `tanıklık=` carries the example sentence; the rest forms the reference.

   ```
   #*'''2006:''' {{kt|başlık=Acı Lokma|yazar=Fahri ERDİNÇ|yayıncı=Yordam Kitap|yıl=2006|sayfa=31|tanıklık=Kalk, ocağın batmasın. '''Mayısın''' üstüne oturmuşsun.|dil=tr}}
   #*'''2025:''' {{mt|dergi=Kitap-lık|sayı=239|yıl=2025|başlık=İki|yazar=Yasemin IŞIK|sayfa=112|tanıklık=Adem abi ve Yaren '''leyleğin''' yılda bir kez kavuştuğu bu anda…|dil=tr}}
   ```
   Maps `tanıklık` → `example.text` and joins `yazar, başlık, dergi, sayı, yıl, tarih, sayfa, yayıncı` into `example.ref`.

3. **Plain `"..." - Author` lines** with no italic or template markup (~460 hits in the same sample).

   ```
   #* "Asıl felaket bu pınara sırt çevirmek, bu pınarın gözlerine taş tıkamak değil de ne olurdu?" - Tarık Buğra
   ```
   Only fires when no other text-bearing node was found, so it does not conflict with the italic+author logic.

Also strips surrounding parens from a trailing author (e.g. `''text'' (Author)`).

## Test plan

- [x] `tests/test_tr_gloss.py`: `test_example_trailing_author_ref`, `test_example_trailing_author_ref_hash_colon`, `test_kt_template_book_citation`, `test_mt_template_magazine_citation`, `test_quoted_plain_example_with_author`.
- [x] All `tests/test_tr_*.py` pass (36/36).
