### PR TITLE
[pt] Handly very simple badly formatted pronunciation sections

### DIFF
--- a/src/wiktextract/extractor/pt/pronunciation.py
+++ b/src/wiktextract/extractor/pt/pronunciation.py
@@ -1,3 +1,5 @@
+import re
+
 from wikitextprocessor.parser import (
     LEVEL_KIND_FLAGS,
     LevelNode,
@@ -47,6 +49,12 @@ def extract_pronunciation_list_item(
 ) -> list[Sound]:
     raw_tags = parent_raw_tags[:]
     sounds = []
+    if len(list_item.children) == 1 and isinstance(list_item.children[0], str):
+        # Match minimal sections `  /ipa/  ` or ` [ipa]  `
+        if re.match(r"\s*(/[^/]+/|\[[^][]+\])\s*$", list_item.children[0]):
+            sound_value = clean_node(wxr, None, list_item.children[0]).strip()
+            sound = Sound(ipa=sound_value)
+            return [sound]
     for index, node in enumerate(list_item.children):
         if isinstance(node, str) and ":" in node:
             raw_tag = clean_node(wxr, None, list_item.children[:index])

--- a/tests/test_pt_sound.py
+++ b/tests/test_pt_sound.py
@@ -26,7 +26,7 @@ class TestPtSound(TestCase):
     def tearDown(self):
         self.wxr.wtp.close_db_conn()
 
-    def test_subsection(self):
+    def test_subsection1(self):
         self.wxr.wtp.add_page("Predefinição:-pt-", 10, "Português")
         self.wxr.wtp.add_page(
             "Predefinição:pronúncia",
@@ -63,4 +63,61 @@ class TestPtSound(TestCase):
         )
         self.assertEqual(
             data[0]["categories"], ["Entrada com pronúncia (Português)"]
+        )
+
+    def test_bad_formatting1(self):
+        # https://github.com/tatuylonen/wiktextract/issues/1624
+        self.wxr.wtp.add_page("Predefinição:-pt-", 10, "Português")
+        self.wxr.wtp.add_page(
+            "Predefinição:pronúncia",
+            10,
+            """<span title="Pronúncia da palavra">Pronúncia</span>[[Categoria:Entrada com pronúncia (Português)|olho]]""",
+        )
+        self.wxr.wtp.add_page("Predefinição:AFI", 10, "{{{1}}}")
+        data = parse_page(
+            self.wxr,
+            "olho",
+            """={{-pt-}}=
+==Substantivo==
+# órgão
+=={{pronúncia|pt}}==
+===Brasil===
+* [fo:]
+""",
+        )
+        self.assertEqual(
+            data[0]["sounds"],
+            [
+                {
+                    "ipa": "[fo:]",
+                },
+            ],
+        )
+
+    def test_bad_formatting2(self):
+        self.wxr.wtp.add_page("Predefinição:-pt-", 10, "Português")
+        self.wxr.wtp.add_page(
+            "Predefinição:pronúncia",
+            10,
+            """<span title="Pronúncia da palavra">Pronúncia</span>[[Categoria:Entrada com pronúncia (Português)|olho]]""",
+        )
+        self.wxr.wtp.add_page("Predefinição:AFI", 10, "{{{1}}}")
+        data = parse_page(
+            self.wxr,
+            "olho",
+            """={{-pt-}}=
+==Substantivo==
+# órgão
+=={{pronúncia|pt}}==
+===Brasil===
+* /fo:/
+""",
+        )
+        self.assertEqual(
+            data[0]["sounds"],
+            [
+                {
+                    "ipa": "/fo:/",
+                },
+            ],
         )


### PR DESCRIPTION
Fixes #1624 

If a pronunciation section is a simple string with a specific formatting (`[ipa]` or `/ipa/`), do minimal processing.