### PR TITLE
[ja] Resolve "呉音=*" in `ja-kanji` 

### DIFF
--- a/src/wiktextract/extractor/ja/kanji.py
+++ b/src/wiktextract/extractor/ja/kanji.py
@@ -32,22 +32,44 @@ Kun'yomi (訓読み); native Japanese readings (hiragana):
 """
 
 
+def _parse_readings(raw: str) -> list[str]:
+    return [
+        r
+        for raw_r in raw.split(",")
+        if (r := re.sub(r"[<;/].*$", "", raw_r).strip())
+    ]
+
+
 def extract_ja_kanji(
     wxr: WiktextractContext, base_data: WordEntry, t_node: TemplateNode
 ) -> None:
     # https://ja.wiktionary.org/wiki/テンプレート:ja-kanji
     # First collect 常用 (joyo) readings (readings in active use)
     # it mixes on'yomi (katakana) and kun'yomi (hiragana)
+    #
+    # We can find 呉音=*, meaning the reading is the same as the kan-on 漢音
     joyo = set()
     joyo_value = t_node.template_parameters.get("常用", "")
     if joyo_value:
         joyo_reading = clean_node(wxr, base_data, joyo_value)
-        for r in joyo_reading.split(","):
-            r = re.sub(r"[<;/].*$", "", r).strip()
-            if r:
-                joyo.add(r)
+        for r in _parse_readings(joyo_reading):
+            joyo.add(r)
 
-    # Then extract all readings, tagging joyo ones accordingly
+    # Collect kan-on readings first so 呉音=* can reference them
+    # (we can't repeat the previous logic due to numbering: 漢音1=, 漢音2=)
+    kan_on_readings: list[str] = []
+    for param, value in t_node.template_parameters.items():
+        if not isinstance(param, str):
+            continue
+        base_param = re.sub(r"\d+$", "", param)
+        reading_type = JA_KANJI_TEMPLATE_PARAMS.get(base_param)
+        if reading_type == "kan-on":
+            raw = clean_node(wxr, base_data, value)
+            for r in _parse_readings(raw):
+                kan_on_readings.append(r)
+
+    # Then extract the remaining readings to append them, tagging joyo ones
+    # accordingly and resolving if necessary.
     for param, value in t_node.template_parameters.items():
         if not isinstance(param, str):
             continue
@@ -55,11 +77,13 @@ def extract_ja_kanji(
         reading_type = JA_KANJI_TEMPLATE_PARAMS.get(base_param)
         if reading_type is None:
             continue
-        reading = clean_node(wxr, base_data, value)
-        if not reading:
-            continue
-        for r in reading.split(","):
-            r = re.sub(r"[<;/].*$", "", r).strip()
+        raw = clean_node(wxr, base_data, value)
+        readings = (
+            kan_on_readings
+            if (reading_type == "go-on" and raw.strip() == "*")
+            else _parse_readings(raw)
+        )
+        for r in readings:
             tags = [reading_type]
             if r in joyo:
                 tags.append("joyo")

--- a/tests/test_ja_kanji.py
+++ b/tests/test_ja_kanji.py
@@ -67,7 +67,7 @@ class TestExtractJaKanji(unittest.TestCase):
         )
 
     def test_extract_ja_kanji_3(self) -> None:
-        # https://ja.wiktionary.org/wiki/文#日本語
+        # https://ja.wiktionary.org/wiki/春#日本語
         data = self._extract_ja_kanji(
             "{{ja-kanji|常用=シュン,はる|施策=教育:2|呉音=*|漢音=シュン|訓=はる}}"
         )
@@ -75,7 +75,7 @@ class TestExtractJaKanji(unittest.TestCase):
         self.assertEqual(
             data.forms,
             [
-                Form(form="*", tags=["transliteration", "go-on"]),
+                Form(form="シュン", tags=["transliteration", "go-on", "joyo"]),
                 Form(form="シュン", tags=["transliteration", "kan-on", "joyo"]),
                 Form(form="はる", tags=["transliteration", "kun", "joyo"]),
             ],

--- a/tests/test_ja_kanji.py
+++ b/tests/test_ja_kanji.py
@@ -65,3 +65,18 @@ class TestExtractJaKanji(unittest.TestCase):
                 Form(form="かざ-る", tags=["transliteration", "kun"]),
             ],
         )
+
+    def test_extract_ja_kanji_3(self) -> None:
+        # https://ja.wiktionary.org/wiki/文#日本語
+        data = self._extract_ja_kanji(
+            "{{ja-kanji|常用=シュン,はる|施策=教育:2|呉音=*|漢音=シュン|訓=はる}}"
+        )
+        print(data.forms)
+        self.assertEqual(
+            data.forms,
+            [
+                Form(form="*", tags=["transliteration", "go-on"]),
+                Form(form="シュン", tags=["transliteration", "kan-on", "joyo"]),
+                Form(form="はる", tags=["transliteration", "kun", "joyo"]),
+            ],
+        )


### PR DESCRIPTION
It's documented here: https://ja.wiktionary.org/wiki/%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88:ja-kanji

> 呉音が漢音に共通する場合、呉音=*と記述できます。

that 呉音=* resolves to whatever value is in 漢音 (since it's a common occurrence).

This fixes that, to obtain the readings displayed here: https://ja.wiktionary.org/wiki/%E6%98%A5#Japanese

<img width="514" height="424" alt="image" src="https://github.com/user-attachments/assets/cbdd9b06-39f3-4e2d-b717-cb5374628c97" />

---

I added the test first, before the changes, for easier visualization (that test passed at that point, but ofc the result was not ideal).
