### PR TITLE
[fix] Balance apostrophes to prevent zero length bold offsets

### DIFF
--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -439,3 +439,18 @@ class CleanTests(unittest.TestCase):
     def test_html_numeric_character(self):
         # https://de.wiktionary.org/wiki/Sonne
         self.assertEqual(clean_value(self.wxr, "[[&#x2609;]]"), "☉")
+
+    def test_unbalanced_apostrophes(self):
+        # '''word''. 
+        # MediaWiki resolves this by giving one apostrophe back to the text.
+        # https://de.wiktionary.org/wiki/orient
+        self.assertEqual(
+            clean_value(self.wxr, "El sol surt per l'''orient.''"),
+            "El sol surt per l'orient.",
+        )
+        # balanced markup is unaffected
+        # https://de.wiktionary.org/wiki/lakto
+        self.assertEqual(
+            clean_value(self.wxr, "Ili trinkas bongustan '''lakton.'''"),
+            "Ili trinkas bongustan lakton.",
+        )

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -1,6 +1,11 @@
 import unittest
 
-from wiktextract.extractor.share import split_senseids
+from wikitextprocessor import NodeKind, Wtp
+
+from wiktextract.config import WiktionaryConfig
+from wiktextract.extractor.share import calculate_bold_offsets, split_senseids
+from wiktextract.page import clean_node
+from wiktextract.wxr_context import WiktextractContext
 
 
 class TestShare(unittest.TestCase):
@@ -22,3 +27,30 @@ class TestShare(unittest.TestCase):
 
         for test_case in test_cases:
             self.assertEqual(split_senseids(test_case[0]), test_case[1])
+
+
+class TestBoldOffsets(unittest.TestCase):
+    def setUp(self) -> None:
+        self.wxr = WiktextractContext(
+            Wtp(lang_code="de"), WiktionaryConfig(dump_file_lang_code="de")
+        )
+
+    def tearDown(self) -> None:
+        self.wxr.wtp.close_db_conn()
+
+    def test_unbalanced_apostrophes(self):
+        # https://de.wiktionary.org/wiki/orient
+        self.wxr.wtp.start_page("orient")
+        root = self.wxr.wtp.parse("El sol surt per l'''orient.''")
+        text = clean_node(self.wxr, None, root)
+        self.assertEqual(text, "El sol surt per l'orient.")
+        data = {}
+        calculate_bold_offsets(
+            self.wxr,
+            root,
+            text,
+            data,
+            "bold_text_offsets",
+            extra_node_kind=NodeKind.ITALIC,
+        )
+        self.assertEqual(data["bold_text_offsets"], [(18, 25)])


### PR DESCRIPTION
Only the tests for now. 

The fix is better suited in wikitextprocessor. See the related https://github.com/tatuylonen/wikitextprocessor/pull/372

It requires porting some of this doQuotes logic:
https://github.com/wikimedia/mediawiki/blob/HEAD/includes/Parser/Parser.php
https://github.com/wikimedia/mediawiki/blob/df909d40cbc7348665987f4b0ebe6f7ee52cdeeb/includes/Parser/Parser.php#L1921

Fixes #1706