### PR TITLE
[ja] Use `wago` as pos instead of `unknown`

### DIFF
--- a/src/wiktextract/extractor/ja/section_titles.py
+++ b/src/wiktextract/extractor/ja/section_titles.py
@@ -31,7 +31,7 @@ POS_DATA = {
     # "小詞"
     # "修飾詞"
     # "疑問詞"
-    "和語の漢字表記": {"pos": "unknown", "tags": ["kanji", "form-of"]},
+    "和語の漢字表記": {"pos": "wago", "tags": ["kanji", "form-of"]},
     "成句": {"pos": "phrase", "tags": ["idiomatic"]},
     "成語": {"pos": "phrase", "tags": ["idiomatic"]},
     "縮約形": {"pos": "contraction"},

--- a/src/wiktextract/extractor/ja/section_titles.py
+++ b/src/wiktextract/extractor/ja/section_titles.py
@@ -31,7 +31,7 @@ POS_DATA = {
     # "小詞"
     # "修飾詞"
     # "疑問詞"
-    "和語の漢字表記": {"pos": "wago", "tags": ["kanji", "form-of"]},
+    "和語の漢字表記": {"pos": "character", "tags": ["wago-kanji", "form-of"]},
     "成句": {"pos": "phrase", "tags": ["idiomatic"]},
     "成語": {"pos": "phrase", "tags": ["idiomatic"]},
     "縮約形": {"pos": "contraction"},

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -6133,6 +6133,7 @@ valid_tags = {
     "volitional": "mood",  # Verb mood (e.g., Japanese: suggests, urges, initates act)
     "vos-form": "register",  # Spanish verb forms used with "vos"
     "vulgar": "register",
+    "wago-kanji": "misc",
     "weak": "misc",
     "with-a": "with",
     "with-ablative": "with",
@@ -6521,8 +6522,10 @@ def sort_tags(
     return tuple(
         sorted(
             set(tags),
-            key=lambda t: tag_categories.get(valid_tags.get(t, "unknown"), 0)
-            - len(t) / 1000,
+            key=lambda t: (
+                tag_categories.get(valid_tags.get(t, "unknown"), 0)
+                - len(t) / 1000
+            ),
             reverse=True,
         )
     )

--- a/tests/test_ja_gloss.py
+++ b/tests/test_ja_gloss.py
@@ -172,7 +172,7 @@ class TestJaGloss(TestCase):
 ==={{wago}}===
 #{{wagokanji of|てんぷら}}""",
         )
-        self.assertEqual(page_data[0]["pos"], "wago")
+        self.assertEqual(page_data[0]["pos"], "character")
         self.assertEqual(
             page_data[0]["senses"],
             [

--- a/tests/test_ja_gloss.py
+++ b/tests/test_ja_gloss.py
@@ -172,6 +172,7 @@ class TestJaGloss(TestCase):
 ==={{wago}}===
 #{{wagokanji of|てんぷら}}""",
         )
+        self.assertEqual(page_data[0]["pos"], "wago")
         self.assertEqual(
             page_data[0]["senses"],
             [


### PR DESCRIPTION
Title.

The rationale behind is that:
- "unknown" is lossy, and makes selecting this data potentionally risky when it conflicts with other headers that may also converge to "unknown". One could narrow the selection by only taking pos="unknown" and tags including "kanji" and "form-of", but that, also, is potentially faulty.
- "wago" is the name of the template that expands to this header. See [here](https://ja.wiktionary.org/wiki/%E9%8B%AD%E3%81%84). Unfortunately the template [page](https://ja.wiktionary.org/wiki/%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88:wago) is most succint. See also the wikipedia on [wago](https://en.wikipedia.org/wiki/Wago). See also the changed test below.

The obvious disadvantage is that "wago" doesn't really correspond to a "pos", but it is rather a convenient category for wiktionary editors. I don't think this is an issue since it practically works as a "pos", and that is how it is habitually used in these sort of redirection pages (which are many).

We could have opted for `wagokanji`, which wiktionary uses for the list items and the headwords, but strictly speaking, "wago" is the header, and, as shown above, it is also an accepted English word (albeit very technical).

We could have also removed the tags ("kanji" and "form-of"), but I wanted the changes to be minimal, even if they are (at least the "kanji" one), sort of redundant.
