### PR TITLE
[fr] Czech issues with non-standard word entry heads

### DIFF
--- a/src/wiktextract/extractor/fr/form_line.py
+++ b/src/wiktextract/extractor/fr/form_line.py
@@ -258,7 +258,13 @@ def process_conj_link_node(
         and len(page_data[-2].forms) > 0
         and page_data[-2].forms[-1].source == conj_title
     ):
-        page_data[-1].forms = page_data[-2].forms
+        if "canonical" in page_data[-2].forms[0].tags:
+            # An earlier weird head word, like "hodit se" reflexive form
+            # in hodit/Czech, should not override a later head form, either
+            # another "canonical" entry or a default nothing.
+            page_data[-1].forms.extend(page_data[-2].forms[1:])
+        else:
+            page_data[-1].forms.extend(page_data[-2].forms)
     elif conj_title.startswith("Conjugaison:"):
         extract_conjugation(wxr, page_data[-1], conj_title)
     elif conj_title.startswith("Annexe:Déclinaison en"):

--- a/src/wiktextract/extractor/fr/form_line.py
+++ b/src/wiktextract/extractor/fr/form_line.py
@@ -3,7 +3,7 @@ from wikitextprocessor.parser import HTMLNode, NodeKind, TemplateNode, WikiNode
 from ...page import clean_node
 from ...wxr_context import WiktextractContext
 from .conjugation import extract_conjugation, extract_declension_page
-from .models import Form, Sound, WordEntry
+from .models import Form, Linkage, Sound, WordEntry
 from .pronunciation import (
     ASPIRATED_H_TEMPLATES,
     PRON_TEMPLATES,
@@ -30,7 +30,11 @@ def extract_form_line(
 
     pre_template_name = ""
     first_bold = True
+    skip_iterations = 0
     for index, node in enumerate(nodes):
+        if skip_iterations > 0:
+            skip_iterations -= 1
+            continue
         if isinstance(node, TemplateNode):
             if node.template_name in IGNORE_TEMPLATES:
                 continue
@@ -105,8 +109,16 @@ def extract_form_line(
         ):
             process_form_line_bold_node(wxr, node, page_data[-1])
             first_bold = False
+        elif isinstance(node, str) and "(" in node:
+            skip_iterations, forms, related = handle_parens(
+                wxr,
+                nodes[index:],  # including this node with the "("
+            )
+            # No code for forms data implemented yet
+            # page_data[-1].forms.extend(forms)
+            page_data[-1].related.extend(related)
 
-        translate_raw_tags(page_data[-1])
+    translate_raw_tags(page_data[-1])
 
 
 def process_equiv_pour_template(
@@ -299,3 +311,50 @@ def process_form_line_bold_node(
         word_entry.original_title = wxr.wtp.title
     elif bold_str not in [wxr.wtp.title, ""]:
         word_entry.forms.append(Form(form=bold_str, tags=["canonical"]))
+
+
+def handle_parens(
+    wxr: WiktextractContext,
+    nodes: list[WikiNode | str],
+) -> tuple[int, list[Form], list[Linkage]]:
+    # Scan the line with a parenthesized block with a colon in it, like
+    # (imperfectif : posílat), and handle that; return number of nodes
+    # that the main loop should skip, if they've been processed
+    # here already, and the contents extracted.
+    end_paren = False
+    colon_i: None | int = None
+    for i, node in enumerate(nodes):
+        if isinstance(node, str):
+            stripped = node.strip()
+            if stripped.endswith(":"):
+                colon_i = i
+            if stripped.endswith(")"):
+                end_paren = True
+                break
+
+    if colon_i is None:
+        # We did not find a sensible colon
+        return 0, [], []
+
+    if not end_paren:
+        wxr.wtp.warning(
+            f"Did not find sensible end-paren? "
+            f"Start-paren context {nodes[0:2]=}",
+            sortid="form_line/handle_parens",
+        )
+        return 0, [], []
+
+    before = nodes[: colon_i + 1]
+    after = nodes[colon_i + 1 : i]
+
+    raw_tag = clean_node(wxr, None, before).strip(" \n(:")
+    target = clean_node(wxr, None, after).strip(" \n)")
+
+    # Currently implemented only detecting "related" words, like
+    # poslat/czech
+    if raw_tag and target:
+        rel = Linkage(raw_tags=[raw_tag], word=target)
+        translate_raw_tags(rel)
+        return i, [], [rel]
+
+    return 0, [], []

--- a/src/wiktextract/extractor/fr/tags.py
+++ b/src/wiktextract/extractor/fr/tags.py
@@ -2,7 +2,7 @@
 # https://fr.wiktionary.org/wiki/Annexe:Glossaire_grammatical
 # List of templates:
 # https://fr.wiktionary.org/wiki/Wiktionnaire:Liste_de_tous_les_modèles
-from .models import WordEntry
+from .models import Linkage, WordEntry
 from .topics import SLANG_TOPICS, TOPIC_TAGS
 
 # https://en.wikipedia.org/wiki/Grammatical_gender
@@ -580,7 +580,7 @@ def _append(container: list[str], value: str | list[str]) -> None:
                 container.append(t)
 
 
-def translate_raw_tags(data: WordEntry) -> WordEntry:
+def translate_raw_tags(data: WordEntry | Linkage) -> WordEntry:
     raw_tags = []
     for raw_tag in data.raw_tags:
         raw_tag_lower = raw_tag.lower()

--- a/tests/test_fr_form_line.py
+++ b/tests/test_fr_form_line.py
@@ -290,7 +290,6 @@ class TestFormLine(TestCase):
 # [[envoyer|Envoyer]].
 """,
         )
-        print(page_data[0])
         self.assertEqual(
             page_data[0]["related"],
             [{'tags': ['imperfective'], 'word': 'posílat'}],

--- a/tests/test_fr_form_line.py
+++ b/tests/test_fr_form_line.py
@@ -278,3 +278,20 @@ class TestFormLine(TestCase):
 # {{lexique|Internet|conv}} {{lien|cœur|fr|nom|dif=Cœur}}.""",
         )
         self.assertEqual(page_data[0]["word"], "<3")
+
+    def test_czech_linkage(self):
+        # Issue #1699
+        page_data = parse_page(
+            self.wxr,
+            "poslat",
+            """== {{langue|cs}} ==
+=== {{S|verbe|cs}} ===
+'''poslat''' {{pron|pɔslat|cs}} {{perfectif|cs}} (''imperfectif'' : [[posílat]]) {{conjugaison|cs}} test
+# [[envoyer|Envoyer]].
+""",
+        )
+        print(page_data[0])
+        self.assertEqual(
+            page_data[0]["related"],
+            [{'tags': ['imperfective'], 'word': 'posílat'}],
+        )

--- a/tests/test_fr_page.py
+++ b/tests/test_fr_page.py
@@ -237,3 +237,38 @@ note
                 }
             ],
         )
+
+    def test_weird_canonicals_before_normal_main_heads(self):
+        # see issue #1698
+        # If we have a distinct "canonical" form like "hodit se", it should
+        # not pollute other entries.
+        page_data = parse_page(
+            self.wxr,
+            "hodit",
+            """== {{langue|cs}} ==
+=== {{S|verbe|cs|num=1}} ===
+'''hodit se''' {{pron|ɦɔʄɪt͡sɛ|cs}} {{prnl|cs}} {{imperfectif|cs}} {{conjugaison|cs}}
+# [[convenir#fr|Convenir]], s'[[accorder]].
+
+=== {{S|verbe|cs|num=2}} ===
+'''hodit foo''' {{pron|ɦɔɟɪt|cs}} {{perfectif|cs}} (''imperfectif'' : [[házet]]) {{conjugaison|cs}}
+# [[jeter|Jeter]], [[projeter]], [[envoyer]].
+
+=== {{S|verbe|cs|num=3}} ===
+'''hodit''' {{pron|ɦɔɟɪt|cs}} {{perfectif|cs}} (''imperfectif'' : [[házet]]) {{conjugaison|cs}}
+# [[jeter|Jeter]], [[projeter]], [[envoyer]].
+""",
+        )
+        self.assertEqual(len(page_data), 3)
+        forms0, forms1 = (
+            page_data[0]["forms"],
+            page_data[1]["forms"],
+        )
+        self.assertEqual(len(forms0), 1)
+        self.assertEqual(forms0[0]["form"], "hodit se")
+        self.assertEqual(len(forms1), 1)
+        self.assertEqual(forms1[0]["form"], "hodit foo")
+        # For this test, page_data[1] doesn't have any forms data, but
+        # usually the parser would populate all of these entries with
+        # stuff from {{conjugaison}} links.
+        self.assertFalse("forms" in page_data[2])


### PR DESCRIPTION
Should fix #1698 and #1699, I'm not merging until I the weekend is over and I write at least a little test stuff.

I don't know why, but I kept on going in loops trying to figure out where the issue was in #1698, where a form was copied from an earlier entry into later ones. It seemed like magic, whoops there we go, and it took me ages to figure out where the copying was taking place, after a hunt-and-peck `print()` spree. Prints everywhere!! And then when I found it I couldn't believe I hadn't found it earlier. I need to get a mental capacity check up to see if I'm actually forty years older than I think and this office is just one of those decoy potemkin setups meant for great-grand uncle Kristian.