### PR TITLE
[en] Improve POS tag parsing in the pronunciation section

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1021,6 +1021,16 @@ def parse_language(
                 pron.pop(key)  # type: ignore
             return pron
 
+        def sound_matches_pos(sound: SoundData, pos: str) -> bool:
+            if "pos" not in sound:
+                return True
+            sound_pos = sound["pos"]  # type: ignore[typeddict-item]
+            return pos in sound_pos
+
+        def strip_sound_pos(sound: SoundData) -> SoundData:
+            complementary_pop(sound, "pos")
+            return sound
+
         # If the result has sounds, eliminate sounds that have a prefix that
         # does not match "word" or one of "forms"
         if "sounds" in data and "word" in data:
@@ -1035,12 +1045,14 @@ def parse_language(
         # does not match "pos"
         if "sounds" in data and "pos" in data:
             data["sounds"] = list(
-                complementary_pop(s, "pos")
+                strip_sound_pos(s)
                 for s in data["sounds"]
                 # "pos" is not a field of SoundData, correctly, so we're
                 # removing it here. It's a kludge on a kludge on a kludge.
-                if "pos" not in s or s["pos"] == data["pos"]  # type: ignore[typeddict-item]
+                if sound_matches_pos(s, data["pos"])
             )
+        elif "sounds" in data:
+            data["sounds"] = [strip_sound_pos(s) for s in data["sounds"]]
 
     def push_sense(sorting_ordinal: int | None = None) -> bool:
         """Starts collecting data for a new word sense.  This returns True

--- a/src/wiktextract/extractor/en/pronunciation.py
+++ b/src/wiktextract/extractor/en/pronunciation.py
@@ -3,7 +3,7 @@ import re
 import urllib
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Iterator
+from typing import Iterator, NamedTuple
 
 from wikitextprocessor import (
     HTMLNode,
@@ -31,7 +31,9 @@ from .type_utils import Hyphenation, SoundData, TemplateArgs, WordData
 # section
 pron_romanizations = {
     " Revised Romanization ": "romanization revised",
-    " Revised Romanization (translit.) ": "romanization revised transliteration",
+    " Revised Romanization (translit.) ": (
+        "romanization revised transliteration"
+    ),
     " McCune-Reischauer ": "McCune-Reischauer romanization",
     " McCune–Reischauer ": "McCune-Reischauer romanization",
     " Yale Romanization ": "Yale romanization",
@@ -47,6 +49,87 @@ pron_romanization_re = re.compile(
 
 IPA_EXTRACT = r"^(\((.+)\) )?(IPA⁽ᵏᵉʸ⁾|enPR): ((.+?)( \(([^(]+)\))?\s*)$"
 IPA_EXTRACT_RE = re.compile(IPA_EXTRACT)
+
+
+class PronunciationPosMatch(NamedTuple):
+    pos_values: list[str]
+    residual: str
+
+
+class PronunciationPosPrefix(NamedTuple):
+    pos_values: list[str]
+    text: str
+    is_persistent: bool
+
+
+def normalize_pronunciation_pos_label(label: str) -> str:
+    label = label.strip().lower()
+    label = re.sub(r"\s+", " ", label)
+    # Drop explanatory suffixes such as "noun (barren areas)" before
+    # matching the label against part-of-speech names.
+    label = re.sub(r"\s*\([^)]*\)\s*$", "", label).strip()
+    label = label.strip(" \t\n\r():")
+    label = re.sub(r"\s+senses?$", "", label).strip()
+    return label
+
+
+def split_pronunciation_pos_text(text: str) -> PronunciationPosMatch:
+    pos_values: list[str] = []
+    residual: list[str] = []
+    for part in re.split(r"\s*(?:[,;]|\band\b|\bor\b)\s*", text):
+        part = part.strip()
+        if not part:
+            continue
+        normalized = normalize_pronunciation_pos_label(part)
+        if normalized in part_of_speech_map:
+            pos = part_of_speech_map[normalized]["pos"]
+            if pos not in pos_values:
+                pos_values.append(pos)
+        else:
+            residual.append(part)
+    return PronunciationPosMatch(pos_values, ", ".join(residual))
+
+
+def set_sound_pos(sound: SoundData, pos_values: list[str] | None) -> None:
+    if not pos_values:
+        return
+    sound["pos"] = list(pos_values)  # type: ignore[typeddict-unknown-key]
+
+
+def parse_pronunciation_tags_with_pos(
+    wxr: WiktextractContext, text: str, sound: SoundData
+) -> list[str]:
+    match = split_pronunciation_pos_text(text)
+    set_sound_pos(sound, match.pos_values)
+    if match.residual:
+        parse_pronunciation_tags(wxr, match.residual, sound)
+    return match.pos_values
+
+
+def extract_pos_prefix(text: str) -> PronunciationPosPrefix | None:
+    stripped = text.strip()
+    if not (stripped.startswith("(") and stripped.endswith(")")):
+        bare_match = split_pronunciation_pos_text(text)
+        if bare_match.pos_values and not bare_match.residual:
+            return PronunciationPosPrefix(bare_match.pos_values, "", True)
+
+    colon_match = re.match(r"\s*([^:()]+?)\s*:\s*(.*)$", text)
+    if colon_match:
+        match = split_pronunciation_pos_text(colon_match.group(1))
+        if match.pos_values and not match.residual:
+            return PronunciationPosPrefix(
+                match.pos_values, colon_match.group(2).strip(), True
+            )
+
+    paren_match = re.match(r"\s*\(([^()]*)\)\s*(.*)$", text)
+    if paren_match:
+        match = split_pronunciation_pos_text(paren_match.group(1))
+        if match.pos_values and not match.residual:
+            return PronunciationPosPrefix(
+                match.pos_values, paren_match.group(2).strip(), False
+            )
+
+    return None
 
 
 def extract_pron_template(
@@ -455,12 +538,13 @@ def parse_pronunciation(
                 yield line
 
     # have_pronunciations = False
-    active_pos: str | None = None
+    active_pos: list[str] | None = None
 
     for line in split_cleaned_node_on_newlines(contents):
         # print(f"{line=}")
         prefix: str | None = None
         earlier_base_data: SoundData | None = None
+        line_pos: list[str] | None = None
         if not line:
             continue
 
@@ -475,11 +559,11 @@ def parse_pronunciation(
                 # for active_pos; active_pos is a temporary data field
                 # given to each saved SoundData entry which is later
                 # used to sort the entries into their respective PoSes.
-                m = re.match(r"\s*(\w+\s?\w*)\s*:?\s*", text)
-                if m:
-                    if (m_lower := m.group(1).lower()) in part_of_speech_map:
-                        active_pos = part_of_speech_map[m_lower]["pos"]
-                        text = text[m.end() :].strip()
+                if pos_prefix := extract_pos_prefix(text):
+                    text = pos_prefix.text
+                    line_pos = pos_prefix.pos_values
+                    if pos_prefix.is_persistent:
+                        active_pos = pos_prefix.pos_values
             if not text:
                 continue
             if i % 2 == 1:
@@ -508,8 +592,7 @@ def parse_pronunciation(
                         elif "tags" in earlier_base_data:
                             pr["tags"] = sorted(set(earlier_base_data["tags"]))
                 for pr in first_prons:
-                    if active_pos:
-                        pr["pos"] = active_pos  # type: ignore[typeddict-unknown-key]
+                    set_sound_pos(pr, line_pos or active_pos)
                     if pr not in data.get("sounds", ()):
                         data_append(data, "sounds", pr)
                 # This bit is handled
@@ -526,8 +609,7 @@ def parse_pronunciation(
             m = re.search(r"(?m)\(Tokyo\) +([^ ]+) +\[", text)
             if m:
                 pron: SoundData = {field: m.group(1)}  # type: ignore[misc]
-                if active_pos:
-                    pron["pos"] = active_pos  # type: ignore[typeddict-unknown-key]
+                set_sound_pos(pron, line_pos or active_pos)
                 data_append(data, "sounds", pron)
                 # have_pronunciations = True
                 continue
@@ -539,8 +621,7 @@ def parse_pronunciation(
                     ending = ending.strip()
                     if ending:
                         pron = {"rhymes": ending}
-                        if active_pos:
-                            pron["pos"] = active_pos  # type: ignore[typeddict-unknown-key]
+                        set_sound_pos(pron, line_pos or active_pos)
                         data_append(data, "sounds", pron)
                         # have_pronunciations = True
                 continue
@@ -552,8 +633,7 @@ def parse_pronunciation(
                     w = w.strip()
                     if w:
                         pron = {"homophone": w}
-                        if active_pos:
-                            pron["pos"] = active_pos  # type: ignore[typeddict-unknown-key]
+                        set_sound_pos(pron, line_pos or active_pos)
                         data_append(data, "sounds", pron)
                         # have_pronunciations = True
                 continue
@@ -567,8 +647,7 @@ def parse_pronunciation(
                     if w and w not in seen:
                         seen.add(w)
                         pron = {"hangeul": w}
-                        if active_pos:
-                            pron["pos"] = active_pos  # type: ignore[typeddict-unknown-key]
+                        set_sound_pos(pron, line_pos or active_pos)
                         data_append(data, "sounds", pron)
                         # have_pronunciations = True
 
@@ -624,7 +703,9 @@ def parse_pronunciation(
                         tagstext = ""
             if tagstext:
                 earlier_base_data = {}
-                parse_pronunciation_tags(wxr, tagstext, earlier_base_data)
+                parse_pronunciation_tags_with_pos(
+                    wxr, tagstext, earlier_base_data
+                )
 
             # Find romanizations from the pronunciation section (routinely
             # produced for Korean by {{ko-IPA}})
@@ -661,12 +742,10 @@ def parse_pronunciation(
                         pron[field] = v
                     else:
                         pron = {field: v}  # type: ignore[misc]
-                    if active_pos:
-                        pron["pos"] = active_pos  # type: ignore[typeddict-unknown-key]
                     if prefix:
                         pron["form"] = prefix
-                    if active_pos:
-                        pron["pos"] = active_pos  # type: ignore[typeddict-unknown-key]
+                    if "pos" not in pron:
+                        set_sound_pos(pron, line_pos or active_pos)
                     data_append(data, "sounds", pron)
                 # have_pronunciations = True
 
@@ -730,8 +809,7 @@ def parse_pronunciation(
                     )
                 audio["ogg_url"] = ogg
                 audio["mp3_url"] = mp3
-                if active_pos:
-                    audio["pos"] = active_pos  # type: ignore[typeddict-unknown-key]
+                set_sound_pos(audio, line_pos or active_pos)
             if audio not in data.get("sounds", ()):
                 data_append(data, "sounds", audio)
 

--- a/src/wiktextract/extractor/en/pronunciation.py
+++ b/src/wiktextract/extractor/en/pronunciation.py
@@ -62,6 +62,20 @@ class PronunciationPosPrefix(NamedTuple):
     is_persistent: bool
 
 
+PRON_POS_TEMPLATE_NAMES = {
+    "q",
+    "qualifier",
+    "qual",
+    "i",
+    "sense",
+    "a",
+    "accent",
+    "lb",
+    "lbl",
+    "label",
+}
+
+
 def normalize_pronunciation_pos_label(label: str) -> str:
     label = label.strip().lower()
     label = re.sub(r"\s+", " ", label)
@@ -130,6 +144,40 @@ def extract_pos_prefix(text: str) -> PronunciationPosPrefix | None:
             )
 
     return None
+
+
+def extract_pronunciation_pos_template(
+    wxr: WiktextractContext,
+    name: str,
+    ht: TemplateArgs,
+    lang_code: str,
+) -> PronunciationPosMatch:
+    if name in {"a", "accent", "lb", "lbl", "label"}:
+        pos_args = [
+            value
+            for key, value in ht.items()
+            if isinstance(key, int) and key >= 2
+        ]
+        if not pos_args and ht.get(1) != lang_code:
+            pos_args = [ht.get(1, "")]
+    else:
+        pos_args = [
+            value
+            for key, value in ht.items()
+            if isinstance(key, int) and key >= 1
+        ]
+
+    pos_values: list[str] = []
+    residual: list[str] = []
+    for arg in pos_args:
+        text = clean_node(wxr, None, [arg])
+        match = split_pronunciation_pos_text(text)
+        for pos in match.pos_values:
+            if pos not in pos_values:
+                pos_values.append(pos)
+        if match.residual:
+            residual.append(match.residual)
+    return PronunciationPosMatch(pos_values, ", ".join(residual))
 
 
 def extract_pron_template(
@@ -328,6 +376,7 @@ def parse_pronunciation(
     if have_etym and data is base_data:
         data = etym_data
     pron_templates: list[tuple[SoundData, list[SoundData]]] = []
+    pron_pos_markers: list[list[str]] = []
     hyphenations: list[Hyphenation] = []
     audios: list[SoundData] = []
     have_panel_templates = False
@@ -453,17 +502,22 @@ def parse_pronunciation(
         # calling other subtemplates that are handled in _template_fn.
         if is_panel_template(wxr, name):
             return ""
+        if name in PRON_POS_TEMPLATE_NAMES:
+            pos_match = extract_pronunciation_pos_template(
+                wxr, name, ht, lang_code
+            )
+            if pos_match.pos_values:
+                pron_pos_markers.append(pos_match.pos_values)
+                marker = (
+                    f"__PRON_POS_MARKER_{len(pron_pos_markers) - 1}__"
+                )
+                if pos_match.residual:
+                    return f"{marker} ({pos_match.residual})"
+                return marker
         if name in {
-            "q",
-            "qualifier",
-            "sense",
-            "a",
-            "accent",
+            *PRON_POS_TEMPLATE_NAMES,
             "l",
             "link",
-            "lb",
-            "lbl",
-            "label",
         }:
             # Kludge: when these templates expand to /.../ or [...],
             # replace the expansion by something safe.  This is used
@@ -545,6 +599,8 @@ def parse_pronunciation(
         prefix: str | None = None
         earlier_base_data: SoundData | None = None
         line_pos: list[str] | None = None
+        current_group_sounds: list[SoundData] = []
+        line_has_sound = False
         if not line:
             continue
 
@@ -566,6 +622,24 @@ def parse_pronunciation(
                         active_pos = pos_prefix.pos_values
             if not text:
                 continue
+
+            m = re.search(r"__PRON_POS_MARKER_(\d+)__", text)
+            while m:
+                if current_group_sounds and re.search(
+                    r"[,;]", text[: m.start()]
+                ):
+                    current_group_sounds = []
+                pos_values = pron_pos_markers[int(m.group(1))]
+                if current_group_sounds:
+                    for sound in current_group_sounds:
+                        set_sound_pos(sound, pos_values)
+                line_pos = pos_values
+                text = text[: m.start()] + text[m.end() :]
+                m = re.search(r"__PRON_POS_MARKER_(\d+)__", text)
+            text = text.strip()
+            if not text:
+                continue
+
             if i % 2 == 1:
                 # re.split (with capture groups) splits the lines so that
                 # every even entry is a captured splitter; odd lines are either
@@ -595,6 +669,8 @@ def parse_pronunciation(
                     set_sound_pos(pr, line_pos or active_pos)
                     if pr not in data.get("sounds", ()):
                         data_append(data, "sounds", pr)
+                    current_group_sounds.append(pr)
+                    line_has_sound = True
                 # This bit is handled
                 continue
 
@@ -611,6 +687,8 @@ def parse_pronunciation(
                 pron: SoundData = {field: m.group(1)}  # type: ignore[misc]
                 set_sound_pos(pron, line_pos or active_pos)
                 data_append(data, "sounds", pron)
+                current_group_sounds.append(pron)
+                line_has_sound = True
                 # have_pronunciations = True
                 continue
 
@@ -623,6 +701,8 @@ def parse_pronunciation(
                         pron = {"rhymes": ending}
                         set_sound_pos(pron, line_pos or active_pos)
                         data_append(data, "sounds", pron)
+                        current_group_sounds.append(pron)
+                        line_has_sound = True
                         # have_pronunciations = True
                 continue
 
@@ -635,6 +715,8 @@ def parse_pronunciation(
                         pron = {"homophone": w}
                         set_sound_pos(pron, line_pos or active_pos)
                         data_append(data, "sounds", pron)
+                        current_group_sounds.append(pron)
+                        line_has_sound = True
                         # have_pronunciations = True
                 continue
 
@@ -649,6 +731,8 @@ def parse_pronunciation(
                         pron = {"hangeul": w}
                         set_sound_pos(pron, line_pos or active_pos)
                         data_append(data, "sounds", pron)
+                        current_group_sounds.append(pron)
+                        line_has_sound = True
                         # have_pronunciations = True
 
             # This regex-based hyphenation detection left as backup
@@ -747,7 +831,13 @@ def parse_pronunciation(
                     if "pos" not in pron:
                         set_sound_pos(pron, line_pos or active_pos)
                     data_append(data, "sounds", pron)
+                    current_group_sounds.append(pron)
+                    line_has_sound = True
                 # have_pronunciations = True
+            if current_group_sounds and re.search(r"[,;]", text):
+                current_group_sounds = []
+        if line_pos and not line_has_sound:
+            active_pos = line_pos
 
         # XXX what about {{hyphenation|...}}, {{hyph|...}}
         # and those used to be stored under "hyphenation"

--- a/tests/test_en_pronunciation.py
+++ b/tests/test_en_pronunciation.py
@@ -26,6 +26,27 @@ class TestPronunciation(TestCase):
             self.wxr.thesaurus_db_path, self.wxr.thesaurus_db_conn
         )
 
+    def add_pos_pronunciation_templates(self) -> None:
+        self.wxr.wtp.add_page(
+            "Template:IPA", 10, "IPA⁽ᵏᵉʸ⁾: {{{2}}}"
+        )
+        self.wxr.wtp.add_page(
+            "Template:q",
+            10,
+            "({{{1}}}{{#if:{{{2|}}}|, {{{2}}}}}{{#if:{{{3|}}}|, {{{3}}}}})",
+        )
+        self.wxr.wtp.add_page(
+            "Template:sense",
+            10,
+            "({{{1}}}{{#if:{{{2|}}}|, {{{2}}}}}):",
+        )
+        self.wxr.wtp.add_page("Template:i", 10, "({{{1}}})")
+        self.wxr.wtp.add_page(
+            "Template:a",
+            10,
+            "({{{2}}}{{#if:{{{3|}}}|, {{{3}}}}})",
+        )
+
     def test1(self):
         self.wxr.wtp.start_page("foo")
         self.wxr.wtp.add_page(
@@ -277,6 +298,112 @@ class TestPronunciation(TestCase):
                     },
                 ]
             },
+        )
+
+    def test_pos_template_line_labels_following_sublist(self):
+        self.wxr.wtp.start_page("increase")
+        self.add_pos_pronunciation_templates()
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* {{q|verb}}
+** {{IPA|en|/ɪnˈkɹiːs/}}
+* {{q|noun}}
+** {{IPA|en|/ˈɪnkɹiːs/}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        self.assertEqual(
+            out,
+            {
+                "sounds": [
+                    {"ipa": "/ɪnˈkɹiːs/", "pos": ["verb"]},
+                    {"ipa": "/ˈɪnkɹiːs/", "pos": ["noun"]},
+                ]
+            },
+        )
+
+    def test_pos_template_root_level_label(self):
+        self.wxr.wtp.start_page("dotcom")
+        self.add_pos_pronunciation_templates()
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+{{i|noun}}
+* {{IPA|en|/dɒtˈkɒm/}}
+{{i|verb}}
+* {{IPA|en|/ˈdɒtkɒm/}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        self.assertEqual(
+            out,
+            {
+                "sounds": [
+                    {"ipa": "/dɒtˈkɒm/", "pos": ["noun"]},
+                    {"ipa": "/ˈdɒtkɒm/", "pos": ["verb"]},
+                ]
+            },
+        )
+
+    def test_pos_template_prefix_and_postfix_labels(self):
+        self.wxr.wtp.start_page("reboot")
+        self.add_pos_pronunciation_templates()
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* {{q|verb}} {{IPA|en|/ɹiːˈbuːt/}}
+* {{IPA|en|/ˈɹiːbuːt/}} {{q|noun|verb}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        self.assertEqual(
+            out,
+            {
+                "sounds": [
+                    {"ipa": "/ɹiːˈbuːt/", "pos": ["verb"]},
+                    {"ipa": "/ˈɹiːbuːt/", "pos": ["noun", "verb"]},
+                ]
+            },
+        )
+
+    def test_pos_template_multi_pos_and_parenthetical_label(self):
+        self.wxr.wtp.start_page("deserts")
+        self.add_pos_pronunciation_templates()
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* {{a|en|noun (barren areas)|verb}} {{IPA|en|/ˈdɛzɚts/}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        self.assertEqual(
+            out,
+            {"sounds": [{"ipa": "/ˈdɛzɚts/", "pos": ["noun", "verb"]}]},
+        )
+
+    def test_pos_template_multiple_groups_on_one_line(self):
+        # Norwegian Bokmål section
+        self.wxr.wtp.start_page("abandoner")
+        self.add_pos_pronunciation_templates()
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* {{sense|noun}} {{IPA|nb|/abaŋˈdɔŋər/}}, {{sense|verb}} {{IPA|nb|/abandɔˈneːr/}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "nb")
+        self.assertEqual(
+            out,
+            {
+                "sounds": [
+                    {"ipa": "/abaŋˈdɔŋər/", "pos": ["noun"]},
+                    {"ipa": "/abandɔˈneːr/", "pos": ["verb"]},
+                ]
+            },
+        )
+
+    def test_accent_template_non_pos_label_remains_tag(self):
+        self.wxr.wtp.start_page("conduct")
+        self.add_pos_pronunciation_templates()
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* {{a|en|RP}} {{IPA|en|/ˈkɒndʌkt/}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        self.assertEqual(
+            out,
+            {"sounds": [{"ipa": "/ˈkɒndʌkt/", "tags": ["Received-Pronunciation"]}]},
         )
 
     def test_no_templates1(self):

--- a/tests/test_en_pronunciation.py
+++ b/tests/test_en_pronunciation.py
@@ -72,47 +72,47 @@ class TestPronunciation(TestCase):
                     {
                         "tags": ["Received-Pronunciation"],
                         "enpr": "föö",
-                        "pos": "noun",
+                        "pos": ["noun"],
                     },
                     {
                         "ipa": "/foo/",
                         "tags": ["Received-Pronunciation"],
-                        "pos": "noun",
+                        "pos": ["noun"],
                     },
                     {
                         "tags": ["Received-Pronunciation"],
                         "ipa": "/bar/",
-                        "pos": "noun",
+                        "pos": ["noun"],
                     },
                     {
                         "enpr": "bär",
                         "tags": ["Received-Pronunciation"],
-                        "pos": "noun",
+                        "pos": ["noun"],
                     },
                     {
                         "tags": ["Northern-England", "Scotland"],
                         "ipa": "/baz/",
-                        "pos": "noun",
+                        "pos": ["noun"],
                     },
                     {
                         "audio": "LL-Q1860 (eng)-Back ache-past.wav",
                         "ogg_url": "https://upload.wikimedia.org/wikipedia/commons/transcoded/7/7a/LL-Q1860_%28eng%29-Back_ache-past.wav/LL-Q1860_%28eng%29-Back_ache-past.wav.ogg",
                         "mp3_url": "https://upload.wikimedia.org/wikipedia/commons/transcoded/7/7a/LL-Q1860_%28eng%29-Back_ache-past.wav/LL-Q1860_%28eng%29-Back_ache-past.wav.mp3",
-                        "pos": "noun",
+                        "pos": ["noun"],
                         "tags": ["UK"],
                     },
-                    {"tags": ["US"], "enpr": "vöö", "pos": "verb"},
-                    {"ipa": "/voo/", "tags": ["US"], "pos": "verb"},
+                    {"tags": ["US"], "enpr": "vöö", "pos": ["verb"]},
+                    {"ipa": "/voo/", "tags": ["US"], "pos": ["verb"]},
                     {
                         "audio": "en-us-past.ogg",
                         "ogg_url": "https://upload.wikimedia.org/wikipedia/commons/b/b0/En-us-past.ogg",
                         "mp3_url": "https://upload.wikimedia.org/wikipedia/commons/transcoded/b/b0/En-us-past.ogg/En-us-past.ogg.mp3",
-                        "pos": "verb",
+                        "pos": ["verb"],
                         "tags": ["US"],
                     },
-                    {"homophone": "feu", "pos": "verb"},
-                    {"rhymes": "-oo", "pos": "verb"},
-                    {"rhymes": "-öö", "pos": "verb"},
+                    {"homophone": "feu", "pos": ["verb"]},
+                    {"rhymes": "-oo", "pos": ["verb"]},
+                    {"rhymes": "-öö", "pos": ["verb"]},
                     {
                         "tags": [
                             "Received-Pronunciation",
@@ -123,7 +123,7 @@ class TestPronunciation(TestCase):
                         ],
                         "note": "Caribbean, note-fodder causes everything to be a note",
                         "ipa": "/foobar/",
-                        "pos": "verb",
+                        "pos": ["verb"],
                     },
                     {
                         "tags": [
@@ -134,7 +134,7 @@ class TestPronunciation(TestCase):
                         ],
                         "note": "Cajun, dual",
                         "ipa": "foobaz(ipa accepts parens)",
-                        "pos": "verb",
+                        "pos": ["verb"],
                     },
                     {
                         "tags": [
@@ -144,7 +144,7 @@ class TestPronunciation(TestCase):
                             "paucal",
                         ],
                         "ipa": "barbar",
-                        "pos": "verb",
+                        "pos": ["verb"],
                     },
                     {
                         "tags": [
@@ -154,7 +154,7 @@ class TestPronunciation(TestCase):
                             "paucal",
                         ],
                         "ipa": "barbaz",
-                        "pos": "verb",
+                        "pos": ["verb"],
                     },
                     {
                         "tags": [
@@ -164,7 +164,7 @@ class TestPronunciation(TestCase):
                             "paucal",
                         ],
                         "ipa": "baz",
-                        "pos": "verb",
+                        "pos": ["verb"],
                     },
                     {
                         "tags": [
@@ -175,7 +175,7 @@ class TestPronunciation(TestCase):
                             "singular",
                         ],
                         "ipa": "bazfoo",
-                        "pos": "verb",
+                        "pos": ["verb"],
                     },
                 ]
             },
@@ -203,12 +203,77 @@ class TestPronunciation(TestCase):
                     {
                         "tags": ["Received-Pronunciation"],
                         "enpr": "föö",
-                        "pos": "noun",
+                        "pos": ["noun"],
                     },
                     {
                         "tags": ["Received-Pronunciation"],
                         "ipa": "/foo/",
-                        "pos": "noun",
+                        "pos": ["noun"],
+                    },
+                ]
+            },
+        )
+
+    def test_multi_pos_plain_text_label(self):
+        self.wxr.wtp.start_page("offset")
+        self.wxr.wtp.add_page("Template:IPA", 10, "IPA⁽ᵏᵉʸ⁾: /ˈɔfsɛt/")
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* Noun and verb:
+* {{IPA|en|/ˈɔfsɛt/}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        self.assertEqual(
+            out,
+            {"sounds": [{"ipa": "/ˈɔfsɛt/", "pos": ["noun", "verb"]}]},
+        )
+
+    def test_bold_pos_plain_text_label(self):
+        self.wxr.wtp.start_page("use")
+        self.wxr.wtp.add_page("Template:IPA", 10, "IPA⁽ᵏᵉʸ⁾: /juːs/")
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+'''Noun'''
+* {{IPA|en|/juːs/}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        self.assertEqual(out, {"sounds": [{"ipa": "/juːs/", "pos": ["noun"]}]})
+
+    def test_non_pos_qualifier_not_converted_to_pos(self):
+        self.wxr.wtp.start_page("foo")
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* (US) IPA⁽ᵏᵉʸ⁾: /fu/
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        self.assertEqual(out, {"sounds": [{"tags": ["US"], "ipa": "/fu/"}]})
+
+    def test_determinate_parenthesized_pos_prefixes(self):
+        self.wxr.wtp.start_page("determinate")
+        self.wxr.wtp.add_page(
+            "Template:IPA",
+            10,
+            "({{{a}}}) IPA⁽ᵏᵉʸ⁾: {{{2}}}",
+        )
+        tree = self.wxr.wtp.parse("""=== Pronunciation ===
+* (adjective, noun) {{IPA|en|/dɪˈtɜːmɪnət/|a=UK}}
+* (verb) {{IPA|en|/dɪˈtɜːmɪneɪt/|a=UK}}
+""")
+        out = {}
+        parse_pronunciation(self.wxr, tree.children[0], out, {}, {}, {}, "en")
+        self.assertEqual(
+            out,
+            {
+                "sounds": [
+                    {
+                        "ipa": "/dɪˈtɜːmɪnət/",
+                        "tags": ["UK"],
+                        "pos": ["adj", "noun"],
+                    },
+                    {
+                        "ipa": "/dɪˈtɜːmɪneɪt/",
+                        "tags": ["UK"],
+                        "pos": ["verb"],
                     },
                 ]
             },
@@ -234,10 +299,10 @@ class TestPronunciation(TestCase):
                     {
                         "tags": ["Received-Pronunciation"],
                         "ipa": "/foo/",
-                        "pos": "noun",
+                        "pos": ["noun"],
                     },
-                    {"homophone": "feu", "pos": "noun"},
-                    {"rhymes": "-oo", "pos": "noun"},
+                    {"homophone": "feu", "pos": ["noun"]},
+                    {"rhymes": "-oo", "pos": ["noun"]},
                 ]
             },
         )


### PR DESCRIPTION
This series of two patches improves parsing of POS tags in the pronunciation section:
* The first patch makes the "pos" field a list rather than a str to support multiple POS tags attached to a single SoundData object and updates the parsing accordingly. It also adds support for line-local POS tags.
* The second patch adds support for POS tags in qualifier templates (such as `q` and `a`) in various scenarios (before and after pronunciations templates and as a tag for following lines).