### PR TITLE
Rename topic maps to `TOPICS`

### DIFF
--- a/src/wiktextract/extractor/de/tags.py
+++ b/src/wiktextract/extractor/de/tags.py
@@ -545,6 +545,10 @@ K_TEMPLATE_TOPICS = {
     "Elektrotechnik": "electrical-engineering",
 }
 
+TOPICS = {
+    **K_TEMPLATE_TOPICS,
+}
+
 
 def translate_raw_tags(data: WordEntry) -> None:
     raw_tags = []
@@ -557,8 +561,8 @@ def translate_raw_tags(data: WordEntry) -> None:
                 for t in tag:
                     if t not in data.tags:
                         data.tags.append(t)
-        elif raw_tag in K_TEMPLATE_TOPICS and hasattr(data, "topics"):
-            topic = K_TEMPLATE_TOPICS[raw_tag]
+        elif raw_tag in TOPICS and hasattr(data, "topics"):
+            topic = TOPICS[raw_tag]
             if isinstance(topic, str) and topic not in data.topics:
                 data.topics.append(topic)
             elif isinstance(topic, dict) and topic["topic"] not in data.topics:

--- a/src/wiktextract/extractor/de/tags.py
+++ b/src/wiktextract/extractor/de/tags.py
@@ -556,7 +556,8 @@ def _append(container: list[str], value: str | list[str]) -> None:
             container.append(value)
     elif isinstance(value, list):
         for t in value:
-            _append(container, t)
+            if t not in container:
+                container.append(t)
 
 
 def translate_raw_tags(data: WordEntry) -> None:

--- a/src/wiktextract/extractor/de/tags.py
+++ b/src/wiktextract/extractor/de/tags.py
@@ -499,7 +499,7 @@ K_TEMPLATE_TOPICS = {
     "Systematik": "systematics",
     "Zoologie": "zoology",
     "Seefahrt": "seafaring",
-    "Soldatensprache": {"topic": "military", "tag": "slang"},
+    "Soldatensprache": {"tags": "slang", "topics": "military"},
     "Botanik": "botany",
     "Marine": "navy",
     "Informationstechnologie": "computing",
@@ -550,25 +550,28 @@ TOPICS = {
 }
 
 
+def _append(container: list[str], value: str | list[str]) -> None:
+    if isinstance(value, str):
+        if value not in container:
+            container.append(value)
+    elif isinstance(value, list):
+        for t in value:
+            _append(container, t)
+
+
 def translate_raw_tags(data: WordEntry) -> None:
     raw_tags = []
     for raw_tag in data.raw_tags:
         if raw_tag in TAGS:
             tag = TAGS[raw_tag]
-            if isinstance(tag, str) and tag not in data.tags:
-                data.tags.append(tag)
-            elif isinstance(tag, list):
-                for t in tag:
-                    if t not in data.tags:
-                        data.tags.append(t)
+            _append(data.tags, tag)
         elif raw_tag in TOPICS and hasattr(data, "topics"):
             topic = TOPICS[raw_tag]
-            if isinstance(topic, str) and topic not in data.topics:
-                data.topics.append(topic)
-            elif isinstance(topic, dict) and topic["topic"] not in data.topics:
-                data.topics.append(topic["topic"])
-                if topic["tag"] not in data.tags:
-                    data.tags.append(topic["tag"])
+            if isinstance(topic, str):
+                _append(data.topics, topic)
+            elif isinstance(topic, dict):
+                _append(data.tags, topic["tags"])
+                _append(data.topics, topic["topics"])
         else:
             raw_tags.append(raw_tag)
     data.raw_tags = raw_tags

--- a/src/wiktextract/extractor/el/tags.py
+++ b/src/wiktextract/extractor/el/tags.py
@@ -476,7 +476,7 @@ other_tags = {
     "αττικός τύπος": ["Attic"],
 }
 
-topic_map: dict[str, list[str]] = {
+TOPICS: dict[str, list[str]] = {
     "επάγγελμα": ["business"],  # really profession
     "οικονομία": ["business"],  # really economy
     "λογιστική": ["accounting"],
@@ -768,7 +768,7 @@ def translate_raw_tags(taggable: Taggable) -> None:
                 if tag not in taggable.tags:
                     taggable.tags.append(tag)
         else:
-            topics = topic_map.get(clean_raw_tag)
+            topics = TOPICS.get(clean_raw_tag)
             if topics is not None:
                 for topic in topics:
                     if topic not in taggable.topics:

--- a/src/wiktextract/extractor/es/tags.py
+++ b/src/wiktextract/extractor/es/tags.py
@@ -851,6 +851,10 @@ TAGS = {
     "sin género": ["masculine", "feminine"],
 }
 
+TOPICS = {
+    **CSEM_TOPICS,
+}
+
 
 def translate_raw_tags(data: WordEntry | Form):
     raw_tags = []
@@ -864,8 +868,8 @@ def translate_raw_tags(data: WordEntry | Form):
                 for tag in tr_tag:
                     if tag not in data.tags:
                         data.tags.append(tag)
-        elif lower_raw_tag in CSEM_TOPICS and hasattr(data, "topics"):
-            data.topics.append(CSEM_TOPICS[lower_raw_tag])
+        elif lower_raw_tag in TOPICS and hasattr(data, "topics"):
+            data.topics.append(TOPICS[lower_raw_tag])
         elif raw_tag in AMBITO_TAGS:
             tr_tag = AMBITO_TAGS[raw_tag]
             if isinstance(tr_tag, str) and tr_tag not in data.tags:

--- a/src/wiktextract/extractor/fr/tags.py
+++ b/src/wiktextract/extractor/fr/tags.py
@@ -576,7 +576,8 @@ def _append(container: list[str], value: str | list[str]) -> None:
             container.append(value)
     elif isinstance(value, list):
         for t in value:
-            _append(container, t)
+            if t not in container:
+                container.append(t)
 
 
 def translate_raw_tags(data: WordEntry) -> WordEntry:

--- a/src/wiktextract/extractor/fr/tags.py
+++ b/src/wiktextract/extractor/fr/tags.py
@@ -3,6 +3,7 @@
 # List of templates:
 # https://fr.wiktionary.org/wiki/Wiktionnaire:Liste_de_tous_les_modèles
 from .models import WordEntry
+from .topics import SLANG_TOPICS, TOPIC_TAGS
 
 # https://en.wikipedia.org/wiki/Grammatical_gender
 GENDER_TAGS: dict[str, str | list[str]] = {
@@ -563,10 +564,13 @@ TAGS: dict[str, str | list[str]] = {
     **ASPECT_TAGS,
 }
 
+TOPICS = {
+    **TOPIC_TAGS,
+    **SLANG_TOPICS,
+}
+
 
 def translate_raw_tags(data: WordEntry) -> WordEntry:
-    from .topics import SLANG_TOPICS, TOPIC_TAGS
-
     raw_tags = []
     for raw_tag in data.raw_tags:
         raw_tag_lower = raw_tag.lower()
@@ -578,12 +582,14 @@ def translate_raw_tags(data: WordEntry) -> WordEntry:
                 for t in tr_tag:
                     if t not in data.tags:
                         data.tags.append(t)
-        elif hasattr(data, "topics") and raw_tag_lower in TOPIC_TAGS:
-            data.topics.append(TOPIC_TAGS[raw_tag_lower])
-        elif hasattr(data, "topics") and raw_tag_lower in SLANG_TOPICS:
-            data.topics.append(SLANG_TOPICS[raw_tag_lower])
-            if "slang" not in data.tags:
-                data.tags.append("slang")
+        elif raw_tag_lower in TOPICS and hasattr(data, "topics"):
+            topic = TOPICS[raw_tag_lower]
+            if isinstance(topic, str) and topic not in data.topics:
+                data.topics.append(topic)
+            elif isinstance(topic, dict) and topic["topic"] not in data.topics:
+                data.topics.append(topic["topic"])
+                if topic["tag"] not in data.tags:
+                    data.tags.append(topic["tag"])
         else:
             raw_tags.append(raw_tag)
     data.raw_tags = raw_tags

--- a/src/wiktextract/extractor/fr/tags.py
+++ b/src/wiktextract/extractor/fr/tags.py
@@ -570,26 +570,29 @@ TOPICS = {
 }
 
 
+def _append(container: list[str], value: str | list[str]) -> None:
+    if isinstance(value, str):
+        if value not in container:
+            container.append(value)
+    elif isinstance(value, list):
+        for t in value:
+            _append(container, t)
+
+
 def translate_raw_tags(data: WordEntry) -> WordEntry:
     raw_tags = []
     for raw_tag in data.raw_tags:
         raw_tag_lower = raw_tag.lower()
         if raw_tag_lower in TAGS:
             tr_tag = TAGS[raw_tag_lower]
-            if isinstance(tr_tag, str) and tr_tag not in data.tags:
-                data.tags.append(tr_tag)
-            elif isinstance(tr_tag, list):
-                for t in tr_tag:
-                    if t not in data.tags:
-                        data.tags.append(t)
+            _append(data.tags, tr_tag)
         elif raw_tag_lower in TOPICS and hasattr(data, "topics"):
             topic = TOPICS[raw_tag_lower]
-            if isinstance(topic, str) and topic not in data.topics:
-                data.topics.append(topic)
-            elif isinstance(topic, dict) and topic["topic"] not in data.topics:
-                data.topics.append(topic["topic"])
-                if topic["tag"] not in data.tags:
-                    data.tags.append(topic["tag"])
+            if isinstance(topic, str):
+                _append(data.topics, topic)
+            elif isinstance(topic, dict):
+                _append(data.tags, topic["tags"])
+                _append(data.topics, topic["topics"])
         else:
             raw_tags.append(raw_tag)
     data.raw_tags = raw_tags

--- a/src/wiktextract/extractor/fr/topics.py
+++ b/src/wiktextract/extractor/fr/topics.py
@@ -302,7 +302,7 @@ TOPIC_TAGS: dict[str, str] = {
     "transport": "transport",
 }
 
-SLANG_TOPICS = {
+_SLANG_TOPICS = {
     # https://fr.wiktionary.org/wiki/Modèle:argot
     "argot scolaire": "school",
     "argot polytechnicien": "polytechnicien",
@@ -314,4 +314,8 @@ SLANG_TOPICS = {
     "argot des voleurs": "thieves",
     "argot des gadz’arts": "Gadz'Arts",
     "langage sms": "SMS",
+}
+
+SLANG_TOPICS = {
+    k: {"tag": "slang", "topic": v} for k, v in _SLANG_TOPICS.items()
 }

--- a/src/wiktextract/extractor/fr/topics.py
+++ b/src/wiktextract/extractor/fr/topics.py
@@ -317,5 +317,5 @@ _SLANG_TOPICS = {
 }
 
 SLANG_TOPICS = {
-    k: {"tag": "slang", "topic": v} for k, v in _SLANG_TOPICS.items()
+    k: {"tags": "slang", "topics": v} for k, v in _SLANG_TOPICS.items()
 }

--- a/src/wiktextract/extractor/it/tags.py
+++ b/src/wiktextract/extractor/it/tags.py
@@ -270,6 +270,10 @@ TAGS = {
     **OTHER_TAGS,
 }
 
+TOPICS = {
+    **TERM_TEMPLATE_TOPICS,
+}
+
 
 def translate_raw_tags(data: WordEntry) -> None:
     raw_tags = []
@@ -280,8 +284,8 @@ def translate_raw_tags(data: WordEntry) -> None:
                 data.tags.append(tr_tag)
             elif isinstance(tr_tag, list):
                 data.tags.extend(tr_tag)
-        elif raw_tag in TERM_TEMPLATE_TOPICS and hasattr(data, "topics"):
-            data.topics.append(TERM_TEMPLATE_TOPICS[raw_tag])
+        elif raw_tag in TOPICS and hasattr(data, "topics"):
+            data.topics.append(TOPICS[raw_tag])
         else:
             raw_tags.append(raw_tag)
     data.raw_tags = raw_tags

--- a/src/wiktextract/extractor/zh/tags.py
+++ b/src/wiktextract/extractor/zh/tags.py
@@ -639,6 +639,10 @@ TAGS = {
     "新西蘭": "New-Zealand",
 }
 
+TOPICS = {
+    **LABEL_TOPICS,
+}
+
 
 def translate_raw_tags(data: WordEntry) -> WordEntry:
     raw_tags = []
@@ -649,8 +653,8 @@ def translate_raw_tags(data: WordEntry) -> WordEntry:
                 data.tags.append(tr_tag)
             elif isinstance(tr_tag, list):
                 data.tags.extend(tr_tag)
-        elif raw_tag in LABEL_TOPICS and hasattr(data, "topics"):
-            data.topics.append(LABEL_TOPICS[raw_tag])
+        elif raw_tag in TOPICS and hasattr(data, "topics"):
+            data.topics.append(TOPICS[raw_tag])
         elif raw_tag not in raw_tags:
             raw_tags.append(raw_tag)
     data.raw_tags = raw_tags

--- a/tests/test_de_tags.py
+++ b/tests/test_de_tags.py
@@ -1,0 +1,30 @@
+import unittest
+
+from wikitextprocessor import Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.de.models import Sense
+from wiktextract.extractor.de.tags import translate_raw_tags
+from wiktextract.wxr_context import WiktextractContext
+
+
+class TestDEPage(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="de"),
+            WiktionaryConfig(
+                dump_file_lang_code="de",
+                capture_language_codes=None,
+            ),
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def test_de_recursive_topic(self) -> None:
+        sense = Sense(raw_tags=["Soldatensprache"])
+        translate_raw_tags(sense)  # type: ignore
+        self.assertEqual(sense.tags, ["slang"])
+        self.assertEqual(sense.topics, ["military"])

--- a/tests/test_el_tags.py
+++ b/tests/test_el_tags.py
@@ -4,7 +4,7 @@ from wiktextract.extractor.el.section_titles import (
     POS_DATA,
     SUBSECTION_HEADINGS,
 )
-from wiktextract.extractor.el.tags import TAGS, topic_map
+from wiktextract.extractor.el.tags import TAGS, TOPICS
 from wiktextract.tags import valid_tags
 from wiktextract.topics import valid_topics
 
@@ -39,7 +39,7 @@ class TestElTags(TestCase):
                     self.assertFalse(f"Invalid tag in tag_map: {tag=}")
 
     def test_validate_topics(self) -> None:
-        for topics in topic_map.values():
+        for topics in TOPICS.values():
             for topic in topics:
                 for part in topic.split("-"):
                     if not part.isalpha() or (


### PR DESCRIPTION
Closes #1664

There are still inconsistencies in the types, but this should be enough for the groundwork.

#1667 but for `TOPICS`

I decided to add proxies (for `TAGS` we never did this and opted for flat renames), to preserve the extraction provenance. It also allows to not move big dictionaries for the two or three editions that have their topics map elsewhere (in `topics.py` etc.)

French is tricky because it's the only edition that has a non-trivial logic for topics. I followed the German logic of translate_raw_tags, which is:
```py
def translate_raw_tags(data: WordEntry) -> None:
    raw_tags = []
    for raw_tag in data.raw_tags:
        if raw_tag in TAGS:
            tag = TAGS[raw_tag]
            if isinstance(tag, str) and tag not in data.tags:
                data.tags.append(tag)
            elif isinstance(tag, list):
                for t in tag:
                    if t not in data.tags:
                        data.tags.append(t)
        elif raw_tag in TOPICS and hasattr(data, "topics"):
            topic = TOPICS[raw_tag]
            if isinstance(topic, str) and topic not in data.topics:
                data.topics.append(topic)
            elif isinstance(topic, dict) and topic["topic"] not in data.topics:
                data.topics.append(topic["topic"])
                if topic["tag"] not in data.tags:
                    data.tags.append(topic["tag"])
        else:
            raw_tags.append(raw_tag)
    data.raw_tags = raw_tags
  ```

adapted to the lower cast for that edition. It required fiddling with SLANG_TOPICS to make the values dictionaries, which is done at times in other editions.
