### PR TITLE
Rename to `TAGS` for consistency

### DIFF
--- a/src/wiktextract/extractor/de/flexion.py
+++ b/src/wiktextract/extractor/de/flexion.py
@@ -12,7 +12,7 @@ from wikitextprocessor.parser import (
 from ...page import clean_node
 from ...wxr_context import WiktextractContext
 from .models import Form, WordEntry
-from .tags import GRAMMATICAL_TAGS, translate_raw_tags
+from .tags import TAGS, translate_raw_tags
 
 
 def parse_flexion_page(
@@ -37,9 +37,7 @@ def parse_flexion_page(
                 section_str = clean_node(wxr, None, node.largs)
                 for word in section_str.split(" "):
                     word = word.strip(", ")
-                    if word in GRAMMATICAL_TAGS and not page_title.endswith(
-                        f":{word}"
-                    ):
+                    if word in TAGS and not page_title.endswith(f":{word}"):
                         shared_raw_tags.append(word)
                 for raw_tag in LEVEL2_TAGS:
                     if raw_tag in section_str:

--- a/src/wiktextract/extractor/de/gloss.py
+++ b/src/wiktextract/extractor/de/gloss.py
@@ -5,7 +5,7 @@ from wikitextprocessor.parser import LevelNode, NodeKind, TemplateNode, WikiNode
 from ...page import clean_node
 from ...wxr_context import WiktextractContext
 from .models import AltForm, Sense, WordEntry
-from .tags import GRAMMATICAL_TAGS, translate_raw_tags
+from .tags import TAGS, translate_raw_tags
 from .utils import extract_sense_index
 
 
@@ -181,8 +181,8 @@ def process_form_of_list_item(
                         pos_data = FORM_OF_POS_STRINGS[sense_word]
                     elif sense_word in POS_DATA:
                         pos_data = POS_DATA[sense_word]
-                    elif sense_word in GRAMMATICAL_TAGS:
-                        tr_tag = GRAMMATICAL_TAGS[sense_word]
+                    elif sense_word in TAGS:
+                        tr_tag = TAGS[sense_word]
                         if isinstance(tr_tag, str):
                             sense.tags.append(tr_tag)
                         elif isinstance(tr_tag, list):

--- a/src/wiktextract/extractor/de/tags.py
+++ b/src/wiktextract/extractor/de/tags.py
@@ -462,7 +462,7 @@ INFLECTION_TABLE_TAGS = {
     "Zählform": "count-form",
 }
 
-GRAMMATICAL_TAGS = {
+TAGS = {
     **K_TEMPLATE_TAGS,
     **GENDER_TAGS,
     **NUMBER_TAGS,
@@ -549,8 +549,8 @@ K_TEMPLATE_TOPICS = {
 def translate_raw_tags(data: WordEntry) -> None:
     raw_tags = []
     for raw_tag in data.raw_tags:
-        if raw_tag in GRAMMATICAL_TAGS:
-            tag = GRAMMATICAL_TAGS[raw_tag]
+        if raw_tag in TAGS:
+            tag = TAGS[raw_tag]
             if isinstance(tag, str) and tag not in data.tags:
                 data.tags.append(tag)
             elif isinstance(tag, list):

--- a/src/wiktextract/extractor/el/tags.py
+++ b/src/wiktextract/extractor/el/tags.py
@@ -679,7 +679,7 @@ DONTCARES = {
     "πρόσωπα πτώσεις": [],
 }
 
-tag_map: dict[str, list[str]] = {
+TAGS: dict[str, list[str]] = {
     **DONTCARES,
     **verb_table_tags_base,
     **english_tables_tags,
@@ -762,7 +762,7 @@ def translate_raw_tags(taggable: Taggable) -> None:
     """
     for raw_tag in taggable.raw_tags:
         clean_raw_tag = raw_tag.replace("\n", " ").lower()
-        tags = tag_map.get(clean_raw_tag)
+        tags = TAGS.get(clean_raw_tag)
         if tags is not None:
             for tag in tags:
                 if tag not in taggable.tags:

--- a/src/wiktextract/extractor/es/pos.py
+++ b/src/wiktextract/extractor/es/pos.py
@@ -15,7 +15,7 @@ from .inflection import process_inflect_template
 from .linkage import process_linkage_template
 from .models import AltForm, Form, Sense, WordEntry
 from .section_titles import LINKAGE_TITLES
-from .tags import ALL_TAGS, translate_raw_tags
+from .tags import TAGS, translate_raw_tags
 
 
 def extract_pos_section(
@@ -25,8 +25,8 @@ def extract_pos_section(
     section_title: str,
 ) -> None:
     for raw_tag in section_title.split():
-        if raw_tag in ALL_TAGS:
-            tr_tag = ALL_TAGS[raw_tag]
+        if raw_tag in TAGS:
+            tr_tag = TAGS[raw_tag]
             if isinstance(tr_tag, str) and tr_tag not in word_entry.tags:
                 word_entry.tags.append(tr_tag)
             elif isinstance(tr_tag, list):

--- a/src/wiktextract/extractor/es/tags.py
+++ b/src/wiktextract/extractor/es/tags.py
@@ -831,7 +831,7 @@ POS_TITLE_TAGS = {
 }
 
 
-ALL_TAGS = {
+TAGS = {
     **NUMBER_TAGS,
     **GENDER_TAGS,
     **COMPARISON_TAGS,
@@ -856,8 +856,8 @@ def translate_raw_tags(data: WordEntry | Form):
     raw_tags = []
     for raw_tag in data.raw_tags:
         lower_raw_tag = raw_tag.lower()
-        if lower_raw_tag in ALL_TAGS:
-            tr_tag = ALL_TAGS[lower_raw_tag]
+        if lower_raw_tag in TAGS:
+            tr_tag = TAGS[lower_raw_tag]
             if isinstance(tr_tag, str) and tr_tag not in data.tags:
                 data.tags.append(tr_tag)
             elif isinstance(tr_tag, list):

--- a/src/wiktextract/extractor/fr/tags.py
+++ b/src/wiktextract/extractor/fr/tags.py
@@ -542,7 +542,7 @@ ASPECT_TAGS = {
     "imperfectif": "imperfective",  # Modèle:imperfectif
 }
 
-GRAMMATICAL_TAGS: dict[str, str | list[str]] = {
+TAGS: dict[str, str | list[str]] = {
     **GENDER_TAGS,
     **NUMBER_TAGS,
     **MOOD_TAGS,
@@ -570,8 +570,8 @@ def translate_raw_tags(data: WordEntry) -> WordEntry:
     raw_tags = []
     for raw_tag in data.raw_tags:
         raw_tag_lower = raw_tag.lower()
-        if raw_tag_lower in GRAMMATICAL_TAGS:
-            tr_tag = GRAMMATICAL_TAGS[raw_tag_lower]
+        if raw_tag_lower in TAGS:
+            tr_tag = TAGS[raw_tag_lower]
             if isinstance(tr_tag, str) and tr_tag not in data.tags:
                 data.tags.append(tr_tag)
             elif isinstance(tr_tag, list):

--- a/src/wiktextract/extractor/ru/tags.py
+++ b/src/wiktextract/extractor/ru/tags.py
@@ -602,7 +602,7 @@ MORPHOLOGICAL_TEMPLATE_TAGS = {
     "возвратный": "reflexive",
 }
 
-ALL_TAGS = {
+TAGS = {
     **STYLE_TAGS,
     **GRAMMATICAL_TAGS,
     **OTHER_TAGS,
@@ -620,8 +620,8 @@ def translate_raw_tags(data: WordEntry) -> None:
     raw_tags = []
     for raw_tag in data.raw_tags:
         raw_tag_lower = raw_tag.lower()
-        if raw_tag_lower in ALL_TAGS:
-            tr_data = ALL_TAGS[raw_tag_lower]
+        if raw_tag_lower in TAGS:
+            tr_data = TAGS[raw_tag_lower]
             if isinstance(tr_data, str):
                 data.tags.append(tr_data)
             elif isinstance(tr_data, list):

--- a/src/wiktextract/extractor/simple/table.py
+++ b/src/wiktextract/extractor/simple/table.py
@@ -8,7 +8,7 @@ from wiktextract.wxr_context import WiktextractContext
 from wiktextract.wxr_logging import logger
 
 from .models import Form, WordEntry
-from .simple_tags import simple_tag_map
+from .tags import TAGS
 from .tags_utils import convert_tags
 
 # Shorthand for this file. Could be an import, but it's so simple...
@@ -111,7 +111,7 @@ def parse_pos_table(
                 )
             if len(lines) == 1:
                 # XXX do tag parsing instead of i == 0; Levenshtein.
-                if text in simple_tag_map:
+                if text in TAGS:
                     # Found something that looks like a tag.
                     if i == 0:
                         row_hdr = text

--- a/src/wiktextract/extractor/simple/tags.py
+++ b/src/wiktextract/extractor/simple/tags.py
@@ -1,6 +1,6 @@
 from wiktextract.tags import uppercase_tags, valid_tags
 
-simple_tag_map: dict[str, list[str]] = {
+TAGS: dict[str, list[str]] = {
     "no-gloss": ["no-gloss"],
     "comparative": ["comparative"],
     "Comparative": ["comparative"],
@@ -64,7 +64,7 @@ simple_tag_map: dict[str, list[str]] = {
 # extractor but also applicable to other extractors: these are the tags
 # that should be used for tagging. Can be added to when needed, but
 # often there's already an equivalent tag with a slightly different name.
-for tags in simple_tag_map.values():
+for tags in TAGS.values():
     for tag in tags:
         if tag.islower() and tag.isalpha() and tag not in valid_tags:
             assert False, f"Invalid tag in simple_tag_map: {tag}"
@@ -72,5 +72,5 @@ for tags in simple_tag_map.values():
 # uppercase_tags are specific tags with uppercase names that are for stuff
 # like locations and dialect and language names.
 for k in uppercase_tags:
-    if k not in simple_tag_map:
-        simple_tag_map[k] = [k.replace(" ", "-")]
+    if k not in TAGS:
+        TAGS[k] = [k.replace(" ", "-")]

--- a/src/wiktextract/extractor/simple/tags_utils.py
+++ b/src/wiktextract/extractor/simple/tags_utils.py
@@ -2,7 +2,7 @@ import re
 
 from .models import Sense
 from .section_titles import POS_DATA
-from .simple_tags import simple_tag_map
+from .tags import TAGS
 from .text_utils import POS_ENDING_NUMBER_RE, STRIP_PUNCTUATION
 
 # If you want to use groups in a regex meant for re.split(), you need to use the
@@ -46,8 +46,8 @@ def convert_tags(raw_tags: list[str]) -> tuple[list[str], list[str], list[str]]:
                 else:
                     pos = s.lower()
                 pposes.append(pos)
-            elif s in simple_tag_map:
-                ttags.extend(simple_tag_map[s])
+            elif s in TAGS:
+                ttags.extend(TAGS[s])
             else:
                 rtags.append(s)
         if len(ttags) > 0 or len(pposes) > 0:

--- a/src/wiktextract/extractor/zh/tags.py
+++ b/src/wiktextract/extractor/zh/tags.py
@@ -600,7 +600,7 @@ TH_PRON_TAGS = {
 }
 
 
-ALL_TAGS = {
+TAGS = {
     **GRAMMATICAL_TAGS,
     **LABEL_TAGS,
     **ZH_X_TAGS,
@@ -643,8 +643,8 @@ ALL_TAGS = {
 def translate_raw_tags(data: WordEntry) -> WordEntry:
     raw_tags = []
     for raw_tag in data.raw_tags:
-        if raw_tag in ALL_TAGS:
-            tr_tag = ALL_TAGS[raw_tag]
+        if raw_tag in TAGS:
+            tr_tag = TAGS[raw_tag]
             if isinstance(tr_tag, str) and tr_tag not in data.tags:
                 data.tags.append(tr_tag)
             elif isinstance(tr_tag, list):

--- a/tests/test_el_tags.py
+++ b/tests/test_el_tags.py
@@ -4,7 +4,7 @@ from wiktextract.extractor.el.section_titles import (
     POS_DATA,
     SUBSECTION_HEADINGS,
 )
-from wiktextract.extractor.el.tags import tag_map, topic_map
+from wiktextract.extractor.el.tags import TAGS, topic_map
 from wiktextract.tags import valid_tags
 from wiktextract.topics import valid_topics
 
@@ -16,7 +16,7 @@ class TestElTags(TestCase):
         # extractor but also applicable to other extractors: these are the tags
         # that should be used for tagging. Can be added to when needed, but
         # often there's already an equivalent tag with a slightly different name.
-        for tags in tag_map.values():
+        for tags in TAGS.values():
             for tag in tags:
                 for part in tag.split("-"):
                     if not part.isalpha() or (


### PR DESCRIPTION
Continues the work on #1664

Following the [docs](https://github.com/tatuylonen/wiktextract/blob/master/docs/new_extractor_guide.md#create-tagspy-file), the convention is:
- a `tags.py` file with a `TAGS` dictionary
- I didn't check/add annotations this time for simplicity (and because the type is straightforward as opposed to POSSubtitleData, and values can vary between `str` and `str` | `list[str]`)

Note that `sv` doesn't have any tag data anywhere, so there's nothing to be done.

The convention asks for a `TOPICS` dictionary too, but that can wait for another PR.