### PR TITLE
[en] Ignore `defdate` templates in word heads

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1242,6 +1242,9 @@ def parse_language(
         if name == "picdic" or name == "picdicimg" or name == "picdiclabel":
             # XXX extract?
             return ""
+        if name == "defdate":
+            # the one exampe I saw of this was weird.
+            return ""
 
         return None
 


### PR DESCRIPTION
The one example I have doesn't make sense, and should probably be in a sense instead of the head, or the etymology.

Fixes #1609 