### PR TITLE
[es] Fix demonstrative pronoun deixis tags

### DIFF
--- a/src/wiktextract/extractor/en/inflectiondata.py
+++ b/src/wiktextract/extractor/en/inflectiondata.py
@@ -3470,6 +3470,7 @@ infl_map: dict[str, InflMapNode] = {
     "Caritive": "caritive",
     "Gerund & Past participle": ["gerund", "past participle"],
     "Pronoun": "",
+    "Demonstrative pronouns": "",  # esto/Spanish/pron
     "nominative genitive instrumental": "nominative genitive instrumental",
     "dative adverbial": "dative adverbial",
     "♂": "masculine",

--- a/src/wiktextract/tags.py
+++ b/src/wiktextract/tags.py
@@ -5716,7 +5716,7 @@ valid_tags = {
     "masculine-usually": "gender",  # m/f, but usually masculine
     "material": "misc",
     "matronymic": "misc",
-    "medial": "misc",
+    "medial": "referent",  # Between proximal and distal (esto/Spanish)
     "mediopassive": "voice",
     "meliorative": "misc",  # XXX See essere/Italian/Noun word head
     "metaphoric": "misc",

--- a/tests/test_en_inflection_es.py
+++ b/tests/test_en_inflection_es.py
@@ -2883,3 +2883,190 @@ class InflTests(unittest.TestCase):
             ],
         }
         self.assertEqual(expected, ret)
+
+    def test_Spanish_pron1(self):
+        # Demonstrative pronouns: each column is a distinct degree of
+        # deixis, so "ése" must be medial only -- not medial + proximal.
+        ret = self.xinfl("esto", "Spanish", "pron", "Declension", """
+{| class="wikitable inflection-table" style="text-align:center;"
+|-
+! colspan="2" rowspan="2" |
+! colspan="3" | Demonstrative pronouns
+|-
+! proximal
+! medial
+! distal
+|-
+! rowspan="3" | singular
+! masculine
+| <span class="Latn" lang="es">[[:éste#Spanish|éste]]</span>
+| <span class="Latn" lang="es">[[:ése#Spanish|ése]]</span>
+| <span class="Latn" lang="es">[[:aquél#Spanish|aquél]]</span>
+|-
+! feminine
+| <span class="Latn" lang="es">[[:ésta#Spanish|ésta]]</span>
+| <span class="Latn" lang="es">[[:ésa#Spanish|ésa]]</span>
+| <span class="Latn" lang="es">[[:aquélla#Spanish|aquélla]]</span>
+|-
+! neuter
+| <span class="Latn" lang="es">[[:esto#Spanish|esto]]</span>
+| <span class="Latn" lang="es">[[:eso#Spanish|eso]]</span>
+| <span class="Latn" lang="es">[[:aquello#Spanish|aquello]]</span>
+|-
+! rowspan="2" | plural
+! masculine
+| <span class="Latn" lang="es">[[:éstos#Spanish|éstos]]</span>
+| <span class="Latn" lang="es">[[:ésos#Spanish|ésos]]</span>
+| <span class="Latn" lang="es">[[:aquéllos#Spanish|aquéllos]]</span>
+|-
+! feminine
+| <span class="Latn" lang="es">[[:éstas#Spanish|éstas]]</span>
+| <span class="Latn" lang="es">[[:ésas#Spanish|ésas]]</span>
+| <span class="Latn" lang="es">[[:aquéllas#Spanish|aquéllas]]</span>
+|}
+""")
+        expected = {
+            "forms": [
+              {
+                  "form": "no-table-tags",
+                  "source": "Declension",
+                  "tags": ["table-tags"],
+              },
+              {
+                  "form": "éste",
+                  "source": "Declension",
+                  "tags": [
+                      "masculine",
+                      "proximal",
+                      "singular"
+                  ],
+              },
+              {
+                  "form": "ése",
+                  "source": "Declension",
+                  "tags": [
+                      "masculine",
+                      "medial",
+                      "singular"
+                  ],
+              },
+              {
+                  "form": "aquél",
+                  "source": "Declension",
+                  "tags": [
+                      "distal",
+                      "masculine",
+                      "singular"
+                  ],
+              },
+              {
+                  "form": "ésta",
+                  "source": "Declension",
+                  "tags": [
+                      "feminine",
+                      "proximal",
+                      "singular"
+                  ],
+              },
+              {
+                  "form": "ésa",
+                  "source": "Declension",
+                  "tags": [
+                      "feminine",
+                      "medial",
+                      "singular"
+                  ],
+              },
+              {
+                  "form": "aquélla",
+                  "source": "Declension",
+                  "tags": [
+                      "distal",
+                      "feminine",
+                      "singular"
+                  ],
+              },
+              {
+                  "form": "esto",
+                  "source": "Declension",
+                  "tags": [
+                      "neuter",
+                      "proximal",
+                      "singular"
+                  ],
+              },
+              {
+                  "form": "eso",
+                  "source": "Declension",
+                  "tags": [
+                      "medial",
+                      "neuter",
+                      "singular"
+                  ],
+              },
+              {
+                  "form": "aquello",
+                  "source": "Declension",
+                  "tags": [
+                      "distal",
+                      "neuter",
+                      "singular"
+                  ],
+              },
+              {
+                  "form": "éstos",
+                  "source": "Declension",
+                  "tags": [
+                      "masculine",
+                      "plural",
+                      "proximal"
+                  ],
+              },
+              {
+                  "form": "ésos",
+                  "source": "Declension",
+                  "tags": [
+                      "masculine",
+                      "medial",
+                      "plural"
+                  ],
+              },
+              {
+                  "form": "aquéllos",
+                  "source": "Declension",
+                  "tags": [
+                      "distal",
+                      "masculine",
+                      "plural"
+                  ],
+              },
+              {
+                  "form": "éstas",
+                  "source": "Declension",
+                  "tags": [
+                      "feminine",
+                      "plural",
+                      "proximal"
+                  ],
+              },
+              {
+                  "form": "ésas",
+                  "source": "Declension",
+                  "tags": [
+                      "feminine",
+                      "medial",
+                      "plural"
+                  ],
+              },
+              {
+                  "form": "aquéllas",
+                  "source": "Declension",
+                  "tags": [
+                      "distal",
+                      "feminine",
+                      "plural"
+                  ],
+              },
+            ],
+        }
+        self.assertEqual(expected, ret)


### PR DESCRIPTION
The Spanish demonstrative pronoun table (`{{es-demonstrativepronouns}}`, on
`esto`, `eso`, `ese`, `ésta` and others) comes out wrong in two independent
ways. Live today, from
[esto.jsonl](https://kaikki.org/dictionary/Spanish/meaning/e/es/esto.jsonl):

```
éste    ['error-unrecognized-form', 'masculine', 'proximal', 'singular']
ése     ['error-unrecognized-form', 'masculine', 'medial', 'proximal', 'singular']
aquél   ['distal', 'error-unrecognized-form', 'masculine', 'singular']
```

**1. `"Demonstrative pronouns"` is missing from `infl_map`.** It is the table's
spanning title header, so it is unrecognized and all 15 cells pick up
`error-unrecognized-form`.

**2. `ése` is tagged both `medial` and `proximal`** — mutually exclusive
degrees of deixis. This one is silent: no error tag, the data just says the
word is simultaneously near and mid. It affects `ése`, `ésa`, `eso`, `ésos`,
`ésas`.

## Why (2) happens

`proximal` is declared with `colspan="1"` but reaches the `medial` column:

```
row=1 start=2 colspans=2 tagsets=[('proximal',)]   <- widened over medial
row=1 start=3 colspans=1 tagsets=[('medial',)]      new_cats={'misc'}
COMPUTE_COLTAGS 3 1: [('medial', 'proximal')]
```

A header stops a neighbour expanding rightward over it only when their tag
categories overlap — `referent` is in `hdr_expand_first`, `misc` is in
`hdr_expand_cont`. `valid_tags["medial"]` was `"misc"` while `proximal` and
`distal` are `"referent"`, so `distal` displaced `proximal` and `medial` did
not. Minimal tables confirm it:

| headers | middle cell |
|---|---|
| `proximal / medial / distal` | `medial, proximal` ← leak |
| `proximal / distal / distal` | `distal` |
| `proximal / feminine / distal` | `feminine, proximal` ← same leak, `gender` |

Medial is the middle term of the proximal/medial/distal system, so `referent`
looks like its right category. The commit that set it
(4655798e, 2021) describes itself as "tag category definitions in valid_tags
(somewhat incomplete)", so I read this as an omission rather than a decision —
please correct me if `medial` is carrying another sense I have missed.

## Blast radius

Deliberately narrow, since this changes a global table:

- The category value is only ever *read* by the `en` extractor
  (`inflection.py`, `form_descriptions.py`). `el`, `template` and `simple`
  only test membership (`tag not in valid_tags`), so they are unaffected.
- Exactly one `infl_map` header emits `medial`, so only three-way deixis
  tables can change.
- Swedish already overrides `hdr_expand_cont` to `{degree, polarity}`, which
  excludes `misc`, so it never hit this.

## After

```
éste    ['masculine', 'proximal', 'singular']
ése     ['masculine', 'medial', 'singular']
aquél   ['distal', 'masculine', 'singular']
```

`make test`: 1788 passing (1787 before, plus `test_Spanish_pron1` covering the
real expanded table).

While finding this I scanned dumps for `error-unrecognized-form` as a defect
signal; German still has a cluster of them (`sein`/`Ihr` as determiners, and
the pronominal adverbs `worin`/`darin`/`hierin` on ten prepositions). Happy to
look at those separately if they would be welcome.
