### PR TITLE
`etymology_number` fields are now strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ following keys (others may also be present or added later):
   the etymology section.  These can be used to easily parse etymological
   relations.  Certain common templates that do not signify etymological
   relations are not included.
-* ``etymology_number`` - for words with multiple numbered etymologies, this contains the number of the etymology under which this entry appeared
+* ``etymology_number`` - for words with multiple numbered etymologies, this contains the number of the etymology under which this entry appeared, [as a string as of May 2026]
 * ``descendants`` - descendants of the word (see below)
 * ``synonyms`` - non-disambiguated synonym linkages for the word (see below)
 * ``antonyms`` - non-disambiguated antonym linkages for the word (see below)

--- a/src/wiktextract/extractor/el/models.py
+++ b/src/wiktextract/extractor/el/models.py
@@ -244,7 +244,7 @@ class WordEntry(GreekBaseModel):
         "etymology section.",
     )
     # For sections like "Etymology 1"
-    etymology_number: int = -1
+    etymology_number: str = "-1"
     senses: list[Sense] = []
     title: str = Field(default="", description="Redirect page source title")
     redirect: str = Field(default="", description="Redirect page target title")

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -3320,9 +3320,9 @@ def parse_language(
                 push_etym()
                 wxr.wtp.start_subsection(None)
                 if wxr.config.capture_etymologies:
-                    m = re.search(r"\s(\d+)$", t)
+                    m = re.search(r"\s(\d+(\.\d+)?)$", t)
                     if m:
-                        etym_data["etymology_number"] = int(m.group(1))
+                        etym_data["etymology_number"] = m.group(1)
                     parse_etymology(etym_data, node)
             elif t == DESCENDANTS_TITLE and wxr.config.capture_descendants:
                 data = select_data()

--- a/src/wiktextract/extractor/en/type_utils.py
+++ b/src/wiktextract/extractor/en/type_utils.py
@@ -203,7 +203,7 @@ class WordData(TypedDict, total=False):
     derived: list[LinkageData]
     descendants: list[DescendantData]
     etymology_examples: list[EtymologyExample]
-    etymology_number: int
+    etymology_number: str
     etymology_templates: list[TemplateData]
     etymology_text: str
     form_of: list[FormOf]

--- a/src/wiktextract/extractor/template/models.py
+++ b/src/wiktextract/extractor/template/models.py
@@ -221,7 +221,7 @@ class WordEntry(__EXAMPLE_TEMPLATE__BaseModel):
         "etymology section.",
     )
     # For sections like "Etymology 1"
-    # etymology_number: int = -1
+    # etymology_number: str = "-1"
     senses: list[Sense] = []
     title: str = Field(default="", description="Redirect page source title")
     redirect: str = Field(default="", description="Redirect page target title")

--- a/src/wiktextract/wiktionary.py
+++ b/src/wiktextract/wiktionary.py
@@ -446,9 +446,14 @@ def check_json_data(wxr: WiktextractContext, dt: dict) -> None:
     check_tags(wxr, dt, word, lang, pos, dt)
     check_str_fields(wxr, dt, word, lang, pos, dt, ["etymology_text"])
     num = dt.get("etymology_number")
-    if num is not None and not isinstance(num, int):
+    if num is not None and not isinstance(num, str):
         check_error(
-            wxr, dt, word, lang, pos, '"etymology_number" must be an int'
+            wxr,
+            dt,
+            word,
+            lang,
+            pos,
+            '"etymology_number" has been changed to str',
         )
     # Check that certain fields, if present, contain lists of dicts
     if not check_dict_list_fields(


### PR DESCRIPTION
Fixes #1619 

Due to the existence of etymology headers with
non-integer number values ("Etymology 1.1"), we
have decided to change the `etymology_number` field from `int` to `str`.

This is unlikely to cause major issues, but apologies if it does; doing math with a section identifier
would be a bit weird, except maybe comparisons.

Currently, only English edition wiktextract actually populates `etymology_number` with anything, and
it extracts / uses the pattern `\d+(\.\d+)?"
("1", "1.1", "11.11")