### PR TITLE
[mediawiki-langcodes] "nrm" -> "nrf" in tests

### DIFF
--- a/tests/test_en_descendant.py
+++ b/tests/test_en_descendant.py
@@ -613,12 +613,12 @@ class TestEnDescendant(TestCase):
                                         },
                                         {
                                             "lang": "Norman",
-                                            "lang_code": "nrm",
+                                            "lang_code": "nrf",
                                             "word": "aveir",
                                         },
                                         {
                                             "lang": "Norman",
-                                            "lang_code": "nrm",
+                                            "lang_code": "nrf",
                                             "word": "aver",
                                         },
                                         {
@@ -675,12 +675,12 @@ class TestEnDescendant(TestCase):
                                         },
                                         {
                                             "lang": "Norman",
-                                            "lang_code": "nrm",
+                                            "lang_code": "nrf",
                                             "word": "aveir",
                                         },
                                         {
                                             "lang": "Norman",
-                                            "lang_code": "nrm",
+                                            "lang_code": "nrf",
                                             "word": "aver",
                                         },
                                         {
@@ -738,12 +738,12 @@ class TestEnDescendant(TestCase):
                                         },
                                         {
                                             "lang": "Norman",
-                                            "lang_code": "nrm",
+                                            "lang_code": "nrf",
                                             "word": "aveir",
                                         },
                                         {
                                             "lang": "Norman",
-                                            "lang_code": "nrm",
+                                            "lang_code": "nrf",
                                             "word": "aver",
                                         },
                                         {
@@ -801,12 +801,12 @@ class TestEnDescendant(TestCase):
                                         },
                                         {
                                             "lang": "Norman",
-                                            "lang_code": "nrm",
+                                            "lang_code": "nrf",
                                             "word": "aveir",
                                         },
                                         {
                                             "lang": "Norman",
-                                            "lang_code": "nrm",
+                                            "lang_code": "nrf",
                                             "word": "aver",
                                         },
                                         {

--- a/tests/test_ko_translation.py
+++ b/tests/test_ko_translation.py
@@ -36,7 +36,7 @@ class TestKoTranslation(TestCase):
 |
 * 노비알(nov): [[hunde]] ((수컷/암컷) 개)
 * 라트갈레어(bat-ltg): [[bārns]] (남성)
-* 노르만어(nrm): (저지어); [[même]] (남성/여성)
+* 노르만어(nrf): (저지어); [[même]] (남성/여성)
 }}""",
         )
         self.assertEqual(
@@ -65,7 +65,7 @@ class TestKoTranslation(TestCase):
                     "word": "même",
                     "tags": ["masculine", "feminine"],
                     "lang": "노르만어",
-                    "lang_code": "nrm",
+                    "lang_code": "nrf",
                 },
             ],
         )


### PR DESCRIPTION
Closes #1695 

Changed some mediawiki-langcodes generated "nrm" code strings to "nrf" as in the current implementation of mediawiki-langcodes.

There was one Korean translation test that uses the raw string "nrm" and puts in the data, although the test didn't break I've "corrected" it here. I couldn't find the original string on the Korean wiktionary.

A change to mediawiki-langcode broke our tests when I was on vacation so now my inbox is full of "kaikki regeneration process failed" e-mails. :hot_face: Tatu has wanted to have mediawiki-langcode and other outside dependencies we have vendored or something like that so that if something breaks, it doesn't break immediately for us.