### PR TITLE
[en] Add "singular-possessive" and "plural-possessive" tags

### DIFF
--- a/src/wiktextract/extractor/en/inflection.py
+++ b/src/wiktextract/extractor/en/inflection.py
@@ -135,6 +135,12 @@ title_contains_global_map = {
     "command form of": "imperative",  # a راتلل/Pashto
     "historical inflection of": "dummy-skip-this",  # kork/Norwegian Nynorsk
     "obsolete declension": "obsolete",  # März/German 20241111
+    # käyminen/Finnish 20260707
+    "first-person singular possessor": "first-person singular singular-possessive",
+    "second-person singular possessor": "second-person singular singular-possessive",
+    "first-person plural possessor": "first-person plural plural-possessive",
+    "second-person plural possessor": "second-person plural plural-possessive",
+    "third-person possessor": "third-person possessive",
 }
 for k, v in title_contains_global_map.items():
     if any(t not in valid_tags for t in v.split()):

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -5891,6 +5891,7 @@ valid_tags = {
     "plural-of-variety": "misc",  # Plural indicating different kinds of things (Arabic)
     "plural-only": "misc",  # Word only manifested in plural in this sense
     "plural-normally": "misc",  # Usually plural, but singular may be possible
+    "plural-possessive": "number",  # käymisesi vs. käymistenne
     "poetic": "misc",
     "polite": "register",  # Politeness degree of verbs etc
     "polytonic": "misc",
@@ -5990,6 +5991,7 @@ valid_tags = {
     "singular": "number",  # Number, cf. plural, dual, trial, paucal
     "singular-normally": "misc",
     "singular-only": "misc",
+    "singular-possessive": "number", # käymisesi vs. käymistenne
     "singulative": "misc",  # Individuation of a collective or mass noun, like number
     "situative": "case",  # expressing location of things in comparison with one another
     "slang": "register",


### PR DESCRIPTION
Fixes #1683 

These are useful tags in cases where you have something like the tables in Finnish entries that add tags in titles for stuff like "first-person singular possessor", while the table itself has a plainly titled "singular" or "plural" header refering to the number of acts/infinitives, which would be hard to parse otherwise.