### PR TITLE
[en] Add etymology templates in head to `etymology_templates`

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -277,6 +277,17 @@ HEAD_TAG_RE = re.compile(
 # data for later.
 WORD_LEVEL_HEAD_TEMPLATES = {"term-label", "tlb"}
 
+# Annoying templates that should be in etymology sections, but sometimes
+# are thrown in heads because the etymology section is missing, like at
+# the oldest level of a reconstruction: see wiktextract#1658
+ETYMOLOGY_TEMPLATES_IN_HEADS = {
+    "etymon",
+}
+
+PROBLEMATIC_TEMPLATES_CLUMP = (
+    WORD_LEVEL_HEAD_TEMPLATES | ETYMOLOGY_TEMPLATES_IN_HEADS
+)
+
 FLOATING_TABLE_TEMPLATES: set[str] = {
     # az-suffix-form creates a style=floatright div that is otherwise
     # deleted; if it is not pre-expanded, we can intercept the template
@@ -1544,7 +1555,7 @@ def parse_language(
                 data_append(pos_data, "tags", "romanization")
         if (
             HEAD_TAG_RE.search(name) is not None
-            or name in WORD_LEVEL_HEAD_TEMPLATES
+            or name in PROBLEMATIC_TEMPLATES_CLUMP
         ):
             args_ht = clean_template_args(wxr, ht)
             cleaned_expansion = clean_node(wxr, None, expansion)
@@ -1553,7 +1564,10 @@ def parse_language(
                 "args": args_ht,
                 "expansion": cleaned_expansion,
             }
-            data_append(pos_data, "head_templates", dt)
+            if name in ETYMOLOGY_TEMPLATES_IN_HEADS:
+                data_append(pos_data, "etymology_templates", dt)
+            else:
+                data_append(pos_data, "head_templates", dt)
             if name in WORD_LEVEL_HEAD_TEMPLATES:
                 term_label_templates.append(dt)
                 # Squash these, their tags are applied to the whole word,

--- a/tests/test_en_head.py
+++ b/tests/test_en_head.py
@@ -1476,7 +1476,6 @@ class HeadTests(unittest.TestCase):
 """
         )
         langret = parse_language(self.wxr, parsed.children[0], "English", "en")
-        print(langret)
         self.assertEqual(self.wxr.wtp.warnings, [])
         self.assertEqual(self.wxr.wtp.debugs, [])
         self.assertEqual(len(langret[0]["forms"]), 1)
@@ -1486,4 +1485,40 @@ class HeadTests(unittest.TestCase):
                 "tags": ["ergative"],
                 "form": "testpagoo",
             },
+        )
+
+    def test_etymon_in_head(self):
+        self.wxr.wtp.add_page(
+            "Template:etymon",
+            10,
+            "<span></span>",  # can't add empty page
+        )
+        self.wxr.wtp.add_page(
+            "Template:ine-root",
+            10,
+            """<span class="headword-line"><strong class="Latn headword" lang="ine-pro">&#42;bʰeh₂-</strong> (<i>imperfective</i>)</span>[[Category:Proto-Indo-European lemmas|B¯HEH2-]][[Category:Proto-Indo-European roots|B¯HEH2-]][[Category:Proto-Indo-European CeH-shaped roots|B¯HEH2-]][[Category:Proto-Indo-European imperfective roots|B¯HEH2-]][[Category:Proto-Indo-European entries with incorrect language header|B¯HEH2-]][[Category:Pages with entries|BʰEH₂-]][[Category:Pages with 1 entry|BʰEH₂-]]""",
+        )
+        parsed = self.wxr.wtp.parse(
+            """==Proto-Indo-European==
+
+===Root 1===
+{{etymon|ine-pro|id=shine|pos=root}}
+{{ine-root|impf}}
+
+# to [[shine]], glow [[light]]
+"""
+        )
+        langret = parse_language(
+            self.wxr, parsed.children[0], "Proto-Indo-European", "ine-pro"
+        )
+        self.assertEqual(len(langret[0]["forms"]), 1)
+        self.assertEqual(
+            langret[0]["etymology_templates"],
+            [
+                {
+                    "name": "etymon",
+                    "args": {"1": "ine-pro", "id": "shine", "pos": "root"},
+                    "expansion": "",
+                }
+            ],
         )


### PR DESCRIPTION
Fixes #1658