### PR TITLE
[en] Use TABLE_CAPTION wikinodes as titles if classed

### DIFF
--- a/src/wiktextract/extractor/en/inflection.py
+++ b/src/wiktextract/extractor/en/inflection.py
@@ -219,6 +219,18 @@ title_contains_wordtags_map = {
     "pluperfect": "pluperfect",
     "future": "future",
     "aorist": "aorist",
+    "eastern armenian": "Eastern-Armenian",
+    "western armenian": "Western-Armenian",
+    "-al conjugation": "-al-conjugation",
+    "-al negative conjugation": "-al-conjugation",
+    "-il conjugation": "-il-conjugation",
+    "-il negative conjugation": "-il-conjugation",
+    "-el conjugation": "-el-conjugation",
+    "-el negative conjugation": "-el-conjugation",
+    "-ul conjugation": "-ul-conjugation",
+    "-ul negative conjugation": "-ul-conjugation",
+    "u-type": "u-type",
+    "nominalized infinitive": "noun infinitive",
 }
 for k, v in title_contains_wordtags_map.items():
     if any(t not in valid_tags for t in v.split()):
@@ -228,7 +240,12 @@ for k, v in title_contains_wordtags_map.items():
 title_contains_wordtags_re = re.compile(
     r"(?i)(^|\b)({}|{})($|\b)".format(
         table_hdr_ign_part,
-        "|".join(re.escape(x) for x in title_contains_wordtags_map.keys()),
+        "|".join(
+            re.escape(x)
+            for x in reversed(
+                sorted(title_contains_wordtags_map.keys(), key=len)
+            )
+        ),
     )
 )
 
@@ -1702,6 +1719,27 @@ def parse_simple_table(
                     assert x in valid_tags
                 assert isinstance(alts, (list, tuple))
                 assert isinstance(tags, str)
+            elif (
+                (
+                    m := re.match(
+                        # word1, word2 (romanization1, romanization2)
+                        r"\s*([^(),]+),([^(),]+)\(([^(),]+),([^(),]+)\)",
+                        col,
+                    )
+                )
+                # NOT `word, (tag, tag)` with an empty m.group(2)...
+                # There is a test that fails because of this. It's an
+                # outdated table, but still, ...Italian_verb1
+                and all(s.strip() for s in m.groups())
+                and any(
+                    (
+                        # except for entries like word1, word2 (tag2, tag2)...
+                        classify_desc(s) in ("english", "romanization")
+                        for s in (m.group(3), m.group(4))
+                    )
+                )
+            ):
+                alts = [m.group(1), m.group(2), m.group(3), m.group(4)]
             else:
                 # Use default splitting.  However, recognize
                 # language-specific replacements and change them to magic
@@ -2777,7 +2815,10 @@ def handle_mixed_lines(
                 # from the string, while ^xyz needs to be
                 # removed separately, though it's usually
                 # something with a single letter?
-                "".join(xx for xx in x if not is_superscript(xx)),
+                "".join(xx for xx in x if not is_superscript(xx))
+                # Remove trailing footnote asterisks that mess with
+                # classification
+                .strip("* "),
             )
         )
         for x in alts
@@ -3236,6 +3277,8 @@ def handle_wikitext_or_html_table(
         assert isinstance(after, str)
         assert isinstance(depth, int)
         # print("HANDLE_WIKITEXT_TABLE", titles)
+        # if len(titles) > 0:
+        #     wxr.wtp.debug(f"HANDLE_WIKITEXT_TABLE {titles=}")
 
         # Filling for columns with rowspan > 1
         col_gap_data: list[InflCell | None] = []
@@ -3263,7 +3306,8 @@ def handle_wikitext_or_html_table(
             # print("  {}".format(node))
             if kind in (NodeKind.TABLE_CAPTION, "caption"):
                 # print("  CAPTION:", node)
-                pass
+                if "inflection-table-title" in node.attrs.get("class", ""):
+                    titles = [clean_node(wxr, None, node.children)]
             elif kind in (NodeKind.TABLE_ROW, "tr"):
                 if "vsShow" in node.attrs.get("class", "").split():
                     # vsShow rows are those that are intially shown in tables

--- a/src/wiktextract/extractor/en/inflectiondata.py
+++ b/src/wiktextract/extractor/en/inflectiondata.py
@@ -176,10 +176,8 @@ infl_map: dict[str, InflMapNode] = {
     "superessive": "superessive",
     "sublative": "sublative",
     "delative": "delative",
-    "non-attributive possessive - singular":
-        "predicative possessive possessed-single",  # XXX hűtő/Hungarian/Noun
-    "non-attributive possessive - plural":
-        "predicative possessive possessed-single",
+    "non-attributive possessive - singular": "predicative possessive possessed-single",  # XXX hűtő/Hungarian/Noun
+    "non-attributive possessive - plural": "predicative possessive possessed-single",
     "infinitive": "infinitive",
     "prepositional": "prepositional",
     "masculine": {
@@ -225,7 +223,7 @@ infl_map: dict[str, InflMapNode] = {
     "2nd person sing.": "second-person singular",
     "2nd person sing. (u)": "second-person singular formal",
     "2nd person sing. (gij)": [
-        "second-person singular archaic " "formal majestic",
+        "second-person singular archaic formal majestic",
         "second-person singular colloquial Flanders",
     ],
     "3rd person sing.": "third-person singular",
@@ -2484,12 +2482,12 @@ infl_map: dict[str, InflMapNode] = {
     "Perfective": "perfective",
     "Stem forms": "stem",
     "Continuative": "continuative",
-    "Mizenkei (\"imperfective\")": "imperfective",
-    "Ren’yōkei (\"continuative\")": "continuative",
-    "Shūshikei (\"terminal\")": "terminative",
-    "Rentaikei (\"attributive\")": "attributive",
-    "Kateikei (\"hypothetical\")": "hypothetical",
-    "Meireikei (\"imperative\")": "imperative",
+    'Mizenkei ("imperfective")': "imperfective",
+    'Ren’yōkei ("continuative")': "continuative",
+    'Shūshikei ("terminal")': "terminative",
+    'Rentaikei ("attributive")': "attributive",
+    'Kateikei ("hypothetical")': "hypothetical",
+    'Meireikei ("imperative")': "imperative",
     "Continuative (連用形)": "continuative",
     "Terminal (終止形)": "terminative",
     "Attributive (連体形)": "attributive",
@@ -2723,7 +2721,7 @@ infl_map: dict[str, InflMapNode] = {
     "m.": "masculine",
     "f.": "feminine",
     "Stem": "stem",
-    "aorist stem": "stem",
+    "aorist stem": {"lang": "Armenian", "then": "aorist stem", "else": "stem"},
     "pos.": "positive",
     "neg.": "negative",
     "future perfect in the past": "future perfect past",
@@ -4042,11 +4040,15 @@ infl_map: dict[str, InflMapNode] = {
         "then": "stem",
     },
     "Base Form": {
-        "lang": ["Assyrian Neo-Aramaic",],
+        "lang": [
+            "Assyrian Neo-Aramaic",
+        ],
         "then": "stem",
     },
     "base form": {
-        "lang": ["Assyrian Neo-Aramaic",],
+        "lang": [
+            "Assyrian Neo-Aramaic",
+        ],
         "then": "stem",
     },
     "Personal-pronoun- including forms": {
@@ -6399,7 +6401,7 @@ infl_map: dict[str, InflMapNode] = {
     "*p/2/3/11/14": [
         "object-plural object-first-person "
         "object-second-person object-third-person",
-        "object-class-2 object-class-3 object-class-11 " "object-class-14",
+        "object-class-2 object-class-3 object-class-11 object-class-14",
     ],
     "c4/c6/c9": "object-class-4 object-class-6 object-class-9",
     "2s/2p/15/17": [

--- a/src/wiktextract/extractor/en/inflectiondata.py
+++ b/src/wiktextract/extractor/en/inflectiondata.py
@@ -2142,6 +2142,7 @@ infl_map: dict[str, InflMapNode] = {
     },
     "մենք": {"lang": "Armenian", "if": "first-person plural", "then": ""},
     "նրանք": {"lang": "Armenian", "if": "third-person plural", "then": ""},
+    "անոնք": {"lang": "Armenian", "if": "third-person plural", "then": ""},
     "verbal nouns": "noun-from-verb",
     "supine": "supine",
     "past historic": "past historic",

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -6483,6 +6483,12 @@ valid_tags = {
     "Jiaoliao-Mandarin": "script",
     "Central-Plains-Mandarin": "script",
     "Lanyin-Mandarin": "script",
+    # Table tags for Armenian conjugation
+    "-el-conjugation": "class",
+    "-al-conjugation": "class",
+    "-il-conjugation": "class",
+    "-ul-conjugation": "class",
+    "u-type": "class",
 }
 
 for k, v in valid_tags.items():


### PR DESCRIPTION
Fixes #1615

Check out https://github.com/tatuylonen/wikitextprocessor/issues/420
for a bug that blocked this PR in wikitextprocessor.

If a WikiNode.TABLE_CAPTION has a class `inflection-table-title`,
it should be used as the title of a table within a larger
template. AFAICT, this is new; before this, we ignored
table captions completely because of the problem is classifying
them as notes or nothing or titles. This is unambiguous, thanks
Wiktionary editors!

This commit also contains additions to title parsing,
and a minor addition to how cells in the form
"word, word (word, word)" should be partitioned for
`handle_mixed_lines()`