### PR TITLE
[en] Suppress template which was redirected to a previously suppressed template

### DIFF
--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -369,6 +369,9 @@ PANEL_TEMPLATES: set[str] = {
     "French possessive adjectives",
     "French possessive pronouns",
     "Han etym",
+    "Han etyl",  # this redirects to Han etym and would cause Lua errors,
+                 # and I don't know why, but I'm putting it here because
+                 # we should be ignoring it anyhow.
     "Japanese demonstratives",
     "Latn-script",
     "LDL",

--- a/src/wiktextract/extractor/en/page.py
+++ b/src/wiktextract/extractor/en/page.py
@@ -1693,7 +1693,6 @@ def parse_language(
                     isinstance(node, TemplateNode)
                     and node.template_name == "vi-readings"
                 ):
-                    print(node.template_parameters)
                     for parameter, tag in (
                         ("hanviet", "han-viet-reading"),
                         ("nom", "nom-reading"),


### PR DESCRIPTION
See later parts #1646 

I thought this was a deep and subtle bug in wikitextprocessor, but it turned out to be super dumb.

We have a template that is suppressed because it's a "panel template" that is turned into an empty string in template_hander_fn, but we do not suppress one of its redirected typo versions, so that one slipped through and generated LUA errors.